### PR TITLE
셀프서비스 마켓 연결 + 어댑터 버그 수정 + 인앱 발급 가이드 (UX/UI · 실동작)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -335,6 +335,11 @@ MONITORING_ALERT_THRESHOLD_LATENCY=2.0 # 응답시간 알림 임계값(초)
 # === Phase 24: OAuth + API Key 관리 ===
 AUTH_DEMO_MODE=0              # 데모 로그인 활성화 (개발용, 프로덕션에서는 0으로 유지)
 JWT_SECRET_KEY=                   # JWT 서명 키 (랜덤 강력한 값 사용)
+# 셀프서비스 마켓 연결(셀러별 API 키) 암호화 키 — Fernet 키(urlsafe base64 32B).
+# 미설정 시 SECRET_KEY에서 파생, 둘 다 없으면 평문 저장(개발용). 운영 필수 권장.
+MARKET_CRED_ENC_KEY=
+# 셀러별 자격증명 저장 디렉토리 (기본 data/market_credentials)
+MARKET_CRED_DIR=
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES=15
 JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 GOOGLE_OAUTH_CLIENT_ID=           # Google OAuth2 클라이언트 ID

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -221,3 +221,32 @@
 - **테스트**: `tests/test_verify_market_connections.py` 7개(별칭 env + 키매핑).
 - ⚠️ **실 API 라이브 등록 검증(상품이 실제로 올라가는지)은 여전히 운영 자격증명 필요** — 위 가이드의
   "5. 첫 테스트 업로드"로 오너가 직접 1건 등록해 "상품 페이지 열기" 링크까지 확인할 것.
+
+## Phase 192 — 셀프서비스 마켓 연결 (SaaS 대비) ✅ (2026-06-10)
+
+### 오너 지시
+- "SaaS 하게 되면 소비자가 쉽게쉽게 각 마켓에 연결할 수 있어야 한다 — UI/UX·백엔드 잘."
+
+### 작업 요약
+- **셀러별 자격증명 저장소**: `src/seller_console/market_credentials.py`
+  - `data/market_credentials/<seller_id>.json` Fernet 암호화 저장
+    (`MARKET_CRED_ENC_KEY` 우선 → `SECRET_KEY` 파생 → 없으면 평문+경고).
+  - `save/get/delete/is_connected/status(마스킹)/credential_env`,
+    `seller_market_env(seller, markets, extra=)` 컨텍스트로 표준 env에 일시 주입.
+  - 폴백: 셀러 저장값 없으면 전역 환경변수(오너 단일테넌트) 그대로 사용.
+- **셀프서비스 연결 화면**: `GET /seller/markets/connect` + `markets_connect.html`
+  - 마켓별 카드: 상태 배지, 키 입력 폼(비밀값 password/마스킹), [연결 테스트]/[저장]/[연결 해제].
+  - 사이드바에 "마켓 연결(키 설정)" 메뉴 추가.
+- **라우트**: `POST /connect/<m>`(저장), `POST /connect/<m>/test`(저장값+입력중값 라이브 테스트),
+  `POST /connect/<m>/disconnect`(삭제).
+- **업로드 연동**: `/collect/upload`·`/collect/prevalidate`를 `seller_market_env`로 감싸
+  셀러 저장 자격증명이 실제 업로드/사전검증을 구동하도록 연결.
+- **테스트**: `tests/test_market_credentials.py` 18개(저장/암호화/마스킹/주입/라우트).
+
+### 보안 메모
+- 운영에서 `MARKET_CRED_ENC_KEY`(Fernet 키) 설정 필수 권장(미설정 시 SECRET_KEY 파생).
+- ⚠️ 오너가 채팅에 `TOSS_SECRET_KEY`(test_sk_…) 평문 노출 → 토스 콘솔에서 재발급 권장.
+
+### 후속(백로그)
+- 셀러별 자격증명을 DB/암호화 시크릿 매니저로 이전(파일 → 멀티인스턴스 대비).
+- OAuth 방식 마켓(쿠팡/네이버)을 키 직접입력 대신 "연결 버튼" OAuth 플로우로 고도화.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -175,6 +175,19 @@
   파괴적 동작은 빨강 확인, 비파괴는 파랑으로 톤 구분. 상세는 `dead_button_audit.md`.
 
 ### 다음 단계 (백로그)
-- ③ 셀러 대시보드 화면 정밀 점검 (빈 상태/로딩/에러/네비게이션 UX) — 진행 예정.
-- ④ 쿠팡/스마트스토어/11번가 실 채널 업로더 모듈 연결 (현재 큐 적재 방식).
+- ③ 셀러 대시보드 화면 정밀 점검 → ✅ (회복탄력성 테스트 고정, 이미 잘 구성됨 확인).
+- ④ 쿠팡/스마트스토어 실 채널 업로더 모듈 연결 → ✅ (아래 참고).
+- 11번가(elevenst) 실 업로더 모듈은 아직 없음 → 연결 시 큐 적재 유지(honest). 추후 작성 대상.
 - `_base_app.html`/대시보드 등 셀러 콘솔 밖 화면의 토스트/확인 모달 통일.
+
+### ④ 쿠팡/스마트스토어 실채널 업로더 연결 (2026-06-10)
+- **브리지 신설**: `src/channel_sync/_channel_bridge.py`(공통 변환/실행),
+  `coupang_uploader.py`·`smartstore_uploader.py`. 디스패처가 `from src.channel_sync import *_uploader`로
+  로드 → 기존 `src.uploaders.CoupangUploader`/`NaverSmartStoreUploader`(Phase 17-2) 재사용.
+- **가격 매핑**: 원화 판매가 = `sell_price_krw` → `recommended_price(_krw)` → `price_krw` →
+  (통화 KRW일 때) `price` 순 첫 양수. 비KRW 가격을 원화로 오용하지 않음. 원화가 0이면 업로드 차단.
+- **정직한 실패 표면화**: 자격증명 미설정 → `token_missing`(디스패처 매핑), API 실패/원화 0 → `api_error`.
+  성공 시 `external_product_id`/`external_url`을 응답·UI에 노출.
+- **테스트**: `tests/test_channel_sync_uploaders.py` 16개(매핑/자격증명/실패/성공/디스패처 통합, 목 API).
+- ⚠️ **실 API 라이브 검증은 운영 환경에서 오너가 COUPANG_*/NAVER_* 자격증명으로 별도 수행 필요**
+  (CI엔 자격증명 없음 → 목 검증까지만).

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -63,8 +63,7 @@
   `/seller/markets` 결과를 대조해 마지막 실검증 시간을 남길 것.
 
 ### 백로그 (오너 승인 대기 — 먼저 묻지 말 것)
-- **죽은 버튼 감사 3차**: `dead_button_audit.md` 재스캔에서 남은 `bookmarklet`/`me`/`personal_tokens`/`pricing`/`discovery`
-  계열 `alert(...)` 정리.
+- **죽은 버튼 감사 3차**: → ✅ 완료 (2026-06-10, 오너 지시로 진행). 아래 Phase 191 참고.
 - SaaS 공개 준비 (약관/결제/랜딩) — 2026 Q4. **오너가 지시할 때까지 대기.**
 
 ---
@@ -136,3 +135,29 @@
 ### 다음 단계 (백로그)
 - 쿠팡/스마트스토어/11번가 실 채널 업로더 모듈 연결 (현재 큐 적재 방식)
 - 등록 이력 DB 저장 및 재시도 큐 플로우 고도화
+
+---
+
+## Phase 191 — UX/UI 디테일: 전역 토스트 + 죽은 버튼 감사 3차 ✅ (2026-06-10)
+
+### 오너 지시 사항
+- "UX/UI 디테일 세팅이랑 각 버튼들의 실동작 — 실제로 사이트/서비스가 돌아가게."
+
+### 작업 요약
+- **전역 토스트 인프라**: `_base.html`에 `#pcToastContainer`(모든 셀러 페이지 공용),
+  `seller.js`에 페이지 독립 `pcToast(message, type)` 헬퍼 추가.
+  - XSS 방지(textContent), 타입별 색/아이콘, error 6s·기타 3.5s 자동 소멸, bootstrap 미로딩 폴백.
+- **alert() → pcToast 전환(8개 페이지)**: `pricing_rules`, `pricing_competitors`, `pricing_fx_impact`,
+  `pricing_history`, `discovery`, `discovery_keywords`, `me`, `personal_tokens`, `collect_preview`.
+  - 성공/실패 톤 구분, reload 직전 성공 토스트는 1.2초 지연 후 새로고침으로 가시성 확보.
+- **honest 유지**: 파괴적 동작 `confirm(...)` 유지, `bookmarklet.html` 외부 실행 코드 내부 `alert(...)` 유지.
+- **stale 테스트 정리**: `test_phase_163_favicon_assets` — Phase 189 라이트 테마 복구로 `#020010`(다크)이
+  사라져 baseline에서 깨져 있던 assertion을 `theme-color` 메타 존재 검증으로 교체(향후 테마 변경에 견고).
+
+### 테스트
+- `tests/test_dead_buttons_phase191.py`: 19개 신규 (전역 토스트 인프라 + 8개 페이지 alert 제거).
+- 뷰/템플릿 범위 858개 통과, 회귀 없음.
+
+### 다음 단계 (백로그)
+- `confirm(...)` 차단형 확인 다이얼로그 → 스타일드 모달 전환(디테일 폴리시, 후속 후보).
+- `_base_app.html`/대시보드 등 셀러 콘솔 밖 화면의 토스트 통일.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -202,3 +202,22 @@
   `tests/test_channel_sync_uploaders.py`에 브리지/디스패처 통합 4개 추가.
 - ⚠️ 11번가는 배송 템플릿/카테고리 등 셀러별 설정값 필요 — 운영 시 `ELEVENST_DISP_CTGR_NO` 등
   계정 설정에 맞춰 카테고리/배송 코드 조정 후 라이브 검증 필요.
+
+### ⑤ 라이브 검증 도구 + 가이드 + env 정합성 수정 (2026-06-10)
+- **검증 도구 신설**: `scripts/verify_market_connections.py` — 5개 마켓 연결 진단 + 업로드 사전검증을
+  한 번에 실행해 사람이 읽는 표로 출력(`python -m scripts.verify_market_connections [market] [--json]`).
+  운영 데이터 변경 없음(읽기 + safe dry-run). 운영 셸에서 자격증명 넣고 실행하면 실제 연결 검증.
+- **가이드 신설**: `docs/operations/LIVE_VERIFICATION_GUIDE.md` — 키 발급→환경변수→연결확인→테스트
+  업로드까지 누구나 따라 하는 단계별 안내 + 상태코드/트러블슈팅/체크리스트/환경변수 표.
+- **라이브 검증으로 잡은 실 버그 3건 수정**:
+  1. **11번가 키 불일치**: 진단 키 `11st` vs 디스패처 키 `elevenst` → 검증 도구에서 별칭 매핑.
+  2. **WooCommerce env 불일치**: prevalidate가 `WC_CONSUMER_KEY`(어디와도 불일치)를 요구 →
+     실제 업로드 경로(`WOO_*`)와 진단(`WC_*`) **둘 다 허용**하도록 수정. (올바른 키를 넣어도
+     prevalidate가 잘못 막던 버그)
+  3. **네이버 env 이중 명명**: 업로드 `NAVER_CLIENT_*` vs 진단 `NAVER_COMMERCE_*` →
+     업로더/브리지/prevalidate가 **둘 다 허용**하도록 폴백 추가.
+- **검증 결과**: 자격증명 미설정 시 5개 마켓 모두 `token_missing` 정직 표기, 자격증명 주입 시
+  5개 마켓 prevalidate 전부 `✅ 통과`(업로드 경로 배선 완료 증명).
+- **테스트**: `tests/test_verify_market_connections.py` 7개(별칭 env + 키매핑).
+- ⚠️ **실 API 라이브 등록 검증(상품이 실제로 올라가는지)은 여전히 운영 자격증명 필요** — 위 가이드의
+  "5. 첫 테스트 업로드"로 오너가 직접 1건 등록해 "상품 페이지 열기" 링크까지 확인할 것.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -158,6 +158,23 @@
 - `tests/test_dead_buttons_phase191.py`: 19개 신규 (전역 토스트 인프라 + 8개 페이지 alert 제거).
 - 뷰/템플릿 범위 858개 통과, 회귀 없음.
 
+### 추가 작업 (오너 "나열한 순서대로" 지시 — 2026-06-10)
+
+**① 마켓 업로드 전체 경로(E2E) 검증 고정**
+- `/seller/collect/upload` → `UploadDispatcher.dispatch` → 실제 `_upload_shopify` 경로를 타되
+  라이브 연동 경계(`ShopifyAdapter`)만 목 처리하여 정합성 고정.
+  - 라이브 성공: result에 `external_product_id`/`external_url`, `succeeded` 집계 + UI가 "상품 페이지 열기" 링크 렌더.
+  - API 실패(401 등): `error_code=api_error` + 조치 hint(SHOPIFY_AUTO_TOKEN) → UI "💡 조치 / 오류코드" 렌더.
+  - 검증 실패: `error_code=validation_failed`. 업로드 중 예외도 500 없이 항목 단위 실패로 정직 보고.
+  - `tests/test_collect_upload_e2e.py` 5개 신규.
+  - ⚠️ 실 운영 시크릿 대조(라이브 실등록) 검증은 **운영 환경에서 오너가 `/admin/diagnostics`·셀러
+    마켓 센터로 별도 수행 필요** (CI엔 시크릿 없음).
+
+**② 네이티브 confirm() → 전역 확인 모달(pcConfirm)**
+- `_base.html` `#pcConfirmModal` + `seller.js` Promise 기반 `pcConfirm()`. 11개 호출/7개 페이지 전환.
+  파괴적 동작은 빨강 확인, 비파괴는 파랑으로 톤 구분. 상세는 `dead_button_audit.md`.
+
 ### 다음 단계 (백로그)
-- `confirm(...)` 차단형 확인 다이얼로그 → 스타일드 모달 전환(디테일 폴리시, 후속 후보).
-- `_base_app.html`/대시보드 등 셀러 콘솔 밖 화면의 토스트 통일.
+- ③ 셀러 대시보드 화면 정밀 점검 (빈 상태/로딩/에러/네비게이션 UX) — 진행 예정.
+- ④ 쿠팡/스마트스토어/11번가 실 채널 업로더 모듈 연결 (현재 큐 적재 방식).
+- `_base_app.html`/대시보드 등 셀러 콘솔 밖 화면의 토스트/확인 모달 통일.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -250,3 +250,27 @@
 ### 후속(백로그)
 - 셀러별 자격증명을 DB/암호화 시크릿 매니저로 이전(파일 → 멀티인스턴스 대비).
 - OAuth 방식 마켓(쿠팡/네이버)을 키 직접입력 대신 "연결 버튼" OAuth 플로우로 고도화.
+
+## Phase 193 — 라이브 검증으로 드러난 어댑터 버그 수정 (2026-06-10)
+
+오너가 운영 자격증명 등록 후 `/seller/markets` 라이브 진단 → 5개 마켓 실패.
+실제 API 응답(404/500/406/토큰)을 보고 코드 버그 2건 수정 + 진단 메시지 강화.
+
+### 수정한 코드 버그
+- **스마트스토어 토큰 발급(진짜 버그)**: 네이버 커머스 OAuth2는 `client_secret` 평문이 아니라
+  **bcrypt 전자서명(`client_secret_sign`) + timestamp** 필요. `_naver_signature()` 추가 후
+  토큰 요청 페이로드 교정. (자격증명이 맞아도 실패하던 원인)
+- **WooCommerce HTTP 406**: WP 호스트 WAF가 User-Agent/Accept 없는 요청을 차단.
+  `_request_headers()`(UA+Accept) 추가, 모든 WC 요청(7곳)에 적용.
+
+### 진단 메시지 강화 (값 문제 식별 보조)
+- 쿠팡/11번가/우커머스 health_check 실패 시 **실제 응답 본문 일부 + 상태코드별 hint** 노출.
+
+### 오너 액션 필요 (값/계정 문제로 추정)
+- **Shopify token_expired**: `SHOPIFY_AUTO_TOKEN`(atk_/shpat_) 값이 유효한지 재확인(재발급).
+- **쿠팡 HTTP 404**: `COUPANG_VENDOR_ID` 형식(A+숫자) 재확인.
+- **11번가 HTTP 500**: 셀러오피스에서 OpenAPI 사용 승인 + `ELEVENST_API_KEY` 재확인.
+  (재배포 후 진단 화면의 응답 본문으로 정확한 원인 확인)
+
+### 테스트
+- `tests/test_market_adapter_live_fixes.py` 5개(네이버 서명/WC 헤더).

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -176,8 +176,7 @@
 
 ### 다음 단계 (백로그)
 - ③ 셀러 대시보드 화면 정밀 점검 → ✅ (회복탄력성 테스트 고정, 이미 잘 구성됨 확인).
-- ④ 쿠팡/스마트스토어 실 채널 업로더 모듈 연결 → ✅ (아래 참고).
-- 11번가(elevenst) 실 업로더 모듈은 아직 없음 → 연결 시 큐 적재 유지(honest). 추후 작성 대상.
+- ④ 쿠팡/스마트스토어/11번가 실 채널 업로더 모듈 연결 → ✅ (아래 참고).
 - `_base_app.html`/대시보드 등 셀러 콘솔 밖 화면의 토스트/확인 모달 통일.
 
 ### ④ 쿠팡/스마트스토어 실채널 업로더 연결 (2026-06-10)
@@ -191,3 +190,15 @@
 - **테스트**: `tests/test_channel_sync_uploaders.py` 16개(매핑/자격증명/실패/성공/디스패처 통합, 목 API).
 - ⚠️ **실 API 라이브 검증은 운영 환경에서 오너가 COUPANG_*/NAVER_* 자격증명으로 별도 수행 필요**
   (CI엔 자격증명 없음 → 목 검증까지만).
+
+### ④-b 11번가(11st) 실 업로더 신설 (2026-06-10)
+- **신규 업로더**: `src/uploaders/elevenst_uploader.py` — `ElevenStUploader`(11번가 OpenAPI XML 등록).
+  CoupangUploader/NaverSmartStoreUploader와 동일 인터페이스(`prepare_product`/`upload_product` →
+  `{success, product_id, url}`). 제목 `[해외직구]` 접두, 10원 단위 판매가, 카테고리 매핑, XML 이스케이프,
+  응답 코드/상품번호 파싱.
+- **브리지**: `src/channel_sync/elevenst_uploader.py`(REQUIRED: `ELEVENST_API_KEY`).
+  디스패처가 자격증명 미설정 → `token_missing`, OpenAPI 실패 → `api_error`로 표기.
+- **테스트**: `tests/test_elevenst_uploader.py` 12개(매핑/XML/파싱/성공/실패, requests 목) +
+  `tests/test_channel_sync_uploaders.py`에 브리지/디스패처 통합 4개 추가.
+- ⚠️ 11번가는 배송 템플릿/카테고리 등 셀러별 설정값 필요 — 운영 시 `ELEVENST_DISP_CTGR_NO` 등
+  계정 설정에 맞춰 카테고리/배송 코드 조정 후 라이브 검증 필요.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -274,3 +274,23 @@
 
 ### 테스트
 - `tests/test_market_adapter_live_fixes.py` 5개(네이버 서명/WC 헤더).
+
+## Phase 194 — 인앱 마켓 연결을 현황/진단에 완전 통합 (2026-06-10)
+
+오너 지시: "렌더에만 키 넣지 말고 사이트 안(퍼센티)에서도 세팅 가능하게. 다른 사용자/소비자도."
+
+- Phase 192의 `/seller/markets/connect`(셀러별 키 저장)를 **마켓 현황/진단 전 표면에 통합**.
+- `market_credentials.all_credential_env(seller)` 추가: 셀러 저장 키 전체 병합.
+- `/seller/markets` 라이브 진단 엔드포인트 3종(`integration-diagnostics` GET/POST,
+  `shopify/check-connection`)을 `temp_env(all_credential_env(seller))`로 감싸
+  **인앱 저장 키가 실제 연결 진단을 구동**(Render env 없이도). 검증: 저장 전 token_missing →
+  저장 후 실제 API 도달.
+- `_market_configured_for_seller()` 추가 — 현황 카드 '연결됨' 판정에 인앱 키 반영.
+- `/seller/markets` 헤더에 "🔌 마켓 연결(키 입력)" 버튼 + 각 카드에 "🔑 키 입력" 링크.
+- `_seller_id()` 요청 컨텍스트 밖 안전 처리.
+- 테스트: test_market_credentials.py에 통합 검증 3개 추가.
+
+### ⚠️ 배포 메모 (중요)
+- 이번 세션 전체 작업은 브랜치 `claude/magical-noether-oo4831`에 있음.
+  **운영(kohganepercentiii.com = main)에 반영하려면 main 머지 → Render 재배포 필요.**
+  오너가 보던 라이브 진단이 그대로였던 이유 = 브랜치 미배포.

--- a/docs/operations/LIVE_VERIFICATION_GUIDE.md
+++ b/docs/operations/LIVE_VERIFICATION_GUIDE.md
@@ -50,12 +50,33 @@ python -m scripts.verify_market_connections --json
 요약: 전체 5개 중 ✅ 연결됨 0개 · 미연결 5개
 ```
 
-### 웹 화면으로도 볼 수 있어요
+### 어디서 실행하나요? (쉬운 순서)
 
-- **`/admin/diagnostics`** — 운영자용 종합 진단 화면
-- **`/seller/markets`** — 셀러 콘솔의 마켓 컨트롤 센터
+#### 방법 A. 웹 화면 — **셸 필요 없음, 가장 쉬움** ⭐
+브라우저에서 로그인 후 아래 주소를 열기만 하면 됩니다. 명령어를 칠 필요가 없어요.
 
-세 가지(검증 도구 · admin · seller)는 같은 결과를 보여줍니다. 편한 걸 쓰세요.
+- **`https://(내도메인)/seller/markets/connect`** — 마켓별로 키 입력 + **[연결 테스트]** 버튼
+- **`https://(내도메인)/seller/markets`** — 마켓 현황 한눈에
+- **`https://(내도메인)/admin/diagnostics`** — 운영자용 종합 진단
+
+> 👉 키를 막 넣고 바로 확인하려면 **`/seller/markets/connect`** 에서 키를 넣고 **[연결 테스트]** 를 누르세요.
+
+#### 방법 B. Render Shell — 명령어로 한 번에 전체 확인
+1. [Render 대시보드](https://dashboard.render.com) → 해당 **웹 서비스** 클릭
+2. 상단/좌측 탭에서 **Shell** 클릭 (실행 중인 서비스에서 열림)
+3. 까만 터미널이 열리면 그대로 입력:
+   ```bash
+   python -m scripts.verify_market_connections
+   ```
+4. 5개 마켓 상태가 표로 출력됩니다. (환경변수는 Render 서비스에 이미 들어있어 자동 적용)
+
+> ⚠️ **Shell 탭이 안 보이면**: Render의 일부 무료 플랜은 Shell이 없습니다. 이때는 **방법 A(웹 화면)** 를 쓰세요. 결과는 동일합니다.
+> 📁 Shell은 기본적으로 프로젝트 루트(`scripts/` 폴더가 있는 위치)에서 열립니다. 혹시 아니면 `cd ~/project/src` 가 아니라 레포 최상위로 이동 후 실행하세요.
+
+#### 방법 C. 내 PC(로컬)
+레포를 받아둔 PC에서도 됩니다. 단, **로컬에는 키가 없으니** 같은 키들을 로컬 환경변수/`.env`에 넣어야 실제 검증이 됩니다(보통 방법 A·B를 권장).
+
+> 세 방법 모두 **같은 결과**를 보여줍니다. 편한 걸 쓰세요.
 
 ---
 
@@ -82,6 +103,30 @@ python -m scripts.verify_market_connections --json
 5. 저장하면 서비스가 자동으로 재배포됩니다(1~2분). 재배포 후 검증 도구를 다시 실행하세요.
 
 > ⚠️ 값을 붙여넣을 때 **앞뒤 공백/줄바꿈이 섞이지 않게** 주의하세요. 가장 흔한 실패 원인입니다.
+
+### 🔐 (중요) 암호화 키 `MARKET_CRED_ENC_KEY` 만들고 넣기
+
+셀러가 `/seller/markets/connect` 화면에서 입력한 마켓 키들은 **이 암호화 키로 잠가서** 저장됩니다.
+키가 없으면 평문 저장(개발용)이라, **운영에서는 반드시 넣어주세요.**
+
+**① 키 만들기** — 아무 데서나 1줄 실행 (Render Shell 또는 내 PC):
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+출력 예시(↓ 이건 예시일 뿐, **본인이 직접 생성한 값**을 쓰세요):
+```
+jiVxNw0coK-kfePqWIJfOnaUeCSOcsXkEl4FVSk12BM=
+```
+- 끝이 `=` 로 끝나는 **44글자** 문자열이면 정상입니다.
+
+**② 키 넣기** — Render 환경변수 등록(3번 섹션과 동일):
+- **Key**: `MARKET_CRED_ENC_KEY`
+- **Value**: 위에서 생성한 44글자 키
+- Save → 자동 재배포
+
+> 💡 별도 사이트에서 "받는" 게 아니라 **직접 생성**하는 값입니다(비밀번호처럼).
+> ⚠️ **한 번 정하면 바꾸지 마세요.** 키를 바꾸면 그 전에 저장된 셀러 키들을 복호화할 수 없습니다.
+> 안 넣어도 당장은 동작하지만(SECRET_KEY로 대체), 운영에서는 전용 키를 권장합니다.
 
 ---
 

--- a/docs/operations/LIVE_VERIFICATION_GUIDE.md
+++ b/docs/operations/LIVE_VERIFICATION_GUIDE.md
@@ -1,0 +1,216 @@
+# 🚦 마켓 연동 라이브 검증 가이드
+
+> **이 문서 하나로** 쿠팡 · 스마트스토어 · 11번가 · Shopify · WooCommerce를
+> 실제로 연결하고, 진짜로 상품이 올라가는지까지 확인할 수 있습니다.
+> 처음 보는 사람도 위에서 아래로 순서대로만 따라 하면 됩니다.
+
+---
+
+## 0. 큰 그림 (3단계만 기억하세요)
+
+```
+①  열쇠 받기          ②  열쇠 꽂기              ③  문 열리는지 확인
+   (API 키 발급)   →     (환경변수 등록)     →    (검증 도구 실행)
+   각 마켓 사이트         Render 대시보드          python -m scripts.verify_market_connections
+```
+
+- **① 열쇠 받기**: 각 마켓 판매자센터에서 API 키(=열쇠)를 발급받습니다.
+- **② 열쇠 꽂기**: 받은 키를 Render의 환경변수(Environment)에 넣습니다.
+- **③ 확인**: 검증 도구를 돌려서 `✅ 연결됨`이 뜨는지 봅니다. 그 다음 테스트 상품을 한 개 올려봅니다.
+
+> 💡 키를 넣기 전에는 모든 마켓이 `🪪 자격증명 없음(token_missing)`으로 나옵니다. **정상입니다.**
+
+---
+
+## 1. 검증 도구 사용법 (제일 먼저 익히기)
+
+연결 상태를 한 번에 보여주는 명령어입니다. Render 셸(Shell) 또는 로컬 터미널에서 실행하세요.
+
+```bash
+# 전체 마켓 한 번에 확인
+python -m scripts.verify_market_connections
+
+# 특정 마켓만 확인 (예: 쿠팡)
+python -m scripts.verify_market_connections coupang
+
+# 기계용 JSON으로 받기 (자동화/로그용)
+python -m scripts.verify_market_connections --json
+```
+
+### 출력 예시 (키를 넣기 전)
+
+```
+■ Coupang (coupang)
+   연결 상태 : 🪪 자격증명 없음
+   업로드준비: ⚠️ token_missing — 필수 환경변수 미설정: COUPANG_ACCESS_KEY, ...
+   해결 방법 : https://wing.coupang.com 에서 API 키 발급
+   필요 환경변수: COUPANG_VENDOR_ID, COUPANG_ACCESS_KEY, COUPANG_SECRET_KEY
+   가이드    : docs/operations/COUPANG.md
+
+요약: 전체 5개 중 ✅ 연결됨 0개 · 미연결 5개
+```
+
+### 웹 화면으로도 볼 수 있어요
+
+- **`/admin/diagnostics`** — 운영자용 종합 진단 화면
+- **`/seller/markets`** — 셀러 콘솔의 마켓 컨트롤 센터
+
+세 가지(검증 도구 · admin · seller)는 같은 결과를 보여줍니다. 편한 걸 쓰세요.
+
+---
+
+## 2. 연결 상태 한눈에 읽기
+
+| 표시 | 뜻 | 무엇을 해야 하나 |
+|------|----|----------------|
+| ✅ `connected` | 정상 연결됨 | 끝! 테스트 업로드로 넘어가세요 |
+| 🪪 `token_missing` | 키(환경변수)가 없음 | 아래 마켓별 안내대로 키를 등록 |
+| ⏰ `token_expired` | 토큰 만료됨 | 마켓 판매자센터에서 토큰 재발급 |
+| 🔒 `scope_insufficient` | 권한 부족 | API 앱의 권한(상품 등록 등)을 추가 |
+| ❌ `api_error` | API 호출 실패 | 키 오타/네트워크/마켓 점검 여부 확인 |
+
+> **검증 도구는 운영 데이터를 절대 바꾸지 않습니다.** 읽기 연결 + 안전한 "빈 쓰기 시험(dry-run)"만 합니다.
+
+---
+
+## 3. Render에 환경변수 넣는 법 (공통)
+
+1. [Render 대시보드](https://dashboard.render.com) 접속 → 해당 서비스 클릭
+2. 왼쪽 메뉴 **Environment** 클릭
+3. **Add Environment Variable** 버튼
+4. **Key**(변수 이름)와 **Value**(키 값)를 입력 → **Save Changes**
+5. 저장하면 서비스가 자동으로 재배포됩니다(1~2분). 재배포 후 검증 도구를 다시 실행하세요.
+
+> ⚠️ 값을 붙여넣을 때 **앞뒤 공백/줄바꿈이 섞이지 않게** 주의하세요. 가장 흔한 실패 원인입니다.
+
+---
+
+## 4. 마켓별 상세 안내
+
+각 마켓은 ① 키 발급 → ② 환경변수 → ③ 연결 확인 → ④ 테스트 업로드 순서입니다.
+
+### 🛒 4-1. 쿠팡 (Coupang)
+
+| 항목 | 내용 |
+|------|------|
+| ① 키 발급 | [쿠팡 윙(Wing)](https://wing.coupang.com) → 판매자 정보 → **오픈 API 키 발급** |
+| ② 환경변수 | `COUPANG_ACCESS_KEY` · `COUPANG_SECRET_KEY` · `COUPANG_VENDOR_ID` |
+| 필요 권한 | 상품 조회 / 상품 등록·수정 / 주문 조회 / 배송 처리 |
+| 상세 문서 | `docs/operations/COUPANG.md` |
+
+```bash
+# ③ 연결 확인
+python -m scripts.verify_market_connections coupang   # → ✅ 연결됨 이면 성공
+```
+
+### 🟢 4-2. 스마트스토어 (네이버 커머스)
+
+| 항목 | 내용 |
+|------|------|
+| ① 키 발급 | [네이버 커머스 API 센터](https://commerce.naver.com) → 애플리케이션 등록 → 클라이언트 ID/Secret |
+| ② 환경변수 | `NAVER_CLIENT_ID` · `NAVER_CLIENT_SECRET` (선택: `NAVER_CHANNEL_ID`) |
+| 🔁 별칭 허용 | `NAVER_COMMERCE_CLIENT_ID` · `NAVER_COMMERCE_CLIENT_SECRET` 로 넣어도 동작합니다 |
+| 필요 권한 | 상품 조회 / 상품 등록·수정 / 주문 조회 / 발송 처리 |
+| 상세 문서 | `docs/operations/NAVER_SMARTSTORE.md` |
+
+> 📌 **네이버 주의**: 같은 자격증명을 코드가 두 이름으로 받습니다. 둘 중 **아무 한 쌍**만 넣으면 됩니다.
+> 헷갈리면 `NAVER_CLIENT_ID` / `NAVER_CLIENT_SECRET` 한 쌍만 넣으세요.
+
+```bash
+python -m scripts.verify_market_connections smartstore
+```
+
+### 🔴 4-3. 11번가 (11st)
+
+| 항목 | 내용 |
+|------|------|
+| ① 키 발급 | [11번가 셀러오피스](https://soffice.11st.co.kr) → 오픈 API → **API 키 발급** |
+| ② 환경변수 | `ELEVENST_API_KEY` (선택: `ELEVENST_DISP_CTGR_NO` = 기본 카테고리 번호) |
+| 필요 권한 | 상품 조회 / 상품 등록·수정 / 주문 조회 / 배송 처리 |
+| 상세 문서 | `docs/operations/ELEVENST.md` |
+
+> ⚠️ 11번가는 **카테고리·배송 템플릿**이 셀러 계정마다 다릅니다. 첫 업로드가 카테고리 오류로 막히면
+> 셀러오피스에서 본인 카테고리 번호를 확인해 `ELEVENST_DISP_CTGR_NO` 에 넣으세요.
+
+```bash
+python -m scripts.verify_market_connections 11st
+```
+
+### 🛍️ 4-4. Shopify
+
+| 항목 | 내용 |
+|------|------|
+| ① 키 발급 | Shopify Admin → **Apps → Develop apps** → 앱 생성 → Admin API access token(`shpat_...`) |
+| ② 환경변수 | `SHOPIFY_SHOP`(=`내상점.myshopify.com`) · `SHOPIFY_AUTO_TOKEN`(`atk_...` 우선) · `SHOPIFY_CLIENT_SECRET` |
+| 🔁 별칭 허용 | `SHOPIFY_AUTO_TOKEN` 없으면 `SHOPIFY_ACCESS_TOKEN`(레거시)도 동작 |
+| 필요 권한(scope) | `read_products`, `write_products`, `read_inventory`, `write_inventory`, `read_orders`, `write_orders` |
+| 상세 문서 | `docs/operations/SHOPIFY_MARKET.md` |
+
+```bash
+python -m scripts.verify_market_connections shopify
+```
+
+### 🟣 4-5. WooCommerce (코가네멀티샵 자체몰)
+
+| 항목 | 내용 |
+|------|------|
+| ① 키 발급 | WordPress 관리자 → **WooCommerce → 설정 → 고급 → REST API** → 키 생성(권한: Read/Write) |
+| ② 환경변수 | `WC_URL` · `WC_KEY` · `WC_SECRET` |
+| 🔁 별칭 허용 | `WOO_BASE_URL` · `WOO_CK` · `WOO_CS` 로 넣어도 동작합니다 |
+| 상세 문서 | `docs/operations/WOOCOMMERCE_MARKET.md` |
+
+```bash
+python -m scripts.verify_market_connections woocommerce
+```
+
+---
+
+## 5. 첫 테스트 업로드 (진짜로 올라가는지 확인)
+
+연결이 `✅ 연결됨`으로 바뀌면, 실제 상품을 1개만 올려서 끝까지 확인합니다.
+
+1. 셀러 콘솔에서 **상품 수집** → `/seller/collect` 에서 아무 상품이나 한 개 수집
+2. **미리보기 화면**에서 **📤 마켓에 등록** 버튼 클릭
+3. 모달 3단계를 따릅니다:
+   - **마켓 선택 + 마진율** 지정
+   - **🔍 사전검증** → `✅ 통과` 가 떠야 다음 단계로 갑니다
+     - 여기서 막히면 화면의 **💡 조치** 문구대로 해결 (대부분 키/가격/이미지 문제)
+   - **업로드 실행** → 성공하면 **"상품 페이지 열기"** 링크가 생깁니다. 눌러서 실제 등록을 눈으로 확인!
+4. 실패하면 화면에 **오류코드 + 💡 조치**가 정직하게 표시됩니다. 표(2번 섹션)를 참고해 해결하세요.
+
+> ✅ **"상품 페이지 열기" 링크가 열리고 실제 마켓에 상품이 보이면 라이브 연동 완료입니다.**
+
+---
+
+## 6. 자주 막히는 곳 (트러블슈팅)
+
+| 증상 | 원인 | 해결 |
+|------|------|------|
+| 키 넣었는데 계속 `token_missing` | 재배포 전 / 변수 이름 오타 / 값에 공백 | Render 재배포 대기 후 재실행, 변수명·값 재확인 |
+| `api_error` 가 뜸 | 키 오타, 권한 부족, 마켓 점검 중 | 키 재발급, 앱 권한(scope) 추가, 잠시 후 재시도 |
+| 사전검증에서 `image_inaccessible` | 이미지 URL이 외부 접근 불가 | 공개적으로 열리는 이미지 URL 사용 |
+| 사전검증에서 `missing_field` | 상품명/판매가 비어있음 | 상품명 입력 또는 마진 계산기로 판매가 산정 |
+| 11번가만 카테고리 오류 | 셀러별 카테고리 번호 불일치 | `ELEVENST_DISP_CTGR_NO` 에 본인 카테고리 번호 설정 |
+| 네이버가 안 됨 | 변수 이름 두 종류 혼동 | `NAVER_CLIENT_ID/SECRET` **한 쌍**만 정확히 |
+
+---
+
+## 7. 최종 체크리스트
+
+- [ ] 각 마켓 판매자센터에서 API 키 발급 완료
+- [ ] Render 환경변수에 키 등록 + 재배포 완료
+- [ ] `python -m scripts.verify_market_connections` → 목표 마켓 `✅ 연결됨`
+- [ ] 테스트 상품 1개 업로드 → **"상품 페이지 열기"** 링크로 실제 등록 확인
+- [ ] (운영 기록) `docs/HANDOFF.md` 에 마지막 라이브 검증 날짜/결과 남기기
+
+---
+
+## 부록. 환경변수 한눈에 보기
+
+| 마켓 | 필수 환경변수 | 별칭(있으면 이것도 가능) |
+|------|--------------|------------------------|
+| 쿠팡 | `COUPANG_ACCESS_KEY`, `COUPANG_SECRET_KEY`, `COUPANG_VENDOR_ID` | — |
+| 스마트스토어 | `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET` | `NAVER_COMMERCE_CLIENT_ID`, `NAVER_COMMERCE_CLIENT_SECRET` |
+| 11번가 | `ELEVENST_API_KEY` | `ELEVENST_DISP_CTGR_NO`(선택, 기본 카테고리) |
+| Shopify | `SHOPIFY_SHOP`, `SHOPIFY_AUTO_TOKEN`, `SHOPIFY_CLIENT_SECRET` | `SHOPIFY_ACCESS_TOKEN`(레거시 토큰) |
+| WooCommerce | `WC_URL`, `WC_KEY`, `WC_SECRET` | `WOO_BASE_URL`, `WOO_CK`, `WOO_CS` |

--- a/docs/operations/dead_button_audit.md
+++ b/docs/operations/dead_button_audit.md
@@ -77,7 +77,25 @@
 
 | 항목 | 상태 |
 |------|------|
-| `src/seller_console/templates/bookmarklet.html` | `alert(...)` 다수 잔존 — 셀러 북마클릿 UX 별도 정비 후보 |
-| `src/seller_console/templates/me.html` | 회원 탈퇴/오류 처리 `alert(...)` 잔존 — 계정 설정 화면 후속 정비 필요 |
-| `src/seller_console/templates/personal_tokens.html` | 토큰 발급/복사/회수 `alert(...)` 잔존 — 토스트/모달 전환 후보 |
-| `src/seller_console/templates/pricing_*`, `discovery*.html` 일부 | 가격/디스커버리 서브페이지에 `alert(...)` 잔존 — 3차 감사 범위로 이관 |
+| `src/seller_console/templates/bookmarklet.html` | 콘솔 측 `alert(...)` → `pcToast`. 외부 사이트에서 실행되는 `javascript:` 북마클릿 코드 내부 `alert(...)`은 의도적 유지(콘솔 밖이라 pcToast 불가). → ✅ 3차 완료 |
+| `src/seller_console/templates/me.html` | 회원 탈퇴/오류 처리 `alert(...)` → `pcToast` (탈퇴 성공 시 토스트 후 1.2초 뒤 리다이렉트). → ✅ 3차 완료 |
+| `src/seller_console/templates/personal_tokens.html` | 토큰 발급/복사/회수 `alert(...)` → `pcToast`. → ✅ 3차 완료 |
+| `src/seller_console/templates/pricing_*`, `discovery*.html` | 가격/디스커버리 서브페이지 `alert(...)` → `pcToast`. → ✅ 3차 완료 |
+| `src/seller_console/templates/collect_preview.html` | 사전검증 경고/오류 `alert(...)` → `pcToast`. → ✅ 3차 완료 |
+
+---
+
+## 3차 감사 완료 (alert → 전역 pcToast 토스트)
+
+> 최종 갱신: 2026-06-10 · honest-UI: 차단형 `alert()` → 비차단 전역 토스트
+
+- **전역 토스트 인프라 신설**: `_base.html`에 `#pcToastContainer`(상단 우측, 모든 셀러 페이지 공용),
+  `seller.js`에 페이지 독립 `pcToast(message, type)` 헬퍼 추가.
+  - 메시지는 `textContent`로 삽입(XSS 방지), 타입별 색/아이콘(`success/error/danger/warning/info`),
+    error/danger는 6초·그 외 3.5초 후 자동 소멸, bootstrap 미로딩 시 폴백.
+- **교체 대상(8개 페이지)**: `pricing_rules`, `pricing_competitors`, `pricing_fx_impact`,
+  `pricing_history`, `discovery`, `discovery_keywords`, `me`, `personal_tokens`, `collect_preview`.
+  - 성공/실패 톤 구분, `location.reload()` 직전 성공 토스트는 1.2초 지연 후 새로고침으로 가시성 확보.
+- **유지(honest)**: 파괴적 동작의 `confirm(...)`은 의도적으로 유지(실제 동작하는 차단형 확인).
+  `bookmarklet.html`의 외부 실행 코드 내부 `alert(...)` 2건은 콘솔 밖 컨텍스트라 유지.
+- **회귀 테스트**: `tests/test_dead_buttons_phase191.py` 19개(전역 토스트 인프라 + 8개 페이지 alert 제거 검증).

--- a/docs/operations/dead_button_audit.md
+++ b/docs/operations/dead_button_audit.md
@@ -96,6 +96,16 @@
 - **교체 대상(8개 페이지)**: `pricing_rules`, `pricing_competitors`, `pricing_fx_impact`,
   `pricing_history`, `discovery`, `discovery_keywords`, `me`, `personal_tokens`, `collect_preview`.
   - 성공/실패 톤 구분, `location.reload()` 직전 성공 토스트는 1.2초 지연 후 새로고침으로 가시성 확보.
-- **유지(honest)**: 파괴적 동작의 `confirm(...)`은 의도적으로 유지(실제 동작하는 차단형 확인).
-  `bookmarklet.html`의 외부 실행 코드 내부 `alert(...)` 2건은 콘솔 밖 컨텍스트라 유지.
-- **회귀 테스트**: `tests/test_dead_buttons_phase191.py` 19개(전역 토스트 인프라 + 8개 페이지 alert 제거 검증).
+- **`bookmarklet.html`의 외부 실행 코드 내부 `alert(...)` 2건은 콘솔 밖 컨텍스트라 유지.**
+- **회귀 테스트**: `tests/test_dead_buttons_phase191.py`(전역 토스트/확인 모달 인프라 + 페이지별 검증).
+
+### 추가: 네이티브 confirm() → 전역 확인 모달(pcConfirm)
+
+- **전역 확인 모달 인프라**: `_base.html`에 `#pcConfirmModal`, `seller.js`에 Promise 기반
+  `pcConfirm(message, {title, confirmLabel, cancelLabel, danger})` 추가.
+  - `await pcConfirm(...)` 형태로 사용, 개행(`\n`) 보존, XSS 방지(textContent),
+    bootstrap/모달 미존재 시 네이티브 `confirm` 폴백.
+- **전환 대상(11개 호출 / 7개 페이지)**: `pricing_rules`(룰 삭제·로그인 이동·가격 적용 dry/실변경 2단),
+  `pricing_competitors`(삭제), `pricing_fx_impact`(재가격), `pricing_history`(롤백),
+  `discovery_keywords`(삭제), `me`(탈퇴), `personal_tokens`(회수).
+  - 파괴적 동작은 `danger`(빨강 확인), 비파괴(재가격/롤백/로그인 이동)는 `danger:false`(파랑)로 톤 구분.

--- a/scripts/verify_market_connections.py
+++ b/scripts/verify_market_connections.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""scripts/verify_market_connections.py — 마켓 연동 라이브 검증 도구.
+
+각 마켓(쿠팡/스마트스토어/11번가/Shopify/WooCommerce)에 대해
+1) 읽기 연결 + 안전한 write dry-run (운영 데이터 변경 없음)
+2) 업로드 사전검증(토큰/필수필드)
+을 실제로 호출하고, 사람이 한눈에 읽을 수 있는 표로 출력한다.
+
+자격증명이 없으면 'token_missing'으로 정직하게 표기되므로,
+운영 환경(Render 셸 등)에서 자격증명을 넣은 뒤 실행하면 실제 연결을 검증할 수 있다.
+
+사용법:
+    python -m scripts.verify_market_connections            # 전체 마켓
+    python -m scripts.verify_market_connections coupang    # 특정 마켓만
+    python -m scripts.verify_market_connections --json     # 기계용 JSON 출력
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# 상태별 이모지/한국어 라벨
+_STATUS_ICON = {
+    "connected": "✅ 연결됨",
+    "token_missing": "🪪 자격증명 없음",
+    "token_expired": "⏰ 토큰 만료",
+    "scope_insufficient": "🔒 권한 부족",
+    "api_error": "❌ API 오류",
+}
+
+# 검증에 사용할 안전한 샘플 상품 (실제 등록 아님 — 사전검증/ dry-run 용)
+_SAMPLE_PRODUCT = {
+    "title": "[검증용] 샘플 상품",
+    "title_ko": "[검증용] 샘플 상품",
+    "sku": "VERIFY-0001",
+    "price": 19900,
+    "currency": "KRW",
+    "sell_price_krw": 19900,
+    "images": [],
+    "description": "연결 검증용 샘플",
+    "category": "GEN",
+}
+
+
+# 진단 서브시스템 키 → 업로드 디스패처 키 (네임스페이스가 다른 경우 변환)
+_DISPATCH_MARKET_ALIAS = {"11st": "elevenst"}
+
+
+def _status_label(status: str) -> str:
+    return _STATUS_ICON.get(status, f"❓ {status}")
+
+
+def verify_market(market: str) -> dict:
+    """단일 마켓 연결 진단 + 업로드 사전검증."""
+    from src.seller_console.market_integration_diagnostics import run_market_diagnostic
+    from src.seller_console.upload_dispatcher import UploadDispatcher
+
+    diag = run_market_diagnostic(market)
+    dispatch_market = _DISPATCH_MARKET_ALIAS.get(market, market)
+
+    prevalidation = None
+    try:
+        results = UploadDispatcher().prevalidate(_SAMPLE_PRODUCT, [dispatch_market])
+        if results:
+            r = results[0]
+            prevalidation = {
+                "ok": r.ok,
+                "error_code": r.error_code,
+                "message": r.message,
+                "hint": r.hint,
+            }
+    except Exception as exc:  # pragma: no cover - 방어적
+        prevalidation = {"ok": False, "error_code": "error", "message": str(exc), "hint": ""}
+
+    return {
+        "market": market,
+        "label": diag.get("label", market),
+        "status": diag.get("status"),
+        "summary": diag.get("summary"),
+        "hint": diag.get("hint"),
+        "required_env": diag.get("required_env", []),
+        "docs_path": diag.get("docs_path"),
+        "prevalidation": prevalidation,
+    }
+
+
+def _print_human(rows: list[dict]) -> None:
+    print("\n=== 마켓 연동 라이브 검증 결과 ===\n")
+    for row in rows:
+        print(f"■ {row['label']} ({row['market']})")
+        print(f"   연결 상태 : {_status_label(row['status'])}")
+        print(f"   요약      : {row['summary']}")
+        pv = row.get("prevalidation") or {}
+        if pv:
+            pv_icon = "✅ 통과" if pv.get("ok") else f"⚠️ {pv.get('error_code')}"
+            print(f"   업로드준비: {pv_icon} — {pv.get('message', '')}")
+        if row["status"] != "connected":
+            print(f"   해결 방법 : {row['hint']}")
+            missing = ", ".join(row.get("required_env") or [])
+            if missing:
+                print(f"   필요 환경변수: {missing}")
+            print(f"   가이드    : {row['docs_path']}")
+        print()
+
+    connected = sum(1 for r in rows if r["status"] == "connected")
+    print(f"요약: 전체 {len(rows)}개 중 ✅ 연결됨 {connected}개 · 미연결 {len(rows) - connected}개")
+    if connected < len(rows):
+        print("→ 미연결 마켓은 위 '필요 환경변수'를 설정한 뒤 이 스크립트를 다시 실행하세요.")
+        print("  자세한 단계: docs/operations/LIVE_VERIFICATION_GUIDE.md")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="마켓 연동 라이브 검증 도구")
+    parser.add_argument("markets", nargs="*", help="검증할 마켓 (생략 시 전체)")
+    parser.add_argument("--json", action="store_true", help="JSON으로 출력")
+    args = parser.parse_args()
+
+    from src.seller_console.market_integration_diagnostics import MARKET_GUIDES
+
+    targets = [m.lower() for m in args.markets] or list(MARKET_GUIDES.keys())
+    unknown = [m for m in targets if m not in MARKET_GUIDES]
+    if unknown:
+        print(f"알 수 없는 마켓: {', '.join(unknown)}", file=sys.stderr)
+        print(f"지원 마켓: {', '.join(MARKET_GUIDES.keys())}", file=sys.stderr)
+        return 2
+
+    rows = [verify_market(m) for m in targets]
+
+    if args.json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+    else:
+        _print_human(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/channel_sync/_channel_bridge.py
+++ b/src/channel_sync/_channel_bridge.py
@@ -1,0 +1,120 @@
+"""채널 업로드 브리지 공통 헬퍼.
+
+UploadDispatcher의 `product_data`(ProductDraft 계열 dict)를
+`src.uploaders.*Uploader.prepare_product()`가 기대하는 collected 형식으로 변환하고,
+자격증명 확인 → prepare → upload → 결과 정규화를 공통 수행한다.
+
+honest-UI 원칙:
+- 자격증명 미설정 → ChannelCredentialsMissing (디스패처가 token_missing으로 표기)
+- API 실패 / 원화 판매가 0 → ChannelUploadError (디스패처가 api_error로 표기)
+- 성공 → {"product_id": ..., "url": ...}
+
+실 API 호출은 자격증명이 있을 때만 발생하며, 라이브 검증은 운영 환경에서 수행한다.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelCredentialsMissing(RuntimeError):
+    """채널 API 자격증명(환경변수) 미설정."""
+
+
+class ChannelUploadError(RuntimeError):
+    """채널 API 업로드 실패 또는 업로드 불가(원화가 0 등)."""
+
+
+def _first_positive_number(*values: Any) -> float | None:
+    """주어진 값들 중 처음으로 양수로 해석되는 값을 반환."""
+    for value in values:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            continue
+        if number > 0:
+            return number
+    return None
+
+
+def to_collected(product_data: Dict[str, Any]) -> Dict[str, Any]:
+    """디스패처 product_data → uploaders.prepare_product()용 collected 형식.
+
+    원화 판매가는 sell_price_krw → recommended_price(_krw) → price_krw →
+    (통화가 KRW일 때) price 순으로 가장 먼저 양수인 값을 채택한다.
+    """
+    pd = product_data or {}
+    currency = str(pd.get("currency") or "").upper()
+    price_if_krw = pd.get("price") if currency == "KRW" else None
+
+    sell_price_krw = _first_positive_number(
+        pd.get("sell_price_krw"),
+        pd.get("recommended_price_krw"),
+        pd.get("recommended_price"),
+        pd.get("price_krw"),
+        price_if_krw,
+    )
+    cost_price_krw = _first_positive_number(pd.get("price_krw"), sell_price_krw) or 0
+
+    options = pd.get("options")
+    tags = pd.get("keywords")
+    if not isinstance(tags, list):
+        tags = pd.get("tags") if isinstance(pd.get("tags"), list) else []
+
+    return {
+        "sku": str(pd.get("sku") or pd.get("asin") or "").strip(),
+        "title_ko": str(pd.get("title_ko") or pd.get("title") or "").strip(),
+        "title_original": str(pd.get("title_en") or pd.get("title") or "").strip(),
+        "sell_price_krw": int(round(sell_price_krw)) if sell_price_krw else 0,
+        "price_krw": int(round(cost_price_krw)),
+        "category_code": str(pd.get("category_code") or pd.get("category") or "GEN").strip() or "GEN",
+        "description_html": str(pd.get("description_html") or pd.get("description") or "").strip(),
+        "images": pd.get("images") if isinstance(pd.get("images"), list) else [],
+        "brand": str(pd.get("brand") or "").strip(),
+        "weight_kg": pd.get("weight_kg"),
+        "options": options if isinstance(options, (dict, list)) else {},
+        "tags": tags,
+    }
+
+
+def run_upload(
+    uploader: Any,
+    product_data: Dict[str, Any],
+    *,
+    required_envs: List[str],
+    market_label: str,
+) -> Dict[str, Any]:
+    """공통 업로드 실행 — 자격증명 확인 → 변환 → 업로드 → 결과 정규화.
+
+    Returns:
+        {"product_id": str|None, "url": str|None}
+    Raises:
+        ChannelCredentialsMissing: 필수 환경변수 미설정
+        ChannelUploadError: 원화 판매가 0 또는 API 실패
+    """
+    missing = [key for key in required_envs if not os.getenv(key)]
+    if missing:
+        raise ChannelCredentialsMissing(
+            f"{market_label} 자격증명 미설정: {', '.join(missing)}"
+        )
+
+    collected = to_collected(product_data)
+    if collected["sell_price_krw"] <= 0:
+        raise ChannelUploadError(
+            f"{market_label} 업로드 불가: 원화 판매가(sell_price_krw)가 0입니다."
+        )
+
+    prepared = uploader.prepare_product(collected)
+    resp = uploader.upload_product(prepared)
+
+    if not isinstance(resp, dict) or not resp.get("success"):
+        error = resp.get("error") if isinstance(resp, dict) else "알 수 없는 오류"
+        raise ChannelUploadError(f"{market_label} 업로드 실패: {error}")
+
+    return {
+        "product_id": str(resp.get("product_id") or "").strip() or None,
+        "url": str(resp.get("url") or "").strip() or None,
+    }

--- a/src/channel_sync/coupang_uploader.py
+++ b/src/channel_sync/coupang_uploader.py
@@ -1,0 +1,31 @@
+"""쿠팡 채널 업로드 브리지.
+
+UploadDispatcher._upload_coupang()가 `from src.channel_sync import coupang_uploader`로
+로드하여 `coupang_uploader.upload(product_data)`를 호출한다.
+실제 등록 로직은 `src.uploaders.CoupangUploader`(Phase 17-2, Wing API HMAC)를 재사용한다.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ._channel_bridge import run_upload
+
+REQUIRED_ENVS = ["COUPANG_ACCESS_KEY", "COUPANG_SECRET_KEY", "COUPANG_VENDOR_ID"]
+MARKET_LABEL = "쿠팡"
+
+
+def upload(product_data: Dict[str, Any]) -> Dict[str, Any]:
+    """쿠팡에 상품을 등록하고 {"product_id", "url"}을 반환한다.
+
+    Raises:
+        ChannelCredentialsMissing: COUPANG_* 환경변수 미설정
+        ChannelUploadError: 원화 판매가 0 또는 Wing API 실패
+    """
+    from src.uploaders.coupang_uploader import CoupangUploader
+
+    return run_upload(
+        CoupangUploader(),
+        product_data,
+        required_envs=REQUIRED_ENVS,
+        market_label=MARKET_LABEL,
+    )

--- a/src/channel_sync/elevenst_uploader.py
+++ b/src/channel_sync/elevenst_uploader.py
@@ -1,0 +1,31 @@
+"""11번가(11st) 채널 업로드 브리지.
+
+UploadDispatcher._upload_elevenst()가 `from src.channel_sync import elevenst_uploader`로
+로드하여 `elevenst_uploader.upload(product_data)`를 호출한다.
+실제 등록 로직은 `src.uploaders.ElevenStUploader`(11번가 OpenAPI)를 재사용한다.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ._channel_bridge import run_upload
+
+REQUIRED_ENVS = ["ELEVENST_API_KEY"]
+MARKET_LABEL = "11번가"
+
+
+def upload(product_data: Dict[str, Any]) -> Dict[str, Any]:
+    """11번가에 상품을 등록하고 {"product_id", "url"}을 반환한다.
+
+    Raises:
+        ChannelCredentialsMissing: ELEVENST_API_KEY 미설정
+        ChannelUploadError: 원화 판매가 0 또는 OpenAPI 실패
+    """
+    from src.uploaders.elevenst_uploader import ElevenStUploader
+
+    return run_upload(
+        ElevenStUploader(),
+        product_data,
+        required_envs=REQUIRED_ENVS,
+        market_label=MARKET_LABEL,
+    )

--- a/src/channel_sync/smartstore_uploader.py
+++ b/src/channel_sync/smartstore_uploader.py
@@ -1,0 +1,31 @@
+"""스마트스토어(네이버 커머스) 채널 업로드 브리지.
+
+UploadDispatcher._upload_smartstore()가 `from src.channel_sync import smartstore_uploader`로
+로드하여 `smartstore_uploader.upload(product_data)`를 호출한다.
+실제 등록 로직은 `src.uploaders.NaverSmartStoreUploader`(Phase 17-2, OAuth2)를 재사용한다.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ._channel_bridge import run_upload
+
+REQUIRED_ENVS = ["NAVER_CLIENT_ID", "NAVER_CLIENT_SECRET"]
+MARKET_LABEL = "스마트스토어"
+
+
+def upload(product_data: Dict[str, Any]) -> Dict[str, Any]:
+    """스마트스토어에 상품을 등록하고 {"product_id", "url"}을 반환한다.
+
+    Raises:
+        ChannelCredentialsMissing: NAVER_* 환경변수 미설정
+        ChannelUploadError: 원화 판매가 0 또는 커머스 API 실패
+    """
+    from src.uploaders.naver_uploader import NaverSmartStoreUploader
+
+    return run_upload(
+        NaverSmartStoreUploader(),
+        product_data,
+        required_envs=REQUIRED_ENVS,
+        market_label=MARKET_LABEL,
+    )

--- a/src/channel_sync/smartstore_uploader.py
+++ b/src/channel_sync/smartstore_uploader.py
@@ -6,26 +6,38 @@ UploadDispatcher._upload_smartstore()가 `from src.channel_sync import smartstor
 """
 from __future__ import annotations
 
+import os
 from typing import Any, Dict
 
-from ._channel_bridge import run_upload
+from ._channel_bridge import ChannelCredentialsMissing, run_upload
 
-REQUIRED_ENVS = ["NAVER_CLIENT_ID", "NAVER_CLIENT_SECRET"]
 MARKET_LABEL = "스마트스토어"
 
 
 def upload(product_data: Dict[str, Any]) -> Dict[str, Any]:
     """스마트스토어에 상품을 등록하고 {"product_id", "url"}을 반환한다.
 
+    네이버 커머스 자격증명은 NAVER_CLIENT_ID/SECRET 또는 NAVER_COMMERCE_CLIENT_ID/SECRET
+    어느 쪽이든 허용한다(코드 경로별 명명 혼용 흡수).
+
     Raises:
-        ChannelCredentialsMissing: NAVER_* 환경변수 미설정
+        ChannelCredentialsMissing: 네이버 자격증명 미설정
         ChannelUploadError: 원화 판매가 0 또는 커머스 API 실패
     """
     from src.uploaders.naver_uploader import NaverSmartStoreUploader
 
+    client_id = os.getenv("NAVER_CLIENT_ID") or os.getenv("NAVER_COMMERCE_CLIENT_ID")
+    client_secret = os.getenv("NAVER_CLIENT_SECRET") or os.getenv("NAVER_COMMERCE_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        raise ChannelCredentialsMissing(
+            "스마트스토어 자격증명 미설정: "
+            "NAVER_CLIENT_ID(또는 NAVER_COMMERCE_CLIENT_ID) / "
+            "NAVER_CLIENT_SECRET(또는 NAVER_COMMERCE_CLIENT_SECRET)"
+        )
+
     return run_upload(
         NaverSmartStoreUploader(),
         product_data,
-        required_envs=REQUIRED_ENVS,
+        required_envs=[],
         market_label=MARKET_LABEL,
     )

--- a/src/seller_console/market_adapters/coupang_adapter.py
+++ b/src/seller_console/market_adapters/coupang_adapter.py
@@ -465,7 +465,13 @@ class CoupangAdapter(MarketAdapter):
             resp = requests.get(f"{_BASE_URL}{url_path}", headers=headers, timeout=5)
             if resp.status_code == 200:
                 return {"status": "ok", "detail": "쿠팡 API 연결 성공"}
-            return {"status": "fail", "detail": f"HTTP {resp.status_code}"}
+            body = (resp.text or "").strip().replace("\n", " ")[:200]
+            hint = ""
+            if resp.status_code == 404:
+                hint = "COUPANG_VENDOR_ID 값이 올바른지(A+숫자 형식) 확인하세요."
+            elif resp.status_code in (401, 403):
+                hint = "COUPANG_ACCESS_KEY/SECRET_KEY 가 올바른지 확인하세요."
+            return {"status": "fail", "detail": f"HTTP {resp.status_code}: {body}", "hint": hint}
         except Exception as exc:
             logger.warning("쿠팡 health_check 실패: %s", exc)
             return {"status": "fail", "detail": str(exc)}

--- a/src/seller_console/market_adapters/eleven_adapter.py
+++ b/src/seller_console/market_adapters/eleven_adapter.py
@@ -354,7 +354,9 @@ class ElevenAdapter(MarketAdapter):
             )
             if resp.status_code == 200:
                 return {"status": "ok", "detail": "11번가 API 연결 성공"}
-            return {"status": "fail", "detail": f"HTTP {resp.status_code}"}
+            body = (resp.text or "").strip().replace("\n", " ")[:200]
+            hint = "ELEVENST_API_KEY 가 올바른지, 11번가 셀러오피스에서 OpenAPI 사용이 승인되었는지 확인하세요."
+            return {"status": "fail", "detail": f"HTTP {resp.status_code}: {body}", "hint": hint}
         except Exception as exc:
             logger.warning("11번가 health_check 실패: %s", exc)
             return {"status": "fail", "detail": str(exc)}

--- a/src/seller_console/market_adapters/smartstore_adapter.py
+++ b/src/seller_console/market_adapters/smartstore_adapter.py
@@ -32,6 +32,27 @@ def _api_active() -> bool:
     return all(os.getenv(v) for v in ["NAVER_COMMERCE_CLIENT_ID", "NAVER_COMMERCE_CLIENT_SECRET"])
 
 
+def _naver_signature(client_id: str, client_secret: str, timestamp_ms: str) -> Optional[str]:
+    """네이버 커머스 API 전자서명 생성.
+
+    규칙: bcrypt(password=f"{client_id}_{timestamp}", salt=client_secret) → base64.
+    client_secret 은 네이버가 발급한 bcrypt salt($2a$…) 그대로 사용한다.
+    """
+    try:
+        import base64
+        import bcrypt
+    except Exception as exc:  # pragma: no cover - bcrypt 미설치
+        logger.warning("bcrypt 임포트 실패 — 네이버 서명 불가: %s", exc)
+        return None
+    try:
+        password = f"{client_id}_{timestamp_ms}".encode("utf-8")
+        hashed = bcrypt.hashpw(password, client_secret.encode("utf-8"))
+        return base64.b64encode(hashed).decode("utf-8")
+    except Exception as exc:
+        logger.warning("네이버 전자서명 생성 실패(시크릿 형식 확인 필요): %s", exc)
+        return None
+
+
 def _dry_run() -> bool:
     return os.getenv("ADAPTER_DRY_RUN", "0") == "1"
 
@@ -46,6 +67,13 @@ def _get_access_token() -> Optional[str]:
     client_id = os.getenv("NAVER_COMMERCE_CLIENT_ID", "")
     client_secret = os.getenv("NAVER_COMMERCE_CLIENT_SECRET", "")
 
+    # 네이버 커머스 API는 client_secret 평문이 아니라 bcrypt 전자서명을 요구한다.
+    timestamp = str(int(now * 1000))
+    sign = _naver_signature(client_id, client_secret, timestamp)
+    if not sign:
+        logger.warning("스마트스토어 토큰 발급 실패: 전자서명 생성 불가(시크릿 형식 확인)")
+        return None
+
     try:
         import requests
         resp = requests.post(
@@ -53,9 +81,11 @@ def _get_access_token() -> Optional[str]:
             data={
                 "grant_type": "client_credentials",
                 "client_id": client_id,
-                "client_secret": client_secret,
+                "timestamp": timestamp,
+                "client_secret_sign": sign,
                 "type": "SELF",
             },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=10,
         )
         resp.raise_for_status()

--- a/src/seller_console/market_adapters/woocommerce_adapter.py
+++ b/src/seller_console/market_adapters/woocommerce_adapter.py
@@ -56,6 +56,17 @@ def _auth() -> tuple:
     )
 
 
+def _request_headers() -> dict:
+    """WP 호스트 WAF/보안플러그인이 막지 않도록 표준 헤더 포함.
+
+    User-Agent/Accept 미지정 시 일부 WordPress 호스트가 HTTP 406을 반환한다.
+    """
+    return {
+        "User-Agent": "ProxyCommerce/1.0 (+https://kohganemultishop.org)",
+        "Accept": "application/json",
+    }
+
+
 def _mask_name(name: str) -> str:
     """이름 마스킹 (첫 글자만 공개)."""
     if not name:
@@ -99,6 +110,7 @@ class WooCommerceAdapter(MarketAdapter):
                 resp = requests.get(
                     f"{_api_url()}/products",
                     auth=_auth(),
+                    headers=_request_headers(),
                     params={"per_page": 100, "status": "publish", "page": page},
                     timeout=15,
                 )
@@ -173,6 +185,7 @@ class WooCommerceAdapter(MarketAdapter):
             resp = requests.put(
                 f"{_api_url()}/products/{product_id}",
                 auth=_auth(),
+                headers=_request_headers(),
                 json={"regular_price": price_str, "sale_price": price_str},
                 timeout=10,
             )
@@ -192,6 +205,7 @@ class WooCommerceAdapter(MarketAdapter):
             resp = requests.get(
                 f"{_api_url()}/products",
                 auth=_auth(),
+                headers=_request_headers(),
                 params={"sku": sku, "per_page": 1},
                 timeout=10,
             )
@@ -232,6 +246,7 @@ class WooCommerceAdapter(MarketAdapter):
                 resp = requests.get(
                     f"{_api_url()}/orders",
                     auth=_auth(),
+                    headers=_request_headers(),
                     params=params,
                     timeout=15,
                 )
@@ -320,6 +335,7 @@ class WooCommerceAdapter(MarketAdapter):
             resp = requests.post(
                 f"{_api_url()}/products",
                 auth=_auth(),
+                headers=_request_headers(),
                 json=product,
                 timeout=15,
             )
@@ -349,6 +365,7 @@ class WooCommerceAdapter(MarketAdapter):
             resp = requests.post(
                 f"{_api_url()}/orders/{order_id}/notes",
                 auth=_auth(),
+                headers=_request_headers(),
                 json={"note": note, "customer_note": False},
                 timeout=15,
             )
@@ -377,6 +394,7 @@ class WooCommerceAdapter(MarketAdapter):
             resp = requests.get(
                 f"{_api_url()}/products",
                 auth=_auth(),
+                headers=_request_headers(),
                 params={"per_page": 1},
                 timeout=5,
             )
@@ -388,7 +406,13 @@ class WooCommerceAdapter(MarketAdapter):
                     "base_url": base_url,
                     "detail": "WooCommerce REST API 정상",
                 }
-            return {"status": "fail", "name": "woocommerce", "detail": f"HTTP {resp.status_code}"}
+            body = (resp.text or "").strip().replace("\n", " ")[:200]
+            hint = ""
+            if resp.status_code == 406:
+                hint = "호스트 보안(WAF)이 차단했을 수 있습니다. WC_URL이 https 정확한지, REST API가 활성인지 확인하세요."
+            elif resp.status_code in (401, 403):
+                hint = "WC_KEY/WC_SECRET(Read/Write 권한) 가 올바른지 확인하세요."
+            return {"status": "fail", "name": "woocommerce", "detail": f"HTTP {resp.status_code}: {body}", "hint": hint}
         except Exception as exc:
             logger.warning("WooCommerce health_check 실패: %s", exc)
             return {"status": "fail", "name": "woocommerce", "detail": str(exc)}

--- a/src/seller_console/market_credentials.py
+++ b/src/seller_console/market_credentials.py
@@ -1,0 +1,275 @@
+"""셀프서비스 마켓 연결 — 셀러별 마켓 자격증명 저장 / 연결 / 주입.
+
+SaaS 다중 셀러 대비: 각 셀러가 자신의 마켓 API 키를 직접 입력·저장·연결 테스트한다.
+환경변수(단일 테넌트/오너) 방식과 공존한다.
+
+- 저장: `data/market_credentials/<seller_id>.json` (Fernet 암호화, 키 없으면 평문+경고)
+- 주입: `seller_market_env(seller_id, market)` 컨텍스트로 표준 환경변수에 일시 주입
+- 폴백: 셀러 저장값이 없으면 전역 환경변수(os.environ)를 그대로 사용
+
+암호화 키: `MARKET_CRED_ENC_KEY`(Fernet 키) 우선, 없으면 `SECRET_KEY` 파생.
+둘 다 없으면 평문 저장(개발용) — 운영에서는 반드시 키를 설정할 것.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import re
+from contextlib import contextmanager
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_DATA_DIR = os.getenv("MARKET_CRED_DIR") or os.path.join("data", "market_credentials")
+
+
+# 마켓별 입력 필드 정의 (env = 코드가 실제로 읽는 표준 환경변수 이름).
+# secret=True 인 값은 화면에 마스킹해서 표시한다.
+MARKET_CRED_FIELDS: Dict[str, List[Dict[str, Any]]] = {
+    "coupang": [
+        {"env": "COUPANG_ACCESS_KEY", "label": "Access Key", "secret": True, "required": True},
+        {"env": "COUPANG_SECRET_KEY", "label": "Secret Key", "secret": True, "required": True},
+        {"env": "COUPANG_VENDOR_ID", "label": "Vendor ID", "secret": False, "required": True},
+    ],
+    "smartstore": [
+        {"env": "NAVER_CLIENT_ID", "label": "Client ID", "secret": False, "required": True},
+        {"env": "NAVER_CLIENT_SECRET", "label": "Client Secret", "secret": True, "required": True},
+        {"env": "NAVER_CHANNEL_ID", "label": "Channel ID (선택)", "secret": False, "required": False},
+    ],
+    "elevenst": [
+        {"env": "ELEVENST_API_KEY", "label": "API Key", "secret": True, "required": True},
+        {"env": "ELEVENST_DISP_CTGR_NO", "label": "기본 카테고리 번호 (선택)", "secret": False, "required": False},
+    ],
+    "shopify": [
+        {"env": "SHOPIFY_SHOP", "label": "상점 도메인 (xxx.myshopify.com)", "secret": False, "required": True},
+        {"env": "SHOPIFY_AUTO_TOKEN", "label": "Admin API Token (atk_…)", "secret": True, "required": True},
+        {"env": "SHOPIFY_CLIENT_SECRET", "label": "Client Secret (선택)", "secret": True, "required": False},
+    ],
+    "woocommerce": [
+        {"env": "WC_URL", "label": "사이트 URL", "secret": False, "required": True},
+        {"env": "WC_KEY", "label": "Consumer Key", "secret": True, "required": True},
+        {"env": "WC_SECRET", "label": "Consumer Secret", "secret": True, "required": True},
+    ],
+}
+
+# 마켓 표시명
+MARKET_LABELS = {
+    "coupang": "쿠팡",
+    "smartstore": "스마트스토어",
+    "elevenst": "11번가",
+    "shopify": "Shopify",
+    "woocommerce": "WooCommerce",
+}
+
+SUPPORTED_MARKETS = list(MARKET_CRED_FIELDS.keys())
+
+
+def _safe_seller_id(seller_id: str) -> str:
+    sid = re.sub(r"[^A-Za-z0-9_.@-]", "_", str(seller_id or "default")).strip("_") or "default"
+    return sid[:128]
+
+
+def _fernet():
+    """Fernet 인스턴스 반환 (암호화 불가 환경이면 None)."""
+    try:
+        from cryptography.fernet import Fernet
+    except Exception:  # pragma: no cover - cryptography 미설치
+        return None
+
+    raw = os.getenv("MARKET_CRED_ENC_KEY")
+    if raw:
+        try:
+            return Fernet(raw.encode() if isinstance(raw, str) else raw)
+        except Exception:
+            logger.warning("MARKET_CRED_ENC_KEY 형식 오류 — SECRET_KEY 파생으로 폴백")
+
+    secret = os.getenv("SECRET_KEY")
+    if secret:
+        key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode()).digest())
+        return Fernet(key)
+    return None
+
+
+def _path(seller_id: str) -> str:
+    return os.path.join(_DATA_DIR, f"{_safe_seller_id(seller_id)}.json")
+
+
+def _load_all(seller_id: str) -> Dict[str, Dict[str, str]]:
+    path = _path(seller_id)
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as fp:
+            blob = json.load(fp)
+    except Exception as exc:
+        logger.warning("자격증명 로드 실패(%s): %s", path, exc)
+        return {}
+
+    if not isinstance(blob, dict):
+        return {}
+    if blob.get("_enc"):
+        fernet = _fernet()
+        if not fernet:
+            logger.warning("암호화된 자격증명이나 복호화 키 없음 — 빈 값 반환")
+            return {}
+        try:
+            decrypted = fernet.decrypt(str(blob.get("data", "")).encode()).decode("utf-8")
+            data = json.loads(decrypted)
+            return data if isinstance(data, dict) else {}
+        except Exception as exc:
+            logger.warning("자격증명 복호화 실패: %s", exc)
+            return {}
+    data = blob.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def _save_all(seller_id: str, data: Dict[str, Dict[str, str]]) -> None:
+    os.makedirs(_DATA_DIR, exist_ok=True)
+    path = _path(seller_id)
+    fernet = _fernet()
+    if fernet:
+        token = fernet.encrypt(json.dumps(data, ensure_ascii=False).encode("utf-8")).decode("utf-8")
+        blob = {"_enc": True, "data": token}
+    else:
+        logger.warning("암호화 키 없음 — 자격증명을 평문으로 저장합니다(개발용). 운영에서는 MARKET_CRED_ENC_KEY를 설정하세요.")
+        blob = {"_enc": False, "data": data}
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as fp:
+        json.dump(blob, fp, ensure_ascii=False)
+    os.replace(tmp, path)
+
+
+# --------------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------------
+
+def get(seller_id: str, market: str) -> Dict[str, str]:
+    """셀러의 특정 마켓 자격증명(환경변수 이름→값) 반환."""
+    return dict(_load_all(seller_id).get(market, {}))
+
+
+def save(seller_id: str, market: str, values: Dict[str, str]) -> Dict[str, str]:
+    """알려진 필드만 추려 저장한다. 빈 값은 제외. 저장된 값 반환."""
+    if market not in MARKET_CRED_FIELDS:
+        raise KeyError(market)
+    allowed = {f["env"] for f in MARKET_CRED_FIELDS[market]}
+    cleaned = {
+        env: str(val).strip()
+        for env, val in (values or {}).items()
+        if env in allowed and str(val).strip()
+    }
+    data = _load_all(seller_id)
+    data[market] = cleaned
+    _save_all(seller_id, data)
+    return cleaned
+
+
+def delete(seller_id: str, market: str) -> bool:
+    """셀러의 특정 마켓 자격증명을 삭제한다."""
+    data = _load_all(seller_id)
+    if market in data:
+        del data[market]
+        _save_all(seller_id, data)
+        return True
+    return False
+
+
+def credential_env(seller_id: str, market: str) -> Dict[str, str]:
+    """주입용 환경변수 dict (셀러 저장값만). 없으면 빈 dict."""
+    return get(seller_id, market)
+
+
+def is_connected(seller_id: str, market: str) -> bool:
+    """필수 필드가 셀러 저장값 또는 전역 환경변수로 모두 채워졌는지."""
+    if market not in MARKET_CRED_FIELDS:
+        return False
+    stored = get(seller_id, market)
+    for field in MARKET_CRED_FIELDS[market]:
+        if not field.get("required"):
+            continue
+        if not (stored.get(field["env"]) or os.getenv(field["env"])):
+            return False
+    return True
+
+
+def _mask(value: str) -> str:
+    if not value:
+        return ""
+    if len(value) <= 4:
+        return "••••"
+    return value[:2] + "••••" + value[-2:]
+
+
+def status(seller_id: str, market: str) -> Dict[str, Any]:
+    """화면 표시용 상태 (마스킹된 값 포함, 비밀값 노출 금지)."""
+    stored = get(seller_id, market)
+    fields = []
+    for field in MARKET_CRED_FIELDS.get(market, []):
+        env = field["env"]
+        stored_val = stored.get(env, "")
+        global_val = os.getenv(env, "")
+        has_value = bool(stored_val or global_val)
+        display = ""
+        if stored_val:
+            display = _mask(stored_val) if field.get("secret") else stored_val
+        elif global_val:
+            display = "(서버 환경변수)" if field.get("secret") else global_val
+        fields.append({
+            "env": env,
+            "label": field["label"],
+            "secret": field.get("secret", False),
+            "required": field.get("required", False),
+            "has_value": has_value,
+            "from_global": bool(global_val and not stored_val),
+            "display": display,
+        })
+    return {
+        "market": market,
+        "label": MARKET_LABELS.get(market, market),
+        "connected": is_connected(seller_id, market),
+        "has_seller_credentials": bool(stored),
+        "fields": fields,
+    }
+
+
+def all_status(seller_id: str) -> List[Dict[str, Any]]:
+    return [status(seller_id, m) for m in SUPPORTED_MARKETS]
+
+
+@contextmanager
+def temp_env(updates: Dict[str, Optional[str]]):
+    """주어진 환경변수를 일시 주입하고 종료 시 원복한다 (빈 값/None은 건너뜀)."""
+    applied = {k: v for k, v in (updates or {}).items() if v}
+    original = {name: os.environ.get(name) for name in applied}
+    try:
+        for name, value in applied.items():
+            os.environ[name] = value
+        yield
+    finally:
+        for name, value in original.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+@contextmanager
+def seller_market_env(seller_id: str, markets, extra: Optional[Dict[str, str]] = None):
+    """선택 마켓들의 셀러 자격증명을 환경변수에 일시 주입한다.
+
+    셀러 저장값이 있으면 그것으로, 없으면 기존 전역 환경변수를 그대로 사용.
+    `extra`로 입력 중(미저장) 값을 추가 주입할 수 있다. 종료 시 원래 값으로 복원.
+    """
+    if isinstance(markets, str):
+        markets = [markets]
+    updates: Dict[str, str] = {}
+    for market in markets or []:
+        updates.update(credential_env(seller_id, market))
+    if extra:
+        updates.update({k: v for k, v in extra.items() if v})
+
+    with temp_env(updates):
+        yield

--- a/src/seller_console/market_credentials.py
+++ b/src/seller_console/market_credentials.py
@@ -182,6 +182,19 @@ def credential_env(seller_id: str, market: str) -> Dict[str, str]:
     return get(seller_id, market)
 
 
+def all_credential_env(seller_id: str) -> Dict[str, str]:
+    """셀러가 저장한 모든 마켓 자격증명을 하나로 합친 env dict.
+
+    마켓별 env 이름은 서로 겹치지 않으므로 단순 병합으로 안전하다.
+    진단/현황 화면이 셀러 저장 키를 반영하도록 주입할 때 사용.
+    """
+    merged: Dict[str, str] = {}
+    for market_values in _load_all(seller_id).values():
+        if isinstance(market_values, dict):
+            merged.update({k: v for k, v in market_values.items() if v})
+    return merged
+
+
 def is_connected(seller_id: str, market: str) -> bool:
     """필수 필드가 셀러 저장값 또는 전역 환경변수로 모두 채워졌는지."""
     if market not in MARKET_CRED_FIELDS:

--- a/src/seller_console/market_guide.py
+++ b/src/seller_console/market_guide.py
@@ -1,0 +1,133 @@
+"""인앱 마켓 API 키 발급 가이드 콘텐츠.
+
+각 마켓별로 "어디서 키를 받아 → 어떤 칸에 넣는지"를 누구나 한눈에 따라할 수 있게
+시각 흐름(flow) + 단계별 설명 + 필드 매핑으로 구조화한다.
+화면 렌더는 markets_guide.html 이 담당한다.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+# 마켓별 발급 가이드. flow = 상단 시각 다이어그램용 짧은 단계 라벨.
+MARKET_GUIDE: List[Dict[str, Any]] = [
+    {
+        "key": "coupang",
+        "label": "쿠팡",
+        "icon": "🛒",
+        "official_url": "https://wing.coupang.com",
+        "official_label": "쿠팡 윙(Wing) 열기",
+        "flow": ["쿠팡 윙 로그인", "업체정보 → 오픈API", "키 3개 발급/복사", "여기에 붙여넣기"],
+        "steps": [
+            {"t": "쿠팡 윙(Wing)에 판매자 계정으로 로그인", "d": "wing.coupang.com 접속 후 로그인합니다."},
+            {"t": "오른쪽 위 ‘업체정보’ → ‘추가판매정보’ → ‘오픈API 키 발급/관리’ 이동", "d": "메뉴 이름은 계정에 따라 약간 다를 수 있어요. ‘오픈API’ 단어를 찾으세요."},
+            {"t": "‘발급’ 버튼을 눌러 Access Key / Secret Key 생성", "d": "Secret Key는 발급 시 한 번만 보입니다. 꼭 복사해 두세요."},
+            {"t": "업체코드(Vendor ID) 확인", "d": "‘A’로 시작하는 숫자 코드입니다(예: A00012345). 업체정보 화면에 있습니다."},
+            {"t": "복사한 3개 값을 아래 입력칸에 붙여넣고 저장", "d": "[연결 테스트] → ✅ 연결됨 이면 완료."},
+        ],
+        "fields": [
+            {"env": "COUPANG_ACCESS_KEY", "label": "Access Key", "where": "오픈API 발급 화면의 ACCESS KEY"},
+            {"env": "COUPANG_SECRET_KEY", "label": "Secret Key", "where": "발급 시 1회만 보이는 SECRET KEY"},
+            {"env": "COUPANG_VENDOR_ID", "label": "Vendor ID(업체코드)", "where": "업체정보의 A+숫자 코드"},
+        ],
+        "tips": [
+            "404 오류가 나면 Vendor ID(A+숫자) 형식이 맞는지 가장 먼저 확인하세요.",
+            "오픈API 사용은 일부 계정에서 사전 신청/승인이 필요할 수 있습니다.",
+        ],
+    },
+    {
+        "key": "smartstore",
+        "label": "스마트스토어 (네이버)",
+        "icon": "🟢",
+        "official_url": "https://commerce.naver.com",
+        "official_label": "네이버 커머스 API센터 열기",
+        "flow": ["커머스 API센터 로그인", "애플리케이션 등록", "ID/Secret 발급", "여기에 붙여넣기"],
+        "steps": [
+            {"t": "네이버 커머스 API센터(commerce.naver.com) 로그인", "d": "스마트스토어 계정으로 로그인합니다."},
+            {"t": "‘애플리케이션 관리’ → ‘애플리케이션 등록’", "d": "판매자용 애플리케이션을 새로 만듭니다."},
+            {"t": "애플리케이션 ID(Client ID)와 시크릿(Client Secret) 확인", "d": "Client Secret은 ‘$2a$…’로 시작하는 긴 문자열입니다(전자서명용)."},
+            {"t": "필요한 권한(상품 등록/수정, 주문 조회 등) 체크", "d": "권한이 부족하면 등록은 되지만 일부 기능이 막힙니다."},
+            {"t": "ID/Secret을 아래 입력칸에 붙여넣고 저장", "d": "[연결 테스트] → ✅ 연결됨 이면 완료."},
+        ],
+        "fields": [
+            {"env": "NAVER_CLIENT_ID", "label": "Client ID", "where": "애플리케이션 정보의 클라이언트 ID"},
+            {"env": "NAVER_CLIENT_SECRET", "label": "Client Secret", "where": "‘$2a$…’로 시작하는 클라이언트 시크릿"},
+        ],
+        "tips": [
+            "Client Secret은 반드시 ‘$2a$…’ 형태 전체를 복사하세요(전자서명 생성에 사용).",
+            "‘토큰 발급 실패’가 뜨면 ID/Secret 오타·공백을 확인하세요.",
+        ],
+    },
+    {
+        "key": "elevenst",
+        "label": "11번가",
+        "icon": "🔴",
+        "official_url": "https://soffice.11st.co.kr",
+        "official_label": "11번가 셀러오피스 열기",
+        "flow": ["셀러오피스 로그인", "오픈API 신청", "API Key 발급", "여기에 붙여넣기"],
+        "steps": [
+            {"t": "11번가 셀러오피스(soffice.11st.co.kr) 로그인", "d": "판매자 계정으로 로그인합니다."},
+            {"t": "‘오픈API’ 메뉴에서 사용 신청", "d": "11번가는 OpenAPI 사용 신청/승인이 필요합니다(미승인 시 500 오류)."},
+            {"t": "승인 후 API Key 발급/확인", "d": "발급된 키 한 개를 복사합니다."},
+            {"t": "API Key를 아래 입력칸에 붙여넣고 저장", "d": "[연결 테스트] → ✅ 연결됨 이면 완료."},
+        ],
+        "fields": [
+            {"env": "ELEVENST_API_KEY", "label": "API Key", "where": "오픈API 발급 화면의 키"},
+            {"env": "ELEVENST_DISP_CTGR_NO", "label": "기본 카테고리 번호(선택)", "where": "셀러 카테고리 번호(첫 등록 오류 시 입력)"},
+        ],
+        "tips": [
+            "HTTP 500이 뜨면 OpenAPI 사용이 ‘승인’되었는지 먼저 확인하세요.",
+            "상품 등록 시 카테고리 오류가 나면 ELEVENST_DISP_CTGR_NO에 본인 카테고리 번호를 넣으세요.",
+        ],
+    },
+    {
+        "key": "shopify",
+        "label": "Shopify",
+        "icon": "🛍️",
+        "official_url": "https://www.shopify.com/admin",
+        "official_label": "Shopify Admin 열기",
+        "flow": ["Admin → Apps", "앱 생성/Develop apps", "Admin API 토큰 발급", "여기에 붙여넣기"],
+        "steps": [
+            {"t": "Shopify Admin → ‘Settings’ → ‘Apps and sales channels’ → ‘Develop apps’", "d": "커스텀 앱 개발 화면으로 들어갑니다."},
+            {"t": "‘Create an app’으로 앱 생성", "d": "이름은 자유(예: ProxyCommerce)."},
+            {"t": "‘Configuration’에서 Admin API 권한 부여", "d": "read/write products·inventory·orders 체크."},
+            {"t": "‘API credentials’에서 Admin API access token 발급", "d": "‘shpat_…’ 형태 토큰입니다. 한 번만 보이니 복사하세요."},
+            {"t": "상점 도메인 + 토큰을 아래 입력칸에 붙여넣고 저장", "d": "상점 도메인은 ‘내상점.myshopify.com’ 형태."},
+        ],
+        "fields": [
+            {"env": "SHOPIFY_SHOP", "label": "상점 도메인", "where": "내상점.myshopify.com"},
+            {"env": "SHOPIFY_AUTO_TOKEN", "label": "Admin API Token", "where": "‘shpat_…’ 액세스 토큰"},
+            {"env": "SHOPIFY_CLIENT_SECRET", "label": "Client Secret(선택)", "where": "웹훅 검증용(있으면 입력)"},
+        ],
+        "tips": [
+            "‘Invalid API key or access token’이 뜨면 토큰을 재발급해 다시 붙여넣으세요.",
+            "토큰은 한 번만 노출됩니다. 못 봤으면 새로 발급하면 됩니다.",
+        ],
+    },
+    {
+        "key": "woocommerce",
+        "label": "WooCommerce (자체몰)",
+        "icon": "🟣",
+        "official_url": "https://kohganemultishop.org/wp-admin",
+        "official_label": "WordPress 관리자 열기",
+        "flow": ["WP 관리자 로그인", "WooCommerce → 설정 → 고급 → REST API", "키 생성(Read/Write)", "여기에 붙여넣기"],
+        "steps": [
+            {"t": "WordPress 관리자(wp-admin) 로그인", "d": "사이트 관리자 계정으로 로그인합니다."},
+            {"t": "‘WooCommerce → 설정 → 고급 → REST API’ 이동", "d": "REST API 키 관리 화면입니다."},
+            {"t": "‘키 추가(Add key)’ → 권한을 ‘읽기/쓰기(Read/Write)’로 생성", "d": "Consumer key/secret가 생성됩니다."},
+            {"t": "사이트 URL + key/secret을 아래 입력칸에 붙여넣고 저장", "d": "[연결 테스트] → ✅ 연결됨 이면 완료."},
+        ],
+        "fields": [
+            {"env": "WC_URL", "label": "사이트 URL", "where": "https://내사이트주소"},
+            {"env": "WC_KEY", "label": "Consumer Key", "where": "‘ck_…’ 키"},
+            {"env": "WC_SECRET", "label": "Consumer Secret", "where": "‘cs_…’ 시크릿"},
+        ],
+        "tips": [
+            "HTTP 406이 뜨면 사이트 보안(WAF) 때문일 수 있습니다. URL이 https로 정확한지 확인하세요.",
+            "권한을 꼭 ‘Read/Write’로 생성하세요(읽기 전용이면 등록 불가).",
+        ],
+    },
+]
+
+
+def get_guide() -> List[Dict[str, Any]]:
+    return MARKET_GUIDE

--- a/src/seller_console/static/seller.js
+++ b/src/seller_console/static/seller.js
@@ -116,6 +116,55 @@ function pcToast(message, type = 'info') {
   }
 }
 
+/**
+ * 전역 확인 모달 (pcConfirm) — 차단형 네이티브 confirm()을 대체한다.
+ * Promise<boolean>을 반환하므로 `if (!(await pcConfirm('...'))) return;` 형태로 사용.
+ * `_base.html`의 #pcConfirmModal을 재사용하며, bootstrap/모달이 없으면 네이티브 confirm 폴백.
+ * @param {string} message - 본문 메시지 (개행 \n 지원, textContent로 안전 삽입)
+ * @param {object} [options] - {title, confirmLabel, cancelLabel, danger}
+ * @returns {Promise<boolean>}
+ */
+function pcConfirm(message, options = {}) {
+  return new Promise((resolve) => {
+    const modalEl = document.getElementById('pcConfirmModal');
+    if (!modalEl || typeof bootstrap === 'undefined' || !bootstrap.Modal) {
+      resolve(window.confirm(message));
+      return;
+    }
+    const titleEl = document.getElementById('pcConfirmTitle');
+    const bodyEl = document.getElementById('pcConfirmBody');
+    const okBtn = document.getElementById('pcConfirmOk');
+    const cancelBtn = document.getElementById('pcConfirmCancel');
+
+    if (titleEl) titleEl.textContent = options.title || '확인';
+    // 개행을 보존하면서 XSS 없이 삽입
+    if (bodyEl) {
+      bodyEl.textContent = '';
+      String(message).split('\n').forEach((line, idx) => {
+        if (idx > 0) bodyEl.appendChild(document.createElement('br'));
+        bodyEl.appendChild(document.createTextNode(line));
+      });
+    }
+    if (okBtn) {
+      okBtn.textContent = options.confirmLabel || '확인';
+      okBtn.className = 'btn btn-' + (options.danger === false ? 'primary' : 'danger');
+    }
+    if (cancelBtn) cancelBtn.textContent = options.cancelLabel || '취소';
+
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    let settled = false;
+    const onOk = () => { settled = true; cleanup(); modal.hide(); resolve(true); };
+    const onHide = () => { if (!settled) { cleanup(); resolve(false); } };
+    function cleanup() {
+      if (okBtn) okBtn.removeEventListener('click', onOk);
+      modalEl.removeEventListener('hidden.bs.modal', onHide);
+    }
+    if (okBtn) okBtn.addEventListener('click', onOk);
+    modalEl.addEventListener('hidden.bs.modal', onHide);
+    modal.show();
+  });
+}
+
 function setButtonLoading(button, isLoading, loadingText = '처리 중…') {
   if (!button) return;
   if (isLoading) {

--- a/src/seller_console/static/seller.js
+++ b/src/seller_console/static/seller.js
@@ -61,6 +61,61 @@ function showGlobalToast(message, type = 'info', options = {}) {
   new bootstrap.Toast(toastEl, {delay: 3000}).show();
 }
 
+/**
+ * 전역 토스트 알림 (pcToast) — 페이지에 별도 토스트 엘리먼트가 없어도 동작한다.
+ * `_base.html`의 #pcToastContainer에 동적으로 토스트를 생성/표시/제거한다.
+ * 차단형 alert()를 대체하는 honest-UI 비차단 알림.
+ * @param {string} message - 표시할 메시지 (텍스트로 안전하게 삽입)
+ * @param {string} type - 'success' | 'error' | 'danger' | 'warning' | 'info'
+ */
+function pcToast(message, type = 'info') {
+  let container = document.getElementById('pcToastContainer');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'pcToastContainer';
+    container.className = 'toast-container position-fixed top-0 end-0 p-3';
+    container.style.zIndex = '1090';
+    container.setAttribute('aria-live', 'polite');
+    container.setAttribute('aria-atomic', 'true');
+    document.body.appendChild(container);
+  }
+  const toneMap = {success: 'success', error: 'danger', danger: 'danger', warning: 'warning', info: 'secondary'};
+  const iconMap = {success: '✅', error: '❌', danger: '❌', warning: '⚠️', info: 'ℹ️'};
+  const tone = toneMap[type] || 'secondary';
+
+  const toastEl = document.createElement('div');
+  toastEl.className = `toast align-items-center text-bg-${tone} border-0`;
+  toastEl.setAttribute('role', 'alert');
+  toastEl.setAttribute('aria-live', 'assertive');
+  toastEl.setAttribute('aria-atomic', 'true');
+
+  const flex = document.createElement('div');
+  flex.className = 'd-flex';
+  const body = document.createElement('div');
+  body.className = 'toast-body';
+  body.textContent = `${iconMap[type] || ''} ${message}`.trim();
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'btn-close btn-close-white me-2 m-auto';
+  closeBtn.setAttribute('data-bs-dismiss', 'toast');
+  closeBtn.setAttribute('aria-label', '닫기');
+  flex.appendChild(body);
+  flex.appendChild(closeBtn);
+  toastEl.appendChild(flex);
+  container.appendChild(toastEl);
+
+  const delay = (type === 'error' || type === 'danger') ? 6000 : 3500;
+  if (typeof bootstrap !== 'undefined' && bootstrap.Toast) {
+    const toast = new bootstrap.Toast(toastEl, {delay});
+    toastEl.addEventListener('hidden.bs.toast', () => toastEl.remove());
+    toast.show();
+  } else {
+    // bootstrap 미로딩 폴백: 잠깐 보여주고 제거
+    toastEl.classList.add('show');
+    setTimeout(() => toastEl.remove(), delay);
+  }
+}
+
 function setButtonLoading(button, isLoading, loadingText = '처리 중…') {
   if (!button) return;
   if (isLoading) {

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -150,6 +150,9 @@
   </div>
 </div>
 
+<!-- 전역 토스트 컨테이너 (pcToast) — 모든 셀러 페이지 공용 비차단 알림 -->
+<div id="pcToastContainer" class="toast-container position-fixed top-0 end-0 p-3" style="z-index:1090;" aria-live="polite" aria-atomic="true"></div>
+
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ url_for('seller_console.static', filename='seller.js') }}"></script>
 <script>

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -62,7 +62,8 @@
       <li><a class="console-nav-link {% if _path.startswith('/seller/pricing/fx-impact') %}active{% endif %}" href="/seller/pricing/fx-impact"><i class="bi bi-currency-exchange"></i><span>환율 영향</span></a></li>
 
       <li class="console-nav-group-title">마켓</li>
-      <li><a class="console-nav-link {% if _path.startswith('/seller/markets') or _path.startswith('/seller/market-status') %}active{% endif %}" href="/seller/markets"><i class="bi bi-shop"></i><span>마켓 연동/현황</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/markets') and not _path.startswith('/seller/markets/connect') or _path.startswith('/seller/market-status') %}active{% endif %}" href="/seller/markets"><i class="bi bi-shop"></i><span>마켓 연동/현황</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/markets/connect') %}active{% endif %}" href="/seller/markets/connect"><i class="bi bi-plug"></i><span>마켓 연결(키 설정)</span></a></li>
 
       <li class="console-nav-group-title">운영</li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/orders') %}active{% endif %}" href="/seller/orders"><i class="bi bi-receipt"></i><span>주문 관리</span></a></li>

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -153,6 +153,23 @@
 <!-- 전역 토스트 컨테이너 (pcToast) — 모든 셀러 페이지 공용 비차단 알림 -->
 <div id="pcToastContainer" class="toast-container position-fixed top-0 end-0 p-3" style="z-index:1090;" aria-live="polite" aria-atomic="true"></div>
 
+<!-- 전역 확인 모달 (pcConfirm) — 네이티브 confirm 다이얼로그 대체 -->
+<div class="modal fade" id="pcConfirmModal" tabindex="-1" aria-labelledby="pcConfirmTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="pcConfirmTitle">확인</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body" id="pcConfirmBody"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal" id="pcConfirmCancel">취소</button>
+        <button type="button" class="btn btn-danger" id="pcConfirmOk">확인</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ url_for('seller_console.static', filename='seller.js') }}"></script>
 <script>

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -62,8 +62,9 @@
       <li><a class="console-nav-link {% if _path.startswith('/seller/pricing/fx-impact') %}active{% endif %}" href="/seller/pricing/fx-impact"><i class="bi bi-currency-exchange"></i><span>환율 영향</span></a></li>
 
       <li class="console-nav-group-title">마켓</li>
-      <li><a class="console-nav-link {% if _path.startswith('/seller/markets') and not _path.startswith('/seller/markets/connect') or _path.startswith('/seller/market-status') %}active{% endif %}" href="/seller/markets"><i class="bi bi-shop"></i><span>마켓 연동/현황</span></a></li>
+      <li><a class="console-nav-link {% if (_path.startswith('/seller/markets') and not _path.startswith('/seller/markets/connect') and not _path.startswith('/seller/markets/guide')) or _path.startswith('/seller/market-status') %}active{% endif %}" href="/seller/markets"><i class="bi bi-shop"></i><span>마켓 연동/현황</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/markets/connect') %}active{% endif %}" href="/seller/markets/connect"><i class="bi bi-plug"></i><span>마켓 연결(키 설정)</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/markets/guide') %}active{% endif %}" href="/seller/markets/guide"><i class="bi bi-journal-text"></i><span>API 키 발급 가이드</span></a></li>
 
       <li class="console-nav-group-title">운영</li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/orders') %}active{% endif %}" href="/seller/orders"><i class="bi bi-receipt"></i><span>주문 관리</span></a></li>

--- a/src/seller_console/templates/bookmarklet.html
+++ b/src/seller_console/templates/bookmarklet.html
@@ -100,7 +100,7 @@ function buildBookmarkletCode(token) {
 function updateBookmarklet() {
   const rawToken = document.getElementById('tokenInput').value.trim();
   if (!rawToken) {
-    alert('토큰을 입력해주세요.');
+    pcToast('토큰을 입력해주세요.', 'warning');
     return;
   }
   // 토큰 값을 JSON-encode하여 특수 문자가 JS 코드에 삽입되지 않도록 처리
@@ -112,7 +112,7 @@ function updateBookmarklet() {
 
 function copyCode() {
   const code = document.getElementById('bookmarkletCode').textContent;
-  navigator.clipboard.writeText(code).then(() => alert('코드가 복사되었습니다.'));
+  navigator.clipboard.writeText(code).then(() => pcToast('코드가 복사되었습니다.', 'success'));
 }
 </script>
 {% endblock %}

--- a/src/seller_console/templates/collect_preview.html
+++ b/src/seller_console/templates/collect_preview.html
@@ -196,7 +196,7 @@ function getSelectedMarkets() {
 async function runPrevalidate() {
   const markets = getSelectedMarkets();
   if (markets.length === 0) {
-    alert('등록할 마켓을 하나 이상 선택하세요.');
+    pcToast('등록할 마켓을 하나 이상 선택하세요.', 'warning');
     return;
   }
   const btn = document.getElementById('btnPrevalidate');
@@ -214,7 +214,7 @@ async function runPrevalidate() {
     btn.textContent = '🔍 사전검증 →';
 
     if (!data.ok) {
-      alert(data.error || '사전검증 실패');
+      pcToast(data.error || '사전검증 실패', 'error');
       return;
     }
     renderPrevalidateResults(data.results);
@@ -222,7 +222,7 @@ async function runPrevalidate() {
   } catch (err) {
     btn.disabled = false;
     btn.textContent = '🔍 사전검증 →';
-    alert('사전검증 요청 실패: ' + err.message);
+    pcToast('사전검증 요청 실패: ' + err.message, 'error');
   }
 }
 

--- a/src/seller_console/templates/discovery.html
+++ b/src/seller_console/templates/discovery.html
@@ -91,10 +91,10 @@ document.getElementById('runScoutBtn').addEventListener('click', async () => {
   try {
     const resp = await fetch('/cron/discovery', {method: 'POST'});
     const data = await resp.json();
-    alert('Discovery 완료: ' + (data.discovered || 0) + '개 신규 도메인 발견');
-    location.reload();
+    pcToast('Discovery 완료: ' + (data.discovered || 0) + '개 신규 도메인 발견', 'success');
+    setTimeout(() => location.reload(), 1200);
   } catch(e) {
-    alert('오류: ' + e.message);
+    pcToast('오류: ' + e.message, 'error');
   } finally {
     btn.disabled = false;
     btn.textContent = '▶ Discovery 실행';
@@ -111,7 +111,7 @@ document.querySelectorAll('.approve-btn').forEach(btn => {
     });
     const data = await resp.json();
     if (data.ok) location.reload();
-    else alert('승인 실패: ' + (data.error || '알 수 없는 오류'));
+    else pcToast('승인 실패: ' + (data.error || '알 수 없는 오류'), 'error');
   });
 });
 
@@ -125,7 +125,7 @@ document.querySelectorAll('.reject-btn').forEach(btn => {
     });
     const data = await resp.json();
     if (data.ok) location.reload();
-    else alert('거부 실패: ' + (data.error || '알 수 없는 오류'));
+    else pcToast('거부 실패: ' + (data.error || '알 수 없는 오류'), 'error');
   });
 });
 </script>

--- a/src/seller_console/templates/discovery_keywords.html
+++ b/src/seller_console/templates/discovery_keywords.html
@@ -74,7 +74,7 @@ document.getElementById('addBtn').addEventListener('click', async () => {
 document.querySelectorAll('.remove-btn').forEach(btn => {
   btn.addEventListener('click', async () => {
     const keyword = btn.dataset.keyword;
-    if (!confirm(`"${keyword}" 키워드를 삭제하시겠습니까?`)) return;
+    if (!(await pcConfirm(`"${keyword}" 키워드를 삭제하시겠습니까?`, {title: '키워드 삭제', confirmLabel: '삭제'}))) return;
     try {
       const resp = await fetch('/seller/discovery/keywords/remove', {
         method: 'POST',

--- a/src/seller_console/templates/discovery_keywords.html
+++ b/src/seller_console/templates/discovery_keywords.html
@@ -65,9 +65,9 @@ document.getElementById('addBtn').addEventListener('click', async () => {
     });
     const data = await resp.json();
     if (data.ok) location.reload();
-    else alert('추가 실패: ' + (data.error || '알 수 없는 오류'));
+    else pcToast('추가 실패: ' + (data.error || '알 수 없는 오류'), 'error');
   } catch(e) {
-    alert('오류: ' + e.message);
+    pcToast('오류: ' + e.message, 'error');
   }
 });
 
@@ -83,9 +83,9 @@ document.querySelectorAll('.remove-btn').forEach(btn => {
       });
       const data = await resp.json();
       if (data.ok) location.reload();
-      else alert('삭제 실패: ' + (data.error || '알 수 없는 오류'));
+      else pcToast('삭제 실패: ' + (data.error || '알 수 없는 오류'), 'error');
     } catch(e) {
-      alert('오류: ' + e.message);
+      pcToast('오류: ' + e.message, 'error');
     }
   });
 });

--- a/src/seller_console/templates/markets.html
+++ b/src/seller_console/templates/markets.html
@@ -36,7 +36,10 @@
         <div class="fw-semibold">마켓 연동 컨트롤 센터</div>
         <div class="small text-muted">실제 검증된 연동 상태와 운영자 조치 힌트를 함께 확인하세요.</div>
       </div>
-      <span class="badge text-bg-light" id="marketDiagnosticsSummary">실연동 진단 대기</span>
+      <div class="d-flex align-items-center gap-2">
+        <a href="/seller/markets/connect" class="btn btn-primary btn-sm">🔌 마켓 연결(키 입력)</a>
+        <span class="badge text-bg-light" id="marketDiagnosticsSummary">실연동 진단 대기</span>
+      </div>
     </div>
     <div class="row g-2 mt-2">
       {% for hub in market_hub_cards %}
@@ -64,6 +67,7 @@
             <button class="btn btn-outline-primary btn-sm" type="button" data-market-action="connection" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'connection')">연결 확인</button>
             <button class="btn btn-outline-secondary btn-sm" type="button" data-market-action="scope" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'scope')">권한 확인</button>
             <button class="btn btn-outline-warning btn-sm" type="button" data-market-action="retry" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'retry')">재시도</button>
+            <a class="btn btn-outline-primary btn-sm" href="/seller/markets/connect">🔑 키 입력</a>
           </div>
           <div class="small text-muted mt-2">필수 권한: {{ hub.required_scopes|join(', ') }}</div>
           <div class="small text-muted mt-1">필수 env: {{ hub.required_env|join(', ') }}</div>

--- a/src/seller_console/templates/markets.html
+++ b/src/seller_console/templates/markets.html
@@ -37,6 +37,7 @@
         <div class="small text-muted">실제 검증된 연동 상태와 운영자 조치 힌트를 함께 확인하세요.</div>
       </div>
       <div class="d-flex align-items-center gap-2">
+        <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm">📖 발급 가이드</a>
         <a href="/seller/markets/connect" class="btn btn-primary btn-sm">🔌 마켓 연결(키 입력)</a>
         <span class="badge text-bg-light" id="marketDiagnosticsSummary">실연동 진단 대기</span>
       </div>

--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -1,0 +1,173 @@
+{% extends "_base.html" %}
+{% block title %}마켓 연결{% endblock %}
+
+{% block content %}
+<section class="mb-4">
+  <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
+    <div>
+      <h1 class="h4 mb-1">마켓 연결</h1>
+      <p class="text-muted mb-0">내 마켓 API 키를 직접 입력하고, 저장 전에 연결을 테스트할 수 있어요.</p>
+    </div>
+    <a href="/seller/markets" class="btn btn-outline-secondary btn-sm">← 마켓 현황으로</a>
+  </div>
+
+  <div class="alert alert-light border d-flex gap-2 align-items-start mb-4" role="note">
+    <i class="bi bi-shield-lock text-primary"></i>
+    <div class="small mb-0">
+      입력한 키는 <strong>암호화되어 저장</strong>됩니다(서버에 <code>MARKET_CRED_ENC_KEY</code> 설정 시).
+      <strong>연결 테스트</strong>는 실제 마켓에 읽기/안전한 빈 쓰기만 시도하며 상품을 등록하지 않습니다.
+    </div>
+  </div>
+
+  <div class="row g-3">
+    {% for m in market_statuses %}
+    <div class="col-12 col-lg-6">
+      <div class="card console-card h-100" data-market="{{ m.market }}">
+        <div class="card-body">
+          <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
+            <h2 class="h6 mb-0">{{ m.label }}</h2>
+            <span class="badge rounded-pill {{ 'text-bg-success' if m.connected else 'text-bg-secondary' }}"
+                  data-role="status-badge">
+              {{ '✅ 연결됨' if m.connected else '🪪 미연결' }}
+            </span>
+          </div>
+
+          <form class="market-connect-form" data-market="{{ m.market }}" autocomplete="off">
+            {% for f in m.fields %}
+            <div class="mb-2">
+              <label class="form-label small mb-1">
+                {{ f.label }}
+                {% if f.required %}<span class="text-danger">*</span>{% endif %}
+                {% if f.from_global %}<span class="badge text-bg-light ms-1">서버 환경변수 사용 중</span>{% endif %}
+              </label>
+              <input
+                type="{{ 'password' if f.secret else 'text' }}"
+                class="form-control form-control-sm"
+                name="{{ f.env }}"
+                data-secret="{{ '1' if f.secret else '0' }}"
+                placeholder="{{ '저장됨 (' ~ f.display ~ ')' if (f.has_value and f.secret) else (f.display or f.env) }}"
+                value="{{ '' if f.secret else f.display }}"
+              >
+            </div>
+            {% endfor %}
+
+            <div class="d-flex flex-wrap gap-2 mt-3">
+              <button type="button" class="btn btn-outline-primary btn-sm" data-action="test">
+                <i class="bi bi-plug"></i> 연결 테스트
+              </button>
+              <button type="submit" class="btn btn-primary btn-sm" data-action="save">
+                <i class="bi bi-save"></i> 저장
+              </button>
+              {% if m.has_seller_credentials %}
+              <button type="button" class="btn btn-outline-danger btn-sm ms-auto" data-action="disconnect">
+                연결 해제
+              </button>
+              {% endif %}
+            </div>
+            <div class="small mt-2 d-none" data-role="test-result"></div>
+          </form>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <p class="text-muted small mt-3 mb-0">
+    각 키 발급 방법은 <code>docs/operations/LIVE_VERIFICATION_GUIDE.md</code> 를 참고하세요.
+  </p>
+</section>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+function collectValues(form) {
+  const values = {};
+  form.querySelectorAll('input[name]').forEach(input => {
+    const v = (input.value || '').trim();
+    if (v) values[input.name] = v;
+  });
+  return values;
+}
+
+async function postJson(url, payload) {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload || {}),
+  });
+  const data = await resp.json().catch(() => ({}));
+  return {ok: resp.ok, data};
+}
+
+function renderTestResult(form, result) {
+  const box = form.querySelector('[data-role="test-result"]');
+  if (!box) return;
+  box.classList.remove('d-none', 'text-success', 'text-danger', 'text-warning');
+  if (result && result.status === 'connected') {
+    box.classList.add('text-success');
+    box.textContent = '✅ 연결 성공 — ' + (result.summary || '');
+  } else {
+    box.classList.add('text-warning');
+    const code = result ? (result.status || '실패') : '실패';
+    box.textContent = '⚠️ ' + code + ' — ' + ((result && (result.hint || result.summary)) || '연결을 확인하세요.');
+  }
+}
+
+function updateBadge(card, connected) {
+  const badge = card.querySelector('[data-role="status-badge"]');
+  if (!badge) return;
+  badge.className = 'badge rounded-pill ' + (connected ? 'text-bg-success' : 'text-bg-secondary');
+  badge.textContent = connected ? '✅ 연결됨' : '🪪 미연결';
+}
+
+document.querySelectorAll('.market-connect-form').forEach(form => {
+  const market = form.dataset.market;
+  const card = form.closest('[data-market]');
+
+  // 연결 테스트
+  form.querySelector('[data-action="test"]').addEventListener('click', async (e) => {
+    const btn = e.currentTarget;
+    setButtonLoading(btn, true, '테스트 중…');
+    try {
+      const {data} = await postJson(`/seller/markets/connect/${market}/test`, {values: collectValues(form)});
+      if (!data.ok) { pcToast(data.error || '연결 테스트 실패', 'error'); return; }
+      renderTestResult(form, data.result);
+    } catch (err) {
+      pcToast('연결 테스트 요청 실패: ' + err.message, 'error');
+    } finally {
+      setButtonLoading(btn, false);
+    }
+  });
+
+  // 저장
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const btn = form.querySelector('[data-action="save"]');
+    setButtonLoading(btn, true, '저장 중…');
+    try {
+      const {data} = await postJson(`/seller/markets/connect/${market}`, {values: collectValues(form)});
+      if (!data.ok) { pcToast(data.error || '저장 실패', 'error'); return; }
+      updateBadge(card, data.status && data.status.connected);
+      pcToast(`${market} 자격증명을 저장했어요.`, 'success');
+    } catch (err) {
+      pcToast('저장 요청 실패: ' + err.message, 'error');
+    } finally {
+      setButtonLoading(btn, false);
+    }
+  });
+
+  // 연결 해제
+  const disconnectBtn = form.querySelector('[data-action="disconnect"]');
+  if (disconnectBtn) {
+    disconnectBtn.addEventListener('click', async () => {
+      if (!(await pcConfirm('저장된 자격증명을 삭제할까요? (서버 환경변수는 영향 없음)', {title: '연결 해제', confirmLabel: '삭제'}))) return;
+      const {data} = await postJson(`/seller/markets/connect/${market}/disconnect`, {});
+      if (!data.ok) { pcToast(data.error || '연결 해제 실패', 'error'); return; }
+      updateBadge(card, data.status && data.status.connected);
+      pcToast(`${market} 연결을 해제했어요.`, 'success');
+      setTimeout(() => location.reload(), 900);
+    });
+  }
+});
+</script>
+{% endblock %}

--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -8,7 +8,10 @@
       <h1 class="h4 mb-1">마켓 연결</h1>
       <p class="text-muted mb-0">내 마켓 API 키를 직접 입력하고, 저장 전에 연결을 테스트할 수 있어요.</p>
     </div>
-    <a href="/seller/markets" class="btn btn-outline-secondary btn-sm">← 마켓 현황으로</a>
+    <div class="d-flex gap-2">
+      <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm">📖 발급 가이드</a>
+      <a href="/seller/markets" class="btn btn-outline-secondary btn-sm">← 마켓 현황으로</a>
+    </div>
   </div>
 
   <div class="alert alert-light border d-flex gap-2 align-items-start mb-4" role="note">

--- a/src/seller_console/templates/markets_guide.html
+++ b/src/seller_console/templates/markets_guide.html
@@ -1,0 +1,119 @@
+{% extends "_base.html" %}
+{% block title %}API 키 발급 가이드{% endblock %}
+
+{% block content %}
+<style>
+  .guide-stepper { display:flex; flex-wrap:wrap; align-items:stretch; gap:0; }
+  .guide-step { flex:1 1 0; min-width:150px; text-align:center; position:relative; padding:0 8px; }
+  .guide-step .num { width:34px; height:34px; border-radius:50%; background:#0d6efd; color:#fff;
+     display:flex; align-items:center; justify-content:center; font-weight:700; margin:0 auto 6px; }
+  .guide-step .lbl { font-size:.85rem; color:#334; }
+  .guide-step:not(:last-child)::after { content:"→"; position:absolute; right:-8px; top:6px; color:#9aa; font-weight:700; }
+  .guide-fieldmap td { vertical-align:middle; }
+  .guide-jump a { text-decoration:none; }
+  .guide-illu { max-width:560px; }
+</style>
+
+<section class="mb-4">
+  <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
+    <div>
+      <h1 class="h4 mb-1">📖 마켓 API 키 발급 가이드</h1>
+      <p class="text-muted mb-0">각 마켓에서 키를 받아 → 우리 사이트에 붙여넣기만 하면 연결됩니다.</p>
+    </div>
+    <a href="/seller/markets/connect" class="btn btn-primary btn-sm">🔌 키 입력 화면으로</a>
+  </div>
+
+  <!-- 개념 일러스트 (이미지) -->
+  <div class="card console-card mb-4">
+    <div class="card-body text-center">
+      <svg class="guide-illu w-100" viewBox="0 0 560 150" role="img" aria-label="마켓에서 키를 받아 우리 사이트에 입력하는 흐름">
+        <rect x="8" y="20" width="180" height="110" rx="10" fill="#eef3ff" stroke="#b9c8ff"/>
+        <rect x="8" y="20" width="180" height="24" rx="10" fill="#dbe5ff"/>
+        <circle cx="22" cy="32" r="4" fill="#ff6b6b"/><circle cx="36" cy="32" r="4" fill="#ffd43b"/><circle cx="50" cy="32" r="4" fill="#51cf66"/>
+        <text x="98" y="70" text-anchor="middle" font-size="13" fill="#334">마켓 판매자센터</text>
+        <rect x="58" y="86" width="80" height="22" rx="6" fill="#0d6efd"/>
+        <text x="98" y="101" text-anchor="middle" font-size="11" fill="#fff">API 키 발급</text>
+        <text x="232" y="66" text-anchor="middle" font-size="30">🔑</text>
+        <path d="M196 75 H268" stroke="#9aa" stroke-width="2" marker-end="url(#arrow)"/>
+        <path d="M300 75 H372" stroke="#9aa" stroke-width="2" marker-end="url(#arrow)"/>
+        <defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+          <path d="M0,0 L6,3 L0,6 Z" fill="#9aa"/></marker></defs>
+        <rect x="378" y="20" width="174" height="110" rx="10" fill="#f6f9f6" stroke="#bfe3c6"/>
+        <rect x="378" y="20" width="174" height="24" rx="10" fill="#e3f5e8"/>
+        <text x="465" y="37" text-anchor="middle" font-size="12" fill="#2b6a3a">Proxy Commerce</text>
+        <rect x="394" y="60" width="142" height="20" rx="5" fill="#fff" stroke="#cfe6d4"/>
+        <text x="465" y="74" text-anchor="middle" font-size="10" fill="#789">여기에 붙여넣기</text>
+        <rect x="394" y="92" width="142" height="22" rx="6" fill="#198754"/>
+        <text x="465" y="107" text-anchor="middle" font-size="11" fill="#fff">연결 테스트 → ✅</text>
+      </svg>
+      <div class="small text-muted mt-2">핵심: <strong>마켓에서 키 받기 → 우리 사이트 입력칸에 붙여넣기 → [연결 테스트]</strong> 3단계면 끝.</div>
+    </div>
+  </div>
+
+  <!-- 마켓 바로가기 -->
+  <div class="guide-jump d-flex flex-wrap gap-2 mb-4">
+    {% for g in guide %}
+    <a href="#guide-{{ g.key }}" class="btn btn-outline-secondary btn-sm">{{ g.icon }} {{ g.label }}</a>
+    {% endfor %}
+  </div>
+
+  {% for g in guide %}
+  <div class="card console-card mb-4" id="guide-{{ g.key }}">
+    <div class="card-body">
+      <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+        <h2 class="h5 mb-0">{{ g.icon }} {{ g.label }}</h2>
+        <a href="{{ g.official_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm">
+          🔗 {{ g.official_label }}
+        </a>
+      </div>
+
+      <!-- 시각 흐름 (스텝퍼) -->
+      <div class="guide-stepper my-3">
+        {% for f in g.flow %}
+        <div class="guide-step">
+          <div class="num">{{ loop.index }}</div>
+          <div class="lbl">{{ f }}</div>
+        </div>
+        {% endfor %}
+      </div>
+
+      <!-- 단계별 상세 -->
+      <ol class="mb-3">
+        {% for s in g.steps %}
+        <li class="mb-2">
+          <span class="fw-semibold">{{ s.t }}</span>
+          <div class="small text-muted">{{ s.d }}</div>
+        </li>
+        {% endfor %}
+      </ol>
+
+      <!-- 어디서 받은 값을 어느 칸에 -->
+      <div class="table-responsive">
+        <table class="table table-sm guide-fieldmap mb-2">
+          <thead><tr><th>입력칸</th><th>받은 값</th><th>입력칸 이름(env)</th></tr></thead>
+          <tbody>
+            {% for fld in g.fields %}
+            <tr>
+              <td class="fw-semibold">{{ fld.label }}</td>
+              <td class="small text-muted">{{ fld.where }}</td>
+              <td><code>{{ fld.env }}</code></td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      {% if g.tips %}
+      <div class="alert alert-light border small mb-3">
+        {% for tip in g.tips %}<div>💡 {{ tip }}</div>{% endfor %}
+      </div>
+      {% endif %}
+
+      <a href="/seller/markets/connect" class="btn btn-success btn-sm">✅ {{ g.label }} 키 입력하러 가기</a>
+    </div>
+  </div>
+  {% endfor %}
+
+  <p class="text-muted small">자세한 운영 문서: <code>docs/operations/LIVE_VERIFICATION_GUIDE.md</code></p>
+</section>
+{% endblock %}

--- a/src/seller_console/templates/me.html
+++ b/src/seller_console/templates/me.html
@@ -120,8 +120,8 @@
 {% endif %}
 
 <script>
-function confirmDeactivate() {
-  if (!confirm('정말 탈퇴하시겠습니까? 계정이 비활성화됩니다.')) return;
+async function confirmDeactivate() {
+  if (!(await pcConfirm('정말 탈퇴하시겠습니까? 계정이 비활성화됩니다.', {title: '회원 탈퇴', confirmLabel: '탈퇴'}))) return;
   fetch('/seller/me/deactivate', {method: 'POST'})
     .then(r => r.json())
     .then(d => {

--- a/src/seller_console/templates/me.html
+++ b/src/seller_console/templates/me.html
@@ -126,13 +126,13 @@ function confirmDeactivate() {
     .then(r => r.json())
     .then(d => {
       if (d.ok) {
-        alert('탈퇴되었습니다.');
-        window.location.href = '/auth/login';
+        pcToast('탈퇴되었습니다.', 'success');
+        setTimeout(() => { window.location.href = '/auth/login'; }, 1200);
       } else {
-        alert('오류: ' + (d.error || '알 수 없는 오류'));
+        pcToast('오류: ' + (d.error || '알 수 없는 오류'), 'error');
       }
     })
-    .catch(() => alert('요청 실패'));
+    .catch(() => pcToast('요청 실패', 'error'));
 }
 </script>
 {% endblock %}

--- a/src/seller_console/templates/personal_tokens.html
+++ b/src/seller_console/templates/personal_tokens.html
@@ -147,12 +147,12 @@ document.getElementById('generateBtn').addEventListener('click', async () => {
       btn.classList.replace('btn-primary', 'btn-success');
       btn.textContent = '✅ 발급 완료';
     } else {
-      alert('토큰 발급 실패: ' + (data.error || '알 수 없는 오류'));
+      pcToast('토큰 발급 실패: ' + (data.error || '알 수 없는 오류'), 'error');
       btn.disabled = false;
       btn.textContent = '발급하기';
     }
   } catch(e) {
-    alert('오류: ' + e.message);
+    pcToast('오류: ' + e.message, 'error');
     btn.disabled = false;
     btn.textContent = '발급하기';
   }
@@ -162,7 +162,7 @@ function copyToken() {
   const input = document.getElementById('rawToken');
   input.select();
   document.execCommand('copy');
-  alert('토큰이 클립보드에 복사되었습니다.');
+  pcToast('토큰이 클립보드에 복사되었습니다.', 'success');
 }
 
 document.querySelectorAll('.revoke-btn').forEach(btn => {
@@ -179,10 +179,10 @@ document.querySelectorAll('.revoke-btn').forEach(btn => {
       if (data.ok) {
         location.reload();
       } else {
-        alert('회수 실패: ' + (data.error || '알 수 없는 오류'));
+        pcToast('회수 실패: ' + (data.error || '알 수 없는 오류'), 'error');
       }
     } catch(e) {
-      alert('오류: ' + e.message);
+      pcToast('오류: ' + e.message, 'error');
     }
   });
 });

--- a/src/seller_console/templates/personal_tokens.html
+++ b/src/seller_console/templates/personal_tokens.html
@@ -167,7 +167,7 @@ function copyToken() {
 
 document.querySelectorAll('.revoke-btn').forEach(btn => {
   btn.addEventListener('click', async () => {
-    if (!confirm('이 토큰을 회수하시겠습니까? 회수 후 복구할 수 없습니다.')) return;
+    if (!(await pcConfirm('이 토큰을 회수하시겠습니까? 회수 후 복구할 수 없습니다.', {title: '토큰 회수', confirmLabel: '회수'}))) return;
     const hash = btn.dataset.hash;
     try {
       const resp = await fetch('/seller/me/tokens/revoke', {

--- a/src/seller_console/templates/pricing_competitors.html
+++ b/src/seller_console/templates/pricing_competitors.html
@@ -81,7 +81,7 @@ async function createTarget() {
 }
 
 async function removeTarget(id) {
-  if (!confirm('삭제할까요?')) return;
+  if (!(await pcConfirm('이 경쟁사 모니터링 대상을 삭제할까요?', {title: '경쟁사 삭제', confirmLabel: '삭제'}))) return;
   const res = await fetch(`/seller/pricing/competitors/${id}/delete`, {method: 'POST'});
   const d = await res.json();
   if (d.ok) location.reload();

--- a/src/seller_console/templates/pricing_competitors.html
+++ b/src/seller_console/templates/pricing_competitors.html
@@ -77,7 +77,7 @@ async function createTarget() {
   });
   const d = await res.json();
   if (d.ok) location.reload();
-  else alert(d.error || '저장 실패');
+  else pcToast(d.error || '저장 실패', 'error');
 }
 
 async function removeTarget(id) {
@@ -85,7 +85,7 @@ async function removeTarget(id) {
   const res = await fetch(`/seller/pricing/competitors/${id}/delete`, {method: 'POST'});
   const d = await res.json();
   if (d.ok) location.reload();
-  else alert(d.error || '삭제 실패');
+  else pcToast(d.error || '삭제 실패', 'error');
 }
 
 async function monitorNow(id) {
@@ -95,10 +95,10 @@ async function monitorNow(id) {
   });
   const d = await res.json();
   if (d.ok) {
-    alert(`모니터링 완료: ${d.result.captured}건 수집 / 알림 ${d.result.alerts}건`);
-    location.reload();
+    pcToast(`모니터링 완료: ${d.result.captured}건 수집 / 알림 ${d.result.alerts}건`, 'success');
+    setTimeout(() => location.reload(), 1200);
   } else {
-    alert(d.error || '모니터링 실패');
+    pcToast(d.error || '모니터링 실패', 'error');
   }
 }
 </script>

--- a/src/seller_console/templates/pricing_fx_impact.html
+++ b/src/seller_console/templates/pricing_fx_impact.html
@@ -55,7 +55,7 @@
 {% block extra_js %}
 <script>
 async function bulkReprice() {
-  if (!confirm('영향 상품 기준으로 재가격을 실행할까요?')) return;
+  if (!(await pcConfirm('영향 상품 기준으로 재가격을 실행할까요?', {title: '재가격 실행', confirmLabel: '실행', danger: false}))) return;
   const res = await fetch('/seller/pricing/fx-impact/reprice?dry_run=1', {method: 'POST'});
   const d = await res.json();
   if (!d.ok) return pcToast(d.error || '실패', 'error');

--- a/src/seller_console/templates/pricing_fx_impact.html
+++ b/src/seller_console/templates/pricing_fx_impact.html
@@ -58,8 +58,8 @@ async function bulkReprice() {
   if (!confirm('영향 상품 기준으로 재가격을 실행할까요?')) return;
   const res = await fetch('/seller/pricing/fx-impact/reprice?dry_run=1', {method: 'POST'});
   const d = await res.json();
-  if (!d.ok) return alert(d.error || '실패');
-  alert(`재가격 시뮬레이션 완료: 변경 ${d.results.changed}건`);
+  if (!d.ok) return pcToast(d.error || '실패', 'error');
+  pcToast(`재가격 시뮬레이션 완료: 변경 ${d.results.changed}건`, 'success');
 }
 </script>
 {% endblock %}

--- a/src/seller_console/templates/pricing_history.html
+++ b/src/seller_console/templates/pricing_history.html
@@ -93,10 +93,10 @@ async function rollback(historyId, sku, oldPrice) {
   const r = await fetch(`/seller/pricing/history/${historyId}/rollback`, {method:'POST'});
   const d = await r.json();
   if (d.ok) {
-    alert('롤백 완료');
-    location.reload();
+    pcToast('롤백 완료', 'success');
+    setTimeout(() => location.reload(), 1200);
   } else {
-    alert('롤백 실패: ' + d.error);
+    pcToast('롤백 실패: ' + d.error, 'error');
   }
 }
 </script>

--- a/src/seller_console/templates/pricing_history.html
+++ b/src/seller_console/templates/pricing_history.html
@@ -89,7 +89,7 @@
 {% block extra_js %}
 <script>
 async function rollback(historyId, sku, oldPrice) {
-  if (!confirm(`SKU "${sku}"를 ${oldPrice.toLocaleString()}원으로 롤백할까요?`)) return;
+  if (!(await pcConfirm(`SKU "${sku}"를 ${oldPrice.toLocaleString()}원으로 롤백할까요?`, {title: '가격 롤백', confirmLabel: '롤백', danger: false}))) return;
   const r = await fetch(`/seller/pricing/history/${historyId}/rollback`, {method:'POST'});
   const d = await r.json();
   if (d.ok) {

--- a/src/seller_console/templates/pricing_rules.html
+++ b/src/seller_console/templates/pricing_rules.html
@@ -265,7 +265,7 @@ async function toggleRule(ruleId, btn) {
 }
 
 async function deleteRule(ruleId, name) {
-  if (!confirm(`룰 "${name}"을 삭제할까요?`)) return;
+  if (!(await pcConfirm(`룰 "${name}"을 삭제할까요?`, {title: '룰 삭제', confirmLabel: '삭제'}))) return;
   const r = await fetch(`/seller/pricing/rules/${ruleId}/delete`, {method:'POST'});
   const d = await r.json();
   if (d.ok) location.reload();
@@ -297,7 +297,7 @@ async function submitCreate() {
   data.action_value = data.action_value || '0';
   const r = await fetch('/seller/pricing/rules', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(data)});
   if (r.status === 401) {
-    if (confirm('로그인이 필요합니다. 로그인 페이지로 이동할까요?')) {
+    if (await pcConfirm('로그인이 필요합니다. 로그인 페이지로 이동할까요?', {title: '로그인 필요', confirmLabel: '로그인', danger: false})) {
       location.href = '/auth/login?next=/seller/pricing/rules';
     }
     return;
@@ -348,9 +348,9 @@ document.getElementById('btnSimulate').addEventListener('click', async () => {
 });
 
 document.getElementById('btnRunNow').addEventListener('click', async () => {
-  const dryRun = !confirm('실제로 가격을 변경할까요?\n취소하면 시뮬레이션(dry_run)으로 실행합니다.');
+  const dryRun = !(await pcConfirm('실제로 가격을 변경할까요?\n취소하면 시뮬레이션(dry_run)으로 실행합니다.', {title: '가격 적용', confirmLabel: '실제 변경', cancelLabel: '시뮬레이션'}));
   const label = dryRun ? '시뮬레이션' : '실제 적용';
-  if (!dryRun && !confirm(`주의: 마켓에 실제 가격이 변경됩니다.\n계속하시겠습니까?`)) return;
+  if (!dryRun && !(await pcConfirm('주의: 마켓에 실제 가격이 변경됩니다.\n계속하시겠습니까?', {title: '실제 가격 변경 확인', confirmLabel: '변경 계속'}))) return;
   const r = await fetch('/seller/pricing/run-now', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({dry_run: dryRun})});
   const d = await r.json();
   if (d.ok) pcToast(`${label} 완료 — ${d.results.changed}건 변경`, 'success');

--- a/src/seller_console/templates/pricing_rules.html
+++ b/src/seller_console/templates/pricing_rules.html
@@ -269,7 +269,7 @@ async function deleteRule(ruleId, name) {
   const r = await fetch(`/seller/pricing/rules/${ruleId}/delete`, {method:'POST'});
   const d = await r.json();
   if (d.ok) location.reload();
-  else alert('삭제 실패: ' + d.error);
+  else pcToast('삭제 실패: ' + d.error, 'error');
 }
 
 function editRule(rule) {
@@ -304,7 +304,7 @@ async function submitCreate() {
   }
   const d = await r.json();
   if (d.ok) location.reload();
-  else alert('생성 실패: ' + d.error);
+  else pcToast('생성 실패: ' + d.error, 'error');
 }
 
 async function submitEdit() {
@@ -317,7 +317,7 @@ async function submitEdit() {
   const r = await fetch(`/seller/pricing/rules/${ruleId}/edit`, {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(data)});
   const d = await r.json();
   if (d.ok) location.reload();
-  else alert('저장 실패: ' + d.error);
+  else pcToast('저장 실패: ' + d.error, 'error');
 }
 
 document.getElementById('btnSimulate').addEventListener('click', async () => {
@@ -353,8 +353,8 @@ document.getElementById('btnRunNow').addEventListener('click', async () => {
   if (!dryRun && !confirm(`주의: 마켓에 실제 가격이 변경됩니다.\n계속하시겠습니까?`)) return;
   const r = await fetch('/seller/pricing/run-now', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({dry_run: dryRun})});
   const d = await r.json();
-  if (d.ok) alert(`${label} 완료 — ${d.results.changed}건 변경`);
-  else alert('오류: ' + d.error);
+  if (d.ok) pcToast(`${label} 완료 — ${d.results.changed}건 변경`, 'success');
+  else pcToast('오류: ' + d.error, 'error');
 });
 </script>
 {% endblock %}

--- a/src/seller_console/upload_dispatcher.py
+++ b/src/seller_console/upload_dispatcher.py
@@ -458,6 +458,15 @@ class UploadDispatcher:
                 error_code="module_missing",
                 hint=_MARKET_TOKEN_HINTS.get("elevenst"),
             )
+        except ChannelCredentialsMissing as exc:
+            logger.info("11번가 자격증명 미설정: %s", exc)
+            return UploadResult(
+                market="elevenst",
+                success=False,
+                message=str(exc),
+                error_code="token_missing",
+                hint=_MARKET_TOKEN_HINTS.get("elevenst"),
+            )
         except Exception as exc:
             logger.warning("11번가 업로드 오류: %s", exc)
             return UploadResult(

--- a/src/seller_console/upload_dispatcher.py
+++ b/src/seller_console/upload_dispatcher.py
@@ -14,6 +14,13 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+# 채널 브리지 예외 (자격증명 미설정 식별용). 브리지 미존재 시 폴백 정의.
+try:
+    from src.channel_sync._channel_bridge import ChannelCredentialsMissing
+except Exception:  # pragma: no cover - 브리지 모듈 부재 시 안전 폴백
+    class ChannelCredentialsMissing(RuntimeError):
+        """채널 API 자격증명 미설정 (폴백 정의)."""
+
 # 지원 마켓 코드
 SUPPORTED_MARKETS = ["coupang", "smartstore", "elevenst", "woocommerce", "shopify"]
 
@@ -357,6 +364,15 @@ class UploadDispatcher:
                 error_code="module_missing",
                 hint=_MARKET_TOKEN_HINTS.get("coupang"),
             )
+        except ChannelCredentialsMissing as exc:
+            logger.info("쿠팡 자격증명 미설정: %s", exc)
+            return UploadResult(
+                market="coupang",
+                success=False,
+                message=str(exc),
+                error_code="token_missing",
+                hint=_MARKET_TOKEN_HINTS.get("coupang"),
+            )
         except Exception as exc:
             logger.warning("쿠팡 업로드 오류: %s", exc)
             return UploadResult(
@@ -393,6 +409,15 @@ class UploadDispatcher:
                 queued=True,
                 message="큐에 적재됨 (스마트스토어 업로더 모듈 준비 중)",
                 error_code="module_missing",
+                hint=_MARKET_TOKEN_HINTS.get("smartstore"),
+            )
+        except ChannelCredentialsMissing as exc:
+            logger.info("스마트스토어 자격증명 미설정: %s", exc)
+            return UploadResult(
+                market="smartstore",
+                success=False,
+                message=str(exc),
+                error_code="token_missing",
                 hint=_MARKET_TOKEN_HINTS.get("smartstore"),
             )
         except Exception as exc:

--- a/src/seller_console/upload_dispatcher.py
+++ b/src/seller_console/upload_dispatcher.py
@@ -34,11 +34,15 @@ MARKET_LABELS = {
 }
 
 # 마켓별 필수 환경변수 (사전검증용)
+# 마켓별 필수 환경변수. 별칭(둘 중 하나) 검증은 _prevalidate_market에서 특수 처리한다.
+#   shopify   : SHOPIFY_SHOP + (SHOPIFY_AUTO_TOKEN | SHOPIFY_ACCESS_TOKEN)
+#   smartstore: (NAVER_CLIENT_ID | NAVER_COMMERCE_CLIENT_ID) + (..._SECRET)
+#   woocommerce: (WC_URL | WOO_BASE_URL) + (WC_KEY | WOO_CK) + (WC_SECRET | WOO_CS)
 _MARKET_REQUIRED_ENVS: Dict[str, List[str]] = {
     "coupang": ["COUPANG_ACCESS_KEY", "COUPANG_SECRET_KEY", "COUPANG_VENDOR_ID"],
-    "smartstore": ["NAVER_CLIENT_ID", "NAVER_CLIENT_SECRET"],
+    "smartstore": [],
     "elevenst": ["ELEVENST_API_KEY"],
-    "woocommerce": ["WC_URL", "WC_CONSUMER_KEY", "WC_CONSUMER_SECRET"],
+    "woocommerce": [],
     "shopify": ["SHOPIFY_SHOP"],
 }
 
@@ -47,7 +51,7 @@ _MARKET_TOKEN_HINTS: Dict[str, str] = {
     "coupang": "/admin/diagnostics 에서 COUPANG_ACCESS_KEY / SECRET_KEY / VENDOR_ID 를 설정하세요.",
     "smartstore": "/admin/diagnostics 에서 NAVER_CLIENT_ID / NAVER_CLIENT_SECRET 를 설정하세요.",
     "elevenst": "/admin/diagnostics 에서 ELEVENST_API_KEY 를 설정하세요.",
-    "woocommerce": "/admin/diagnostics 에서 WC_URL / WC_CONSUMER_KEY / WC_CONSUMER_SECRET 를 설정하세요.",
+    "woocommerce": "/admin/diagnostics 에서 WC_URL / WC_KEY / WC_SECRET (또는 WOO_BASE_URL / WOO_CK / WOO_CS) 를 설정하세요.",
     "shopify": "/admin/diagnostics 에서 SHOPIFY_SHOP 및 SHOPIFY_AUTO_TOKEN 을 설정하세요.",
 }
 
@@ -168,6 +172,22 @@ class UploadDispatcher:
             has_token = bool(os.getenv("SHOPIFY_AUTO_TOKEN") or os.getenv("SHOPIFY_ACCESS_TOKEN"))
             if not has_token:
                 missing.append("SHOPIFY_AUTO_TOKEN (또는 SHOPIFY_ACCESS_TOKEN)")
+
+        # 스마트스토어: NAVER_CLIENT_* 또는 NAVER_COMMERCE_CLIENT_* 어느 쪽이든 허용
+        if market == "smartstore":
+            if not (os.getenv("NAVER_CLIENT_ID") or os.getenv("NAVER_COMMERCE_CLIENT_ID")):
+                missing.append("NAVER_CLIENT_ID (또는 NAVER_COMMERCE_CLIENT_ID)")
+            if not (os.getenv("NAVER_CLIENT_SECRET") or os.getenv("NAVER_COMMERCE_CLIENT_SECRET")):
+                missing.append("NAVER_CLIENT_SECRET (또는 NAVER_COMMERCE_CLIENT_SECRET)")
+
+        # WooCommerce: 실제 업로드 경로는 WOO_* 사용, 진단은 WC_* 사용 → 둘 다 허용
+        if market == "woocommerce":
+            if not (os.getenv("WC_URL") or os.getenv("WOO_BASE_URL")):
+                missing.append("WC_URL (또는 WOO_BASE_URL)")
+            if not (os.getenv("WC_KEY") or os.getenv("WOO_CK")):
+                missing.append("WC_KEY (또는 WOO_CK)")
+            if not (os.getenv("WC_SECRET") or os.getenv("WOO_CS")):
+                missing.append("WC_SECRET (또는 WOO_CS)")
 
         if missing:
             return PrevalidationResult(

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -2394,6 +2394,16 @@ def markets_connect():
     return render_template("markets_connect.html", page="markets", market_statuses=statuses)
 
 
+@bp.get("/markets/guide")
+def markets_guide():
+    """마켓 API 키 발급 가이드 (그림 포함, 인앱)."""
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.url))
+    from .market_guide import get_guide
+
+    return render_template("markets_guide.html", page="markets", guide=get_guide())
+
+
 @bp.post("/markets/connect/<market>")
 def markets_connect_save(market):
     """셀러 마켓 자격증명 저장 (JSON)."""

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1001,7 +1001,10 @@ def collect_upload():
         return jsonify({"ok": False, "error": "업로드 디스패처 준비 중입니다."}), 503
 
     try:
-        result = dispatcher.dispatch(product_data, markets)
+        from . import market_credentials as mc
+
+        with mc.seller_market_env(_seller_id(), markets):
+            result = dispatcher.dispatch(product_data, markets)
         return jsonify({"ok": True, "result": result.to_dict()})
     except Exception as exc:
         logger.warning("업로드 디스패처 오류: %s", exc)
@@ -1030,7 +1033,10 @@ def collect_prevalidate():
 
     try:
         from .upload_dispatcher import MARKET_LABELS
-        results = dispatcher.prevalidate(product_data, markets)
+        from . import market_credentials as mc
+
+        with mc.seller_market_env(_seller_id(), markets):
+            results = dispatcher.prevalidate(product_data, markets)
         return jsonify({
             "ok": True,
             "results": [
@@ -2352,6 +2358,98 @@ def markets_integration_diagnostics_refresh():
     except Exception as exc:
         logger.warning("markets_integration_diagnostics_refresh API 오류 (%s): %s", market, exc)
         return jsonify({"ok": False, "error": "마켓 연동 진단 중 오류가 발생했습니다."}), 500
+
+
+# ---------------------------------------------------------------------------
+# 셀프서비스 마켓 연결 (SaaS 대비) — 셀러가 직접 키 입력/테스트/저장
+# ---------------------------------------------------------------------------
+
+def _seller_id() -> str:
+    """현재 셀러 식별자. 단일 테넌트(오너)에서는 'default'."""
+    return str(session.get("user_id") or session.get("user_email") or "default")
+
+
+def _diag_market_key(market: str) -> str:
+    """자격증명 마켓 키 → 진단 서브시스템 키 (11번가만 상이)."""
+    return "11st" if market == "elevenst" else market
+
+
+@bp.get("/markets/connect")
+def markets_connect():
+    """셀프서비스 마켓 연결 관리 화면."""
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.url))
+    from . import market_credentials as mc
+
+    statuses = mc.all_status(_seller_id())
+    return render_template("markets_connect.html", page="markets", market_statuses=statuses)
+
+
+@bp.post("/markets/connect/<market>")
+def markets_connect_save(market):
+    """셀러 마켓 자격증명 저장 (JSON)."""
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    from . import market_credentials as mc
+
+    market = (market or "").strip().lower()
+    if market not in mc.MARKET_CRED_FIELDS:
+        return jsonify({"ok": False, "error": "지원하지 않는 마켓입니다."}), 404
+
+    data = request.get_json(force=True, silent=True) or {}
+    values = data.get("values")
+    if not isinstance(values, dict):
+        return jsonify({"ok": False, "error": "values 형식이 올바르지 않습니다."}), 400
+
+    try:
+        mc.save(_seller_id(), market, values)
+        return jsonify({"ok": True, "status": mc.status(_seller_id(), market)})
+    except Exception as exc:
+        logger.warning("마켓 자격증명 저장 오류 (%s): %s", market, exc)
+        return jsonify({"ok": False, "error": "저장 중 오류가 발생했습니다."}), 500
+
+
+@bp.post("/markets/connect/<market>/test")
+def markets_connect_test(market):
+    """셀러 자격증명(저장값 + 입력 중 값)으로 라이브 연결 테스트."""
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    from . import market_credentials as mc
+    from .market_integration_diagnostics import normalize_market_diagnostic_result, run_market_diagnostic
+
+    market = (market or "").strip().lower()
+    if market not in mc.MARKET_CRED_FIELDS:
+        return jsonify({"ok": False, "error": "지원하지 않는 마켓입니다."}), 404
+
+    data = request.get_json(force=True, silent=True) or {}
+    pending = data.get("values") if isinstance(data.get("values"), dict) else {}
+    allowed = {f["env"] for f in mc.MARKET_CRED_FIELDS[market]}
+    extra = {k: str(v).strip() for k, v in pending.items() if k in allowed and str(v).strip()}
+
+    try:
+        with mc.seller_market_env(_seller_id(), market, extra=extra):
+            result = normalize_market_diagnostic_result(run_market_diagnostic(_diag_market_key(market)))
+        return jsonify({"ok": True, "result": result})
+    except KeyError:
+        return jsonify({"ok": False, "error": "지원하지 않는 마켓입니다."}), 404
+    except Exception as exc:
+        logger.warning("마켓 연결 테스트 오류 (%s): %s", market, exc)
+        return jsonify({"ok": False, "error": "연결 테스트 중 오류가 발생했습니다."}), 500
+
+
+@bp.post("/markets/connect/<market>/disconnect")
+def markets_connect_disconnect(market):
+    """셀러 마켓 자격증명 삭제(연결 해제)."""
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    from . import market_credentials as mc
+
+    market = (market or "").strip().lower()
+    if market not in mc.MARKET_CRED_FIELDS:
+        return jsonify({"ok": False, "error": "지원하지 않는 마켓입니다."}), 404
+
+    removed = mc.delete(_seller_id(), market)
+    return jsonify({"ok": True, "removed": removed, "status": mc.status(_seller_id(), market)})
 
 
 # ---------------------------------------------------------------------------

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -2211,7 +2211,7 @@ def markets_overview():
     for market_code in ["shopify", "coupang", "smartstore", "11st", "amazon", "ebay", "shopee", "woocommerce"]:
         meta = _marketplace_meta(market_code)
         summary = summary_by_market.get(market_code, {})
-        configured = _market_is_configured(market_code)
+        configured = _market_configured_for_seller(market_code)
         status_label = "연결됨" if configured else "미연동"
         status_style = "success" if configured else "secondary"
         note = ""
@@ -2307,8 +2307,10 @@ def markets_shopify_check_connection():
 
     try:
         from src.markets.adapters.shopify import ShopifyAdapter
+        from . import market_credentials as mc
 
-        result = ShopifyAdapter().check_connection()
+        with mc.temp_env(mc.all_credential_env(_seller_id())):
+            result = ShopifyAdapter().check_connection()
         return jsonify(result), 200
     except Exception as exc:
         logger.warning("markets_shopify_check_connection API 오류: %s", exc)
@@ -2329,8 +2331,10 @@ def markets_integration_diagnostics():
 
     try:
         from .market_integration_diagnostics import normalize_market_diagnostic_result, run_all_market_diagnostics
+        from . import market_credentials as mc
 
-        results = [normalize_market_diagnostic_result(item) for item in run_all_market_diagnostics()]
+        with mc.temp_env(mc.all_credential_env(_seller_id())):
+            results = [normalize_market_diagnostic_result(item) for item in run_all_market_diagnostics()]
         return jsonify({"ok": True, "results": results}), 200
     except Exception as exc:
         logger.warning("markets_integration_diagnostics API 오류: %s", exc)
@@ -2350,8 +2354,10 @@ def markets_integration_diagnostics_refresh():
 
     try:
         from .market_integration_diagnostics import normalize_market_diagnostic_result, run_market_diagnostic
+        from . import market_credentials as mc
 
-        result = normalize_market_diagnostic_result(run_market_diagnostic(market))
+        with mc.temp_env(mc.all_credential_env(_seller_id())):
+            result = normalize_market_diagnostic_result(run_market_diagnostic(market))
         return jsonify({"ok": True, "result": result}), 200
     except KeyError:
         return jsonify({"ok": False, "error": "지원하지 않는 마켓입니다."}), 404
@@ -2365,8 +2371,11 @@ def markets_integration_diagnostics_refresh():
 # ---------------------------------------------------------------------------
 
 def _seller_id() -> str:
-    """현재 셀러 식별자. 단일 테넌트(오너)에서는 'default'."""
-    return str(session.get("user_id") or session.get("user_email") or "default")
+    """현재 셀러 식별자. 단일 테넌트(오너)/요청 컨텍스트 밖에서는 'default'."""
+    try:
+        return str(session.get("user_id") or session.get("user_email") or "default")
+    except Exception:
+        return "default"
 
 
 def _diag_market_key(market: str) -> str:
@@ -3007,6 +3016,13 @@ def _marketplace_meta(marketplace: str) -> dict:
             "region": "동아시아",
             "is_ready": True,
         }
+
+
+def _market_configured_for_seller(marketplace: str) -> bool:
+    """전역 환경변수 + 셀러 인앱 저장 자격증명을 함께 고려한 연결 설정 여부."""
+    from . import market_credentials as mc
+    with mc.temp_env(mc.all_credential_env(_seller_id())):
+        return _market_is_configured(marketplace)
 
 
 def _market_is_configured(marketplace: str) -> bool:

--- a/src/uploaders/__init__.py
+++ b/src/uploaders/__init__.py
@@ -2,12 +2,14 @@
 
 from .base_uploader import BaseUploader
 from .coupang_uploader import CoupangUploader
+from .elevenst_uploader import ElevenStUploader
 from .naver_uploader import NaverSmartStoreUploader
 from .upload_manager import UploadManager
 
 __all__ = [
     'BaseUploader',
     'CoupangUploader',
+    'ElevenStUploader',
     'NaverSmartStoreUploader',
     'UploadManager',
 ]

--- a/src/uploaders/elevenst_uploader.py
+++ b/src/uploaders/elevenst_uploader.py
@@ -1,0 +1,229 @@
+"""11번가(11st) OpenAPI 상품 업로더.
+
+11번가 OpenAPI는 XML 기반 상품 등록을 사용한다.
+  POST https://api.11st.co.kr/rest/prodservices/product
+  헤더: openapikey: <ELEVENST_API_KEY>
+  바디: <Product>...</Product> (XML)
+응답 XML에서 결과 코드와 상품번호를 파싱한다.
+
+CoupangUploader / NaverSmartStoreUploader와 동일한 인터페이스
+(`prepare_product`, `upload_product` → {'success', 'product_id', 'url'})를 따른다.
+
+환경변수:
+  ELEVENST_API_KEY     — 11번가 OpenAPI 키 (필수)
+  ELEVENST_DISP_CTGR_NO — 기본 표시 카테고리 번호 (선택)
+
+주의: 11번가 상품 등록은 배송 템플릿/카테고리 등 셀러별 설정값이 필요하다.
+본 모듈은 OpenAPI 표준 핵심 필드를 채우며, 운영 시 셀러 계정 설정에 맞춰
+카테고리/배송 코드를 조정해야 한다(라이브 검증은 운영 환경에서 수행).
+"""
+
+import logging
+import math
+import os
+import xml.etree.ElementTree as ET
+from xml.sax.saxutils import escape
+
+import requests
+
+from .base_uploader import BaseUploader
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.11st.co.kr/rest"
+
+
+class ElevenStUploader(BaseUploader):
+    """11번가 OpenAPI 상품 업로더."""
+
+    uploader_name = "elevenst"
+    marketplace = "11st"
+
+    # 수집 카테고리 코드 → 11번가 표시 카테고리 번호 (대표값, 운영 시 조정)
+    CATEGORY_MAP = {
+        "ELC": "1001819",
+        "HOM": "1002420",
+        "BTY": "1004269",
+        "HLT": "1012387",
+        "TOY": "1008180",
+        "SPT": "1008599",
+        "CLO": "1001068",
+        "BAG": "1003205",
+        "BBY": "1009974",
+        "PET": "1013183",
+        "FOD": "1009491",
+        "OFC": "1010657",
+        "DIG": "1001819",
+    }
+    DEFAULT_CATEGORY = "1001819"
+
+    def __init__(self):
+        """11번가 업로더 초기화. 환경변수에서 API 키를 읽는다."""
+        self.api_key = os.getenv("ELEVENST_API_KEY", "")
+        self.default_category = os.getenv("ELEVENST_DISP_CTGR_NO", self.DEFAULT_CATEGORY)
+        if not self.api_key:
+            logger.warning("ELEVENST_API_KEY is not set")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def upload_product(self, product: dict) -> dict:
+        """11번가에 상품을 등록한다.
+
+        Returns:
+            성공: {'success': True, 'product_id': '...', 'url': '...'}
+            실패: {'success': False, 'error': '...'}
+        """
+        if not self.api_key:
+            return {"success": False, "error": "Missing ELEVENST_API_KEY", "sku": product.get("sku", "")}
+        try:
+            xml_body = self._build_product_xml(product)
+            resp = requests.post(
+                f"{_BASE_URL}/prodservices/product",
+                headers={"openapikey": self.api_key, "Content-Type": "text/xml; charset=utf-8"},
+                data=xml_body.encode("utf-8"),
+                timeout=15,
+            )
+            if resp.status_code not in (200, 201):
+                return {
+                    "success": False,
+                    "error": f"HTTP {resp.status_code}: {resp.text[:200]}",
+                    "sku": product.get("sku", ""),
+                }
+            parsed = self._parse_response(resp.text)
+            if not parsed["ok"]:
+                return {"success": False, "error": parsed["message"], "sku": product.get("sku", "")}
+            product_no = parsed["product_no"]
+            url = f"https://www.11st.co.kr/products/{product_no}" if product_no else ""
+            return {"success": True, "product_id": product_no, "url": url, "sku": product.get("sku", "")}
+        except Exception as exc:
+            logger.error("upload_product failed for sku=%s: %s", product.get("sku", ""), exc)
+            return {"success": False, "error": str(exc), "sku": product.get("sku", "")}
+
+    def update_product(self, product_id: str, updates: dict) -> dict:
+        """11번가 상품 정보를 업데이트한다."""
+        if not self.api_key:
+            return {"success": False, "error": "Missing ELEVENST_API_KEY"}
+        try:
+            price = int(updates.get("price") or 0)
+            xml_body = (
+                "<?xml version='1.0' encoding='UTF-8'?>"
+                f"<PriceRequest><sellprc>{price}</sellprc></PriceRequest>"
+            )
+            resp = requests.post(
+                f"{_BASE_URL}/prodservices/product/{product_id}/price",
+                headers={"openapikey": self.api_key, "Content-Type": "text/xml; charset=utf-8"},
+                data=xml_body.encode("utf-8"),
+                timeout=10,
+            )
+            if resp.status_code in (200, 201):
+                return {"success": True}
+            return {"success": False, "error": f"HTTP {resp.status_code}"}
+        except Exception as exc:
+            logger.error("update_product failed for product_id=%s: %s", product_id, exc)
+            return {"success": False, "error": str(exc)}
+
+    def delete_product(self, product_id: str) -> bool:
+        """11번가 상품을 삭제(판매중지)한다."""
+        if not self.api_key:
+            return False
+        try:
+            resp = requests.delete(
+                f"{_BASE_URL}/prodservices/product/{product_id}",
+                headers={"openapikey": self.api_key},
+                timeout=10,
+            )
+            return resp.status_code in (200, 201, 204)
+        except Exception as exc:
+            logger.error("delete_product failed for product_id=%s: %s", product_id, exc)
+            return False
+
+    def get_categories(self) -> list:
+        """11번가 카테고리 목록을 반환한다(표준 매핑 키)."""
+        return [{"code": code, "category_id": cid} for code, cid in self.CATEGORY_MAP.items()]
+
+    def prepare_product(self, collected: dict) -> dict:
+        """수집된 상품을 11번가 업로드 형식으로 변환한다."""
+        if not collected:
+            return {}
+        title = collected.get("title_ko") or collected.get("title_original", "")
+        title = "[해외직구] " + title
+        if len(title) > 100:
+            title = title[:100]
+        category_code = collected.get("category_code", "GEN")
+        category_id = self.CATEGORY_MAP.get(category_code, self.default_category)
+        sell_price = collected.get("sell_price_krw", 0) or 0
+        # 11번가는 10원 단위 판매가
+        price = int(math.ceil(sell_price / 10) * 10)
+        images = (collected.get("images") or [])[:10]
+        return {
+            "sku": collected.get("sku", ""),
+            "title": title,
+            "description_html": collected.get("description_html", ""),
+            "price": price,
+            "images": images,
+            "category_id": category_id,
+            "brand": collected.get("brand", ""),
+            "stock": 999,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_product_xml(self, product: dict) -> str:
+        """11번가 OpenAPI용 상품 등록 XML을 구성한다."""
+        images = product.get("images") or []
+        image_tags = "".join(
+            f"<prdImage0{i}>{escape(str(url))}</prdImage0{i}>"
+            for i, url in enumerate(images[:4], start=1)
+        )
+        title = escape(str(product.get("title", "")))
+        brand = escape(str(product.get("brand", "")))
+        detail = escape(str(product.get("description_html", "")) or title)
+        category_id = escape(str(product.get("category_id", self.default_category)))
+        price = int(product.get("price", 0) or 0)
+        stock = int(product.get("stock", 999) or 0)
+        return (
+            "<?xml version='1.0' encoding='UTF-8'?>"
+            "<Product>"
+            "<selMthdCd>02</selMthdCd>"
+            f"<dispCtgrNo>{category_id}</dispCtgrNo>"
+            "<prdTypCd>01</prdTypCd>"
+            f"<prdNm>{title}</prdNm>"
+            f"<brand>{brand}</brand>"
+            "<orgnTypCd>03</orgnTypCd>"
+            f"<selPrc>{price}</selPrc>"
+            f"<prdSelQty>{stock}</prdSelQty>"
+            f"{image_tags}"
+            f"<htmlDetail>{detail}</htmlDetail>"
+            "<dlvCnAreaCd>01</dlvCnAreaCd>"
+            "</Product>"
+        )
+
+    @staticmethod
+    def _parse_response(xml_text: str) -> dict:
+        """11번가 등록 응답 XML을 파싱한다.
+
+        Returns:
+            {'ok': bool, 'product_no': str, 'message': str}
+        """
+        try:
+            root = ET.fromstring(xml_text)
+        except Exception as exc:
+            logger.warning("11번가 응답 XML 파싱 실패: %s", exc)
+            return {"ok": False, "product_no": "", "message": "응답 파싱 실패"}
+
+        def _find(*names):
+            for name in names:
+                node = root.find(f".//{name}")
+                if node is not None and (node.text or "").strip():
+                    return node.text.strip()
+            return ""
+
+        code = _find("result_code", "resultCode", "ErrCode")
+        message = _find("result_text", "resultMsg", "ErrMsg") or "등록 실패"
+        product_no = _find("ProductNo", "product_no", "prdNo")
+        ok = code in ("100", "200", "0") or bool(product_no)
+        return {"ok": ok, "product_no": product_no, "message": message}

--- a/src/uploaders/naver_uploader.py
+++ b/src/uploaders/naver_uploader.py
@@ -36,9 +36,13 @@ class NaverSmartStoreUploader(BaseUploader):
     _TOKEN_URL = 'https://api.commerce.naver.com/external/v1/oauth2/token'
 
     def __init__(self):
-        """Naver SmartStore 업로더 초기화. 환경변수에서 API 키를 읽는다."""
-        self.client_id = os.getenv('NAVER_CLIENT_ID', '')
-        self.client_secret = os.getenv('NAVER_CLIENT_SECRET', '')
+        """Naver SmartStore 업로더 초기화. 환경변수에서 API 키를 읽는다.
+
+        네이버 커머스 자격증명은 코드 경로에 따라 두 이름이 혼용되어 왔다.
+        업로드/읽기 진단이 같은 값을 쓰도록 NAVER_COMMERCE_* 를 폴백으로 허용한다.
+        """
+        self.client_id = os.getenv('NAVER_CLIENT_ID') or os.getenv('NAVER_COMMERCE_CLIENT_ID', '')
+        self.client_secret = os.getenv('NAVER_CLIENT_SECRET') or os.getenv('NAVER_COMMERCE_CLIENT_SECRET', '')
         self.channel_id = os.getenv('NAVER_CHANNEL_ID', '')
         if not self.client_id:
             logger.warning('NAVER_CLIENT_ID is not set')

--- a/tests/test_channel_sync_uploaders.py
+++ b/tests/test_channel_sync_uploaders.py
@@ -153,6 +153,31 @@ class TestSmartstoreBridge:
         assert out["product_id"] == "NS1"
 
 
+class TestElevenstBridge:
+    def test_upload_success(self, monkeypatch):
+        import src.uploaders.elevenst_uploader as eu
+        monkeypatch.setenv("ELEVENST_API_KEY", "k")
+
+        class _FakeEleven:
+            def prepare_product(self, collected):
+                return collected
+
+            def upload_product(self, prepared):
+                return {"success": True, "product_id": "E1", "url": "https://11st/E1"}
+
+        monkeypatch.setattr(eu, "ElevenStUploader", _FakeEleven)
+        from src.channel_sync import elevenst_uploader
+        out = elevenst_uploader.upload({"title": "T", "sell_price_krw": 12000})
+        assert out["product_id"] == "E1"
+
+    def test_missing_creds_raises(self, monkeypatch):
+        monkeypatch.delenv("ELEVENST_API_KEY", raising=False)
+        from src.channel_sync import elevenst_uploader
+        from src.channel_sync._channel_bridge import ChannelCredentialsMissing
+        with pytest.raises(ChannelCredentialsMissing):
+            elevenst_uploader.upload({"title": "T", "sell_price_krw": 12000})
+
+
 # ─── 디스패처 통합 ────────────────────────────────────────────────────────────
 
 class TestDispatcherIntegration:
@@ -205,3 +230,27 @@ class TestDispatcherIntegration:
         result = UploadDispatcher()._upload_coupang({"title": "T", "sell_price_krw": 19900})
         assert result.success is False
         assert result.error_code == "api_error"
+
+    def test_elevenst_success_sets_external_fields(self, monkeypatch):
+        import src.uploaders.elevenst_uploader as eu
+        monkeypatch.setenv("ELEVENST_API_KEY", "k")
+
+        class _FakeEleven:
+            def prepare_product(self, collected):
+                return collected
+
+            def upload_product(self, prepared):
+                return {"success": True, "product_id": "E9", "url": "https://11st/E9"}
+
+        monkeypatch.setattr(eu, "ElevenStUploader", _FakeEleven)
+        from src.seller_console.upload_dispatcher import UploadDispatcher
+        result = UploadDispatcher()._upload_elevenst({"title": "T", "sell_price_krw": 12000})
+        assert result.success is True
+        assert result.external_product_id == "E9"
+
+    def test_elevenst_missing_creds_is_token_missing(self, monkeypatch):
+        monkeypatch.delenv("ELEVENST_API_KEY", raising=False)
+        from src.seller_console.upload_dispatcher import UploadDispatcher
+        result = UploadDispatcher()._upload_elevenst({"title": "T", "sell_price_krw": 12000})
+        assert result.success is False
+        assert result.error_code == "token_missing"

--- a/tests/test_channel_sync_uploaders.py
+++ b/tests/test_channel_sync_uploaders.py
@@ -1,0 +1,207 @@
+"""tests/test_channel_sync_uploaders.py — 국내 마켓 실채널 업로더 브리지 검증.
+
+UploadDispatcher의 product_data를 src.uploaders.*Uploader 형식으로 변환하고
+자격증명/실패/성공 경로를 정직하게 처리하는지 목(mock) API로 고정한다.
+
+실 API 호출은 자격증명이 있을 때만 발생하므로, 여기서는 업로더 클래스를 목 처리하여
+필드/가격 매핑과 디스패처 통합의 정합성만 검증한다(라이브 검증은 운영 환경에서 수행).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ─── to_collected 매핑 ────────────────────────────────────────────────────────
+
+class TestToCollectedMapping:
+    """디스패처 product_data → uploaders collected 변환."""
+
+    def test_krw_sell_price_priority(self):
+        from src.channel_sync._channel_bridge import to_collected
+        # sell_price_krw가 최우선
+        c = to_collected({"title": "T", "sell_price_krw": 19900, "price_krw": 9000})
+        assert c["sell_price_krw"] == 19900
+        assert c["price_krw"] == 9000
+
+    def test_falls_back_to_recommended_then_price_krw(self):
+        from src.channel_sync._channel_bridge import to_collected
+        c = to_collected({"title": "T", "recommended_price": 15000})
+        assert c["sell_price_krw"] == 15000
+
+    def test_krw_currency_price_used_when_no_explicit_krw(self):
+        from src.channel_sync._channel_bridge import to_collected
+        c = to_collected({"title": "T", "price": 12000, "currency": "KRW"})
+        assert c["sell_price_krw"] == 12000
+
+    def test_non_krw_price_not_used_as_krw(self):
+        from src.channel_sync._channel_bridge import to_collected
+        # USD 19.9는 원화 판매가로 쓰이면 안 됨 → 0
+        c = to_collected({"title": "T", "price": 19.9, "currency": "USD"})
+        assert c["sell_price_krw"] == 0
+
+    def test_title_and_category_fallbacks(self):
+        from src.channel_sync._channel_bridge import to_collected
+        c = to_collected({"title": "기본제목", "sell_price_krw": 1000})
+        assert c["title_ko"] == "기본제목"
+        assert c["title_original"] == "기본제목"
+        assert c["category_code"] == "GEN"
+
+    def test_keywords_become_tags(self):
+        from src.channel_sync._channel_bridge import to_collected
+        c = to_collected({"title": "T", "sell_price_krw": 1000, "keywords": ["a", "b"]})
+        assert c["tags"] == ["a", "b"]
+
+
+# ─── run_upload 공통 경로 ─────────────────────────────────────────────────────
+
+class _FakeUploader:
+    def __init__(self, resp):
+        self._resp = resp
+        self.prepared = None
+
+    def prepare_product(self, collected):
+        self.prepared = collected
+        return {"_prepared": True, **collected}
+
+    def upload_product(self, prepared):
+        return self._resp
+
+
+class TestRunUpload:
+    """run_upload 자격증명/실패/성공 처리."""
+
+    def test_missing_credentials_raises(self, monkeypatch):
+        from src.channel_sync._channel_bridge import run_upload, ChannelCredentialsMissing
+        monkeypatch.delenv("FOO_KEY", raising=False)
+        with pytest.raises(ChannelCredentialsMissing):
+            run_upload(_FakeUploader({"success": True}), {"sell_price_krw": 1000},
+                       required_envs=["FOO_KEY"], market_label="테스트")
+
+    def test_zero_krw_price_raises_upload_error(self, monkeypatch):
+        from src.channel_sync._channel_bridge import run_upload, ChannelUploadError
+        with pytest.raises(ChannelUploadError):
+            run_upload(_FakeUploader({"success": True}), {"title": "T", "price": 19.9, "currency": "USD"},
+                       required_envs=[], market_label="테스트")
+
+    def test_api_failure_raises_upload_error(self):
+        from src.channel_sync._channel_bridge import run_upload, ChannelUploadError
+        with pytest.raises(ChannelUploadError):
+            run_upload(_FakeUploader({"success": False, "error": "401"}), {"sell_price_krw": 1000},
+                       required_envs=[], market_label="테스트")
+
+    def test_success_returns_product_id_and_url(self):
+        from src.channel_sync._channel_bridge import run_upload
+        out = run_upload(
+            _FakeUploader({"success": True, "product_id": "P123", "url": "https://x/p/123"}),
+            {"sell_price_krw": 1000},
+            required_envs=[], market_label="테스트",
+        )
+        assert out == {"product_id": "P123", "url": "https://x/p/123"}
+
+
+# ─── 마켓별 브리지 (목 업로더) ────────────────────────────────────────────────
+
+class TestCoupangBridge:
+    def test_upload_success(self, monkeypatch):
+        import src.uploaders.coupang_uploader as cu
+        monkeypatch.setenv("COUPANG_ACCESS_KEY", "a")
+        monkeypatch.setenv("COUPANG_SECRET_KEY", "b")
+        monkeypatch.setenv("COUPANG_VENDOR_ID", "c")
+
+        class _FakeCoupang:
+            def prepare_product(self, collected):
+                return collected
+
+            def upload_product(self, prepared):
+                return {"success": True, "product_id": "CP1", "url": "https://coupang/CP1"}
+
+        monkeypatch.setattr(cu, "CoupangUploader", _FakeCoupang)
+        from src.channel_sync import coupang_uploader
+        out = coupang_uploader.upload({"title": "T", "sell_price_krw": 19900})
+        assert out["product_id"] == "CP1"
+
+    def test_missing_creds_raises(self, monkeypatch):
+        for k in ("COUPANG_ACCESS_KEY", "COUPANG_SECRET_KEY", "COUPANG_VENDOR_ID"):
+            monkeypatch.delenv(k, raising=False)
+        from src.channel_sync import coupang_uploader
+        from src.channel_sync._channel_bridge import ChannelCredentialsMissing
+        with pytest.raises(ChannelCredentialsMissing):
+            coupang_uploader.upload({"title": "T", "sell_price_krw": 19900})
+
+
+class TestSmartstoreBridge:
+    def test_upload_success(self, monkeypatch):
+        import src.uploaders.naver_uploader as nu
+        monkeypatch.setenv("NAVER_CLIENT_ID", "a")
+        monkeypatch.setenv("NAVER_CLIENT_SECRET", "b")
+
+        class _FakeNaver:
+            def prepare_product(self, collected):
+                return collected
+
+            def upload_product(self, prepared):
+                return {"success": True, "product_id": "NS1", "url": "https://smartstore/NS1"}
+
+        monkeypatch.setattr(nu, "NaverSmartStoreUploader", _FakeNaver)
+        from src.channel_sync import smartstore_uploader
+        out = smartstore_uploader.upload({"title": "T", "sell_price_krw": 25000})
+        assert out["product_id"] == "NS1"
+
+
+# ─── 디스패처 통합 ────────────────────────────────────────────────────────────
+
+class TestDispatcherIntegration:
+    """디스패처 _upload_coupang/_upload_smartstore가 브리지 결과를 정직하게 표면화."""
+
+    def test_coupang_success_sets_external_fields(self, monkeypatch):
+        import src.uploaders.coupang_uploader as cu
+        monkeypatch.setenv("COUPANG_ACCESS_KEY", "a")
+        monkeypatch.setenv("COUPANG_SECRET_KEY", "b")
+        monkeypatch.setenv("COUPANG_VENDOR_ID", "c")
+
+        class _FakeCoupang:
+            def prepare_product(self, collected):
+                return collected
+
+            def upload_product(self, prepared):
+                return {"success": True, "product_id": "CP9", "url": "https://coupang/CP9"}
+
+        monkeypatch.setattr(cu, "CoupangUploader", _FakeCoupang)
+        from src.seller_console.upload_dispatcher import UploadDispatcher
+        result = UploadDispatcher()._upload_coupang({"title": "T", "sell_price_krw": 19900})
+        assert result.success is True
+        assert result.external_product_id == "CP9"
+        assert result.external_url == "https://coupang/CP9"
+
+    def test_coupang_missing_creds_is_token_missing(self, monkeypatch):
+        for k in ("COUPANG_ACCESS_KEY", "COUPANG_SECRET_KEY", "COUPANG_VENDOR_ID"):
+            monkeypatch.delenv(k, raising=False)
+        from src.seller_console.upload_dispatcher import UploadDispatcher
+        result = UploadDispatcher()._upload_coupang({"title": "T", "sell_price_krw": 19900})
+        assert result.success is False
+        assert result.error_code == "token_missing"
+        assert result.hint
+
+    def test_coupang_api_failure_is_api_error(self, monkeypatch):
+        import src.uploaders.coupang_uploader as cu
+        monkeypatch.setenv("COUPANG_ACCESS_KEY", "a")
+        monkeypatch.setenv("COUPANG_SECRET_KEY", "b")
+        monkeypatch.setenv("COUPANG_VENDOR_ID", "c")
+
+        class _FakeCoupang:
+            def prepare_product(self, collected):
+                return collected
+
+            def upload_product(self, prepared):
+                return {"success": False, "error": "401 Unauthorized"}
+
+        monkeypatch.setattr(cu, "CoupangUploader", _FakeCoupang)
+        from src.seller_console.upload_dispatcher import UploadDispatcher
+        result = UploadDispatcher()._upload_coupang({"title": "T", "sell_price_krw": 19900})
+        assert result.success is False
+        assert result.error_code == "api_error"

--- a/tests/test_collect_upload_e2e.py
+++ b/tests/test_collect_upload_e2e.py
@@ -1,0 +1,161 @@
+"""tests/test_collect_upload_e2e.py — 마켓 업로드 전체 경로(E2E) 검증.
+
+`/seller/collect/upload` 라우트 → UploadDispatcher.dispatch → 실제 `_upload_shopify`
+코드 경로를 타되, 라이브 연동 경계(`ShopifyAdapter`)만 목 처리하여
+다음을 정직하게 검증한다.
+
+- 라이브 성공: 응답 result에 external_product_id / external_url 포함, succeeded=1
+- API 실패(토큰 만료/401 등): success=False + error_code="api_error" + 조치 hint
+- 검증 실패: error_code="validation_failed"
+
+실제 운영 시크릿이 없는 CI 환경에서도 라이브 경로의 정합성을 고정한다.
+(실 시크릿 대조 검증은 운영 환경에서 /admin/diagnostics·셀러 마켓 센터로 별도 수행)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("SELLER_PASSWORD", "test")
+    monkeypatch.setenv("FX_DISABLE_NETWORK", "1")
+    # Shopify 토큰이 있는 라이브 환경을 가정
+    monkeypatch.setenv("SHOPIFY_SHOP", "demo-shop.myshopify.com")
+    monkeypatch.setenv("SHOPIFY_AUTO_TOKEN", "atk_demo_token")
+    import src.order_webhook as wh
+    wh.app.config["TESTING"] = True
+    with wh.app.test_client() as c:
+        with c.session_transaction() as sess:
+            sess["seller_logged_in"] = True
+        yield c
+
+
+def _patch_shopify_adapter(monkeypatch, *, validate_ok=True, upload_ok=True,
+                           upload_msg="ok", external_id="98765",
+                           storefront="https://demo-shop.myshopify.com/products/x",
+                           admin="https://demo-shop.myshopify.com/admin/products/98765",
+                           raise_on_upload=False):
+    """라이브 ShopifyAdapter를 시뮬레이션 어댑터로 치환."""
+    import src.markets.adapters.shopify as shop_mod
+
+    class _FakeAdapter:
+        def __init__(self, *a, **kw):
+            pass
+
+        def is_configured(self):
+            return True
+
+        def validate_listing(self, payload):
+            return SimpleNamespace(ok=validate_ok, message="" if validate_ok else "필수값 누락")
+
+        def upload_product(self, payload):
+            if raise_on_upload:
+                raise RuntimeError("network down")
+            return SimpleNamespace(
+                ok=upload_ok,
+                message=upload_msg,
+                external_id=external_id if upload_ok else "",
+                raw={"admin_url": admin, "storefront_url": storefront} if upload_ok else {},
+            )
+
+    monkeypatch.setattr(shop_mod, "ShopifyAdapter", _FakeAdapter)
+
+
+_PRODUCT = {
+    "title": "데모 상품",
+    "price": 19.9,
+    "currency": "USD",
+    "sku": "DEMO-001",
+    "images": [],  # 빈 이미지 → prevalidate의 HEAD 체크 비대상 (업로드 경로엔 영향 없음)
+}
+
+
+class TestUploadLiveSuccess:
+    """라이브 Shopify 업로드 성공 경로."""
+
+    def test_upload_returns_external_id_and_url(self, client, monkeypatch):
+        _patch_shopify_adapter(monkeypatch, validate_ok=True, upload_ok=True)
+        resp = client.post(
+            "/seller/collect/upload",
+            json={"product": _PRODUCT, "markets": ["shopify"]},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        result = data["result"]
+        assert result["succeeded"] == 1
+        assert result["failed"] == 0
+        item = result["results"][0]
+        assert item["market"] == "shopify"
+        assert item["success"] is True
+        assert item["external_product_id"] == "98765"
+        assert item["external_url"].startswith("https://demo-shop.myshopify.com/products/")
+
+
+class TestUploadLiveFailure:
+    """라이브 Shopify 업로드 실패 — 정직한 error_code/hint 노출."""
+
+    def test_api_failure_surfaces_error_code_and_hint(self, client, monkeypatch):
+        _patch_shopify_adapter(monkeypatch, validate_ok=True, upload_ok=False, upload_msg="401 Unauthorized")
+        resp = client.post(
+            "/seller/collect/upload",
+            json={"product": _PRODUCT, "markets": ["shopify"]},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        result = data["result"]
+        assert result["failed"] == 1
+        item = result["results"][0]
+        assert item["success"] is False
+        assert item["error_code"] == "api_error"
+        assert "SHOPIFY_AUTO_TOKEN" in (item["hint"] or "")
+
+    def test_validation_failure_surfaces_error_code(self, client, monkeypatch):
+        _patch_shopify_adapter(monkeypatch, validate_ok=False)
+        resp = client.post(
+            "/seller/collect/upload",
+            json={"product": _PRODUCT, "markets": ["shopify"]},
+        )
+        data = resp.get_json()
+        item = data["result"]["results"][0]
+        assert item["success"] is False
+        assert item["error_code"] == "validation_failed"
+
+    def test_exception_during_upload_is_caught_honestly(self, client, monkeypatch):
+        _patch_shopify_adapter(monkeypatch, raise_on_upload=True)
+        resp = client.post(
+            "/seller/collect/upload",
+            json={"product": _PRODUCT, "markets": ["shopify"]},
+        )
+        # 라우트는 절대 500으로 죽지 않고 항목 단위 실패로 정직하게 보고한다
+        assert resp.status_code == 200
+        item = resp.get_json()["result"]["results"][0]
+        assert item["success"] is False
+        assert item["error_code"] == "api_error"
+
+
+class TestUploadMixedMarkets:
+    """Shopify 성공 + 미연동 국내마켓 큐 적재가 한 응답에 정직하게 집계된다."""
+
+    def test_shopify_success_and_domestic_queued(self, client, monkeypatch):
+        _patch_shopify_adapter(monkeypatch, validate_ok=True, upload_ok=True)
+        resp = client.post(
+            "/seller/collect/upload",
+            json={"product": _PRODUCT, "markets": ["shopify", "coupang"]},
+        )
+        data = resp.get_json()
+        result = data["result"]
+        assert result["total"] == 2
+        assert result["succeeded"] == 1
+        by_market = {r["market"]: r for r in result["results"]}
+        assert by_market["shopify"]["success"] is True
+        # 쿠팡은 실 업로더 모듈 미연동 → 큐 적재 또는 실패로 정직 표기 (성공이 아님)
+        assert by_market["coupang"]["success"] is False

--- a/tests/test_dead_buttons_phase191.py
+++ b/tests/test_dead_buttons_phase191.py
@@ -81,6 +81,59 @@ class TestPagesNoBlockingAlert:
         assert "pcToastContainer" in body, f"{path}에 전역 토스트 컨테이너가 없습니다"
 
 
+class TestGlobalConfirmInfra:
+    """전역 pcConfirm(모달) 인프라가 베이스 레이아웃/공통 스크립트에 존재한다."""
+
+    def test_base_template_has_confirm_modal(self):
+        path = os.path.join(ROOT, "src/seller_console/templates/_base.html")
+        with open(path, encoding="utf-8") as f:
+            base = f.read()
+        assert "pcConfirmModal" in base, "_base.html에 전역 확인 모달이 있어야 합니다"
+
+    def test_seller_js_defines_pcconfirm(self):
+        path = os.path.join(ROOT, "src/seller_console/static/seller.js")
+        with open(path, encoding="utf-8") as f:
+            js = f.read()
+        assert "function pcConfirm" in js
+        # Promise 기반이어야 await 사용 가능
+        assert "return new Promise" in js
+
+
+# 네이티브 confirm()이 제거되고 pcConfirm으로 전환되어야 하는 페이지들.
+CONFIRM_PAGES = [
+    "/seller/pricing/rules",
+    "/seller/pricing/competitors",
+    "/seller/pricing/fx-impact",
+    "/seller/pricing/history",
+    "/seller/discovery/keywords",
+    "/seller/me",
+    "/seller/me/tokens",
+]
+
+
+class TestPagesUsePcConfirm:
+    """대상 페이지가 차단형 네이티브 confirm() 대신 pcConfirm을 사용한다."""
+
+    @pytest.mark.parametrize("path", CONFIRM_PAGES)
+    def test_no_native_confirm_call(self, client, path):
+        resp = client.get(path)
+        if resp.status_code != 200:
+            pytest.skip(f"{path} → {resp.status_code} (환경 의존)")
+        body = resp.data.decode("utf-8")
+        # pcConfirm(은 허용, 단독 confirm( 호출은 금지.
+        leftover = body.replace("pcConfirm(", "")
+        assert "confirm(" not in leftover, f"{path}에 네이티브 confirm() 호출이 남아있습니다"
+        assert "pcConfirm(" in body, f"{path}가 pcConfirm으로 전환되어야 합니다"
+
+    @pytest.mark.parametrize("path", CONFIRM_PAGES)
+    def test_has_confirm_modal(self, client, path):
+        resp = client.get(path)
+        if resp.status_code != 200:
+            pytest.skip(f"{path} → {resp.status_code} (환경 의존)")
+        body = resp.data.decode("utf-8")
+        assert "pcConfirmModal" in body
+
+
 class TestBookmarkletKeepsExternalAlert:
     """북마클릿 페이지는 외부 실행 코드의 alert()를 유지하되 콘솔 UI는 pcToast를 쓴다."""
 

--- a/tests/test_dead_buttons_phase191.py
+++ b/tests/test_dead_buttons_phase191.py
@@ -1,0 +1,95 @@
+"""tests/test_dead_buttons_phase191.py — 죽은 버튼 감사 3차 회귀 테스트.
+
+honest-UI 원칙(docs/operations/dead_button_audit.md)에 따라 차단형 `alert()`을
+비차단 전역 토스트(`pcToast`)로 전환했는지 검증한다.
+
+대상 페이지: pricing_rules / pricing_competitors / pricing_fx_impact /
+pricing_history / discovery / discovery_keywords / me / personal_tokens
+
+예외: bookmarklet.html은 외부 사이트에서 실행되는 `javascript:` 북마클릿 코드
+내부에 `alert()`을 의도적으로 유지한다(콘솔 밖이라 pcToast 사용 불가).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+
+@pytest.fixture
+def client():
+    """셀러 콘솔이 등록된 Flask 앱 테스트 클라이언트."""
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+# alert()가 완전히 제거되어야 하는, 인증/목 없이 200으로 렌더되는 페이지들.
+NO_ALERT_PAGES = [
+    "/seller/pricing/rules",
+    "/seller/pricing/competitors",
+    "/seller/pricing/fx-impact",
+    "/seller/pricing/history",
+    "/seller/discovery",
+    "/seller/discovery/keywords",
+    "/seller/me/tokens",
+    "/seller/me",
+]
+
+
+class TestGlobalToastInfra:
+    """전역 pcToast 인프라가 베이스 레이아웃/공통 스크립트에 존재한다."""
+
+    def test_base_template_has_global_toast_container(self):
+        path = os.path.join(ROOT, "src/seller_console/templates/_base.html")
+        with open(path, encoding="utf-8") as f:
+            base = f.read()
+        assert "pcToastContainer" in base, "_base.html에 전역 토스트 컨테이너가 있어야 합니다"
+
+    def test_seller_js_defines_pctoast(self):
+        path = os.path.join(ROOT, "src/seller_console/static/seller.js")
+        with open(path, encoding="utf-8") as f:
+            js = f.read()
+        assert "function pcToast" in js, "seller.js에 pcToast 헬퍼가 정의되어야 합니다"
+        # XSS 방지: 메시지는 textContent로 삽입 (innerHTML 직접 주입 금지)
+        assert "body.textContent" in js
+
+
+class TestPagesNoBlockingAlert:
+    """대상 페이지에 차단형 alert() 호출이 남아있지 않아야 한다."""
+
+    @pytest.mark.parametrize("path", NO_ALERT_PAGES)
+    def test_no_alert_call(self, client, path):
+        resp = client.get(path)
+        if resp.status_code != 200:
+            pytest.skip(f"{path} → {resp.status_code} (환경 의존)")
+        body = resp.data.decode("utf-8")
+        assert "alert(" not in body, f"{path}에 alert() 호출이 남아있습니다"
+
+    @pytest.mark.parametrize("path", NO_ALERT_PAGES)
+    def test_has_global_toast_container(self, client, path):
+        resp = client.get(path)
+        if resp.status_code != 200:
+            pytest.skip(f"{path} → {resp.status_code} (환경 의존)")
+        body = resp.data.decode("utf-8")
+        assert "pcToastContainer" in body, f"{path}에 전역 토스트 컨테이너가 없습니다"
+
+
+class TestBookmarkletKeepsExternalAlert:
+    """북마클릿 페이지는 외부 실행 코드의 alert()를 유지하되 콘솔 UI는 pcToast를 쓴다."""
+
+    def test_bookmarklet_console_uses_pctoast(self, client):
+        resp = client.get("/seller/bookmarklet")
+        if resp.status_code != 200:
+            pytest.skip(f"/seller/bookmarklet → {resp.status_code}")
+        body = resp.data.decode("utf-8")
+        # 콘솔 측 사용자 피드백은 pcToast로 전환됨
+        assert "pcToast(" in body
+        # 외부 북마클릿 코드 내부 alert은 의도적으로 유지 (사본이 2개)
+        assert body.count("alert(") <= 2

--- a/tests/test_elevenst_uploader.py
+++ b/tests/test_elevenst_uploader.py
@@ -1,0 +1,113 @@
+"""tests/test_elevenst_uploader.py — 11번가 OpenAPI 업로더 단위 검증.
+
+requests를 목 처리하여 prepare_product 매핑, XML 구성, 응답 파싱,
+업로드 성공/실패 계약(CoupangUploader와 동일)을 고정한다.
+라이브 검증은 운영 환경에서 ELEVENST_API_KEY로 별도 수행.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def uploader(monkeypatch):
+    monkeypatch.setenv("ELEVENST_API_KEY", "test-key")
+    from src.uploaders.elevenst_uploader import ElevenStUploader
+    return ElevenStUploader()
+
+
+class TestPrepareProduct:
+    def test_title_gets_haejikgu_prefix_and_price_rounds_to_10(self, uploader):
+        prepared = uploader.prepare_product({
+            "title_ko": "테스트 상품",
+            "sell_price_krw": 19999,
+            "category_code": "BTY",
+            "images": ["https://img/1.jpg"],
+        })
+        assert prepared["title"].startswith("[해외직구]")
+        assert prepared["price"] == 20000  # 10원 단위 올림
+        assert prepared["category_id"] == uploader.CATEGORY_MAP["BTY"]
+
+    def test_empty_collected_returns_empty(self, uploader):
+        assert uploader.prepare_product({}) == {}
+
+    def test_unknown_category_uses_default(self, uploader):
+        prepared = uploader.prepare_product({"title_ko": "x", "sell_price_krw": 1000, "category_code": "ZZZ"})
+        assert prepared["category_id"] == uploader.default_category
+
+
+class TestBuildXml:
+    def test_xml_contains_core_fields_and_escapes(self, uploader):
+        xml = uploader._build_product_xml({
+            "title": "A & B <test>",
+            "price": 12340,
+            "images": ["https://img/1.jpg", "https://img/2.jpg"],
+            "category_id": "1001819",
+            "brand": "BR",
+            "stock": 999,
+        })
+        assert "<selPrc>12340</selPrc>" in xml
+        assert "<dispCtgrNo>1001819</dispCtgrNo>" in xml
+        # XML 이스케이프 적용
+        assert "A &amp; B &lt;test&gt;" in xml
+        assert "<prdImage01>https://img/1.jpg</prdImage01>" in xml
+
+
+class TestParseResponse:
+    def test_success_with_product_no(self):
+        from src.uploaders.elevenst_uploader import ElevenStUploader
+        xml = "<ProductResponse><result_code>200</result_code><ProductNo>123456</ProductNo></ProductResponse>"
+        parsed = ElevenStUploader._parse_response(xml)
+        assert parsed["ok"] is True
+        assert parsed["product_no"] == "123456"
+
+    def test_failure_code(self):
+        from src.uploaders.elevenst_uploader import ElevenStUploader
+        xml = "<ProductResponse><result_code>500</result_code><result_text>오류</result_text></ProductResponse>"
+        parsed = ElevenStUploader._parse_response(xml)
+        assert parsed["ok"] is False
+        assert "오류" in parsed["message"]
+
+    def test_malformed_xml(self):
+        from src.uploaders.elevenst_uploader import ElevenStUploader
+        parsed = ElevenStUploader._parse_response("not xml <<<")
+        assert parsed["ok"] is False
+
+
+class TestUploadProduct:
+    def test_missing_key_returns_error(self, monkeypatch):
+        monkeypatch.delenv("ELEVENST_API_KEY", raising=False)
+        from src.uploaders.elevenst_uploader import ElevenStUploader
+        out = ElevenStUploader().upload_product({"sku": "S1", "title": "T", "price": 1000})
+        assert out["success"] is False
+        assert "ELEVENST_API_KEY" in out["error"]
+
+    def test_success(self, uploader):
+        resp = MagicMock(status_code=200,
+                         text="<ProductResponse><result_code>200</result_code><ProductNo>P9</ProductNo></ProductResponse>")
+        with patch("src.uploaders.elevenst_uploader.requests.post", return_value=resp):
+            out = uploader.upload_product({"sku": "S1", "title": "T", "price": 1000, "images": []})
+        assert out["success"] is True
+        assert out["product_id"] == "P9"
+        assert out["url"].endswith("/P9")
+
+    def test_http_error(self, uploader):
+        resp = MagicMock(status_code=401, text="Unauthorized")
+        with patch("src.uploaders.elevenst_uploader.requests.post", return_value=resp):
+            out = uploader.upload_product({"sku": "S1", "title": "T", "price": 1000})
+        assert out["success"] is False
+        assert "401" in out["error"]
+
+    def test_api_logical_failure(self, uploader):
+        resp = MagicMock(status_code=200,
+                         text="<ProductResponse><result_code>500</result_code><result_text>등록 거부</result_text></ProductResponse>")
+        with patch("src.uploaders.elevenst_uploader.requests.post", return_value=resp):
+            out = uploader.upload_product({"sku": "S1", "title": "T", "price": 1000})
+        assert out["success"] is False
+        assert "등록 거부" in out["error"]

--- a/tests/test_market_adapter_live_fixes.py
+++ b/tests/test_market_adapter_live_fixes.py
@@ -1,0 +1,94 @@
+"""tests/test_market_adapter_live_fixes.py — 라이브 검증에서 드러난 어댑터 버그 수정 검증.
+
+1) 스마트스토어: 네이버 커머스 OAuth2는 client_secret 평문이 아니라
+   bcrypt 전자서명(client_secret_sign)+timestamp를 요구한다.
+2) WooCommerce: 일부 WP 호스트가 User-Agent/Accept 없는 요청을 HTTP 406으로 막는다.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class TestSmartstoreNaverSignature:
+    def test_signature_is_base64_of_bcrypt(self, monkeypatch):
+        import bcrypt
+        from src.seller_console.market_adapters import smartstore_adapter as ss
+
+        salt = bcrypt.gensalt().decode("utf-8")  # 네이버 client_secret 형태($2b$…)
+        sign = ss._naver_signature("client123", salt, "1700000000000")
+        assert sign
+        # base64 디코딩 가능해야 한다
+        decoded = base64.b64decode(sign)
+        assert decoded  # bcrypt 해시 바이트
+
+    def test_signature_invalid_secret_returns_none(self):
+        from src.seller_console.market_adapters import smartstore_adapter as ss
+        # bcrypt salt 형식이 아니면 None (정직 실패)
+        assert ss._naver_signature("c", "not-a-valid-bcrypt-salt", "123") is None
+
+    def test_token_request_sends_sign_not_plaintext_secret(self, monkeypatch):
+        import bcrypt
+        from src.seller_console.market_adapters import smartstore_adapter as ss
+
+        ss._token_cache.clear()
+        salt = bcrypt.gensalt().decode("utf-8")
+        monkeypatch.setenv("NAVER_COMMERCE_CLIENT_ID", "cid")
+        monkeypatch.setenv("NAVER_COMMERCE_CLIENT_SECRET", salt)
+
+        captured = {}
+
+        def fake_post(url, data=None, headers=None, timeout=None):
+            captured["data"] = data
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"access_token": "TOK", "expires_in": 3600}
+            return resp
+
+        with patch("requests.post", side_effect=fake_post):
+            token = ss._get_access_token()
+
+        assert token == "TOK"
+        data = captured["data"]
+        # 평문 시크릿을 보내면 안 되고, 전자서명/타임스탬프를 보내야 한다
+        assert "client_secret" not in data
+        assert "client_secret_sign" in data and data["client_secret_sign"]
+        assert "timestamp" in data
+        assert data["grant_type"] == "client_credentials"
+        ss._token_cache.clear()
+
+
+class TestWooCommerceHeaders:
+    def test_health_check_sends_user_agent_and_accept(self, monkeypatch):
+        from src.seller_console.market_adapters import woocommerce_adapter as wc
+
+        monkeypatch.setenv("WC_URL", "https://shop.example.com")
+        monkeypatch.setenv("WC_KEY", "ck_x")
+        monkeypatch.setenv("WC_SECRET", "cs_x")
+        monkeypatch.delenv("ADAPTER_DRY_RUN", raising=False)
+
+        captured = {}
+
+        def fake_get(url, auth=None, headers=None, params=None, timeout=None):
+            captured["headers"] = headers
+            resp = MagicMock()
+            resp.status_code = 200
+            return resp
+
+        with patch("requests.get", side_effect=fake_get):
+            result = wc.WooCommerceAdapter().health_check()
+
+        assert result["status"] == "ok"
+        headers = captured["headers"]
+        assert "User-Agent" in headers
+        assert headers.get("Accept") == "application/json"
+
+    def test_request_headers_helper(self):
+        from src.seller_console.market_adapters import woocommerce_adapter as wc
+        h = wc._request_headers()
+        assert h["User-Agent"]
+        assert h["Accept"] == "application/json"

--- a/tests/test_market_credentials.py
+++ b/tests/test_market_credentials.py
@@ -120,6 +120,36 @@ class TestEnvInjection:
         assert os.getenv("ELEVENST_API_KEY") is None
 
 
+class TestAllCredentialEnv:
+    def test_merges_all_markets(self, mc):
+        mc.save("s", "coupang", {"COUPANG_ACCESS_KEY": "ak", "COUPANG_SECRET_KEY": "sk", "COUPANG_VENDOR_ID": "A1"})
+        mc.save("s", "elevenst", {"ELEVENST_API_KEY": "ek"})
+        merged = mc.all_credential_env("s")
+        assert merged["COUPANG_ACCESS_KEY"] == "ak"
+        assert merged["ELEVENST_API_KEY"] == "ek"
+
+
+class TestSellerCredsReflectedInMarketsPage:
+    """인앱 저장 키가 마켓 현황 '연결됨' 판정에 반영된다 (Render env 없이도)."""
+
+    def test_market_configured_for_seller_uses_store(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MARKET_CRED_DIR", str(tmp_path))
+        monkeypatch.setenv("SECRET_KEY", "x")
+        # 전역 환경변수는 비움
+        for k in ("COUPANG_ACCESS_KEY", "COUPANG_SECRET_KEY", "COUPANG_VENDOR_ID"):
+            monkeypatch.delenv(k, raising=False)
+        from src.seller_console import market_credentials as module
+        importlib.reload(module)
+        module.save("default", "coupang", {
+            "COUPANG_ACCESS_KEY": "ak", "COUPANG_SECRET_KEY": "sk", "COUPANG_VENDOR_ID": "A1"})
+
+        from src.seller_console import views
+        # 전역 env 기준으로는 미설정
+        assert views._market_is_configured("coupang") is False
+        # 셀러 인앱 저장 기준으로는 설정됨
+        assert views._market_configured_for_seller("coupang") is True
+
+
 class TestConnectRoutes:
     @pytest.fixture
     def client(self, tmp_path, monkeypatch):

--- a/tests/test_market_credentials.py
+++ b/tests/test_market_credentials.py
@@ -1,0 +1,166 @@
+"""tests/test_market_credentials.py — 셀프서비스 마켓 연결(셀러별 자격증명) 검증.
+
+저장/조회/암호화/마스킹/주입/라우트를 고정한다. SaaS 다중 셀러 대비 기능.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def mc(tmp_path, monkeypatch):
+    monkeypatch.setenv("MARKET_CRED_DIR", str(tmp_path))
+    monkeypatch.setenv("SECRET_KEY", "unit-test-secret")
+    monkeypatch.delenv("MARKET_CRED_ENC_KEY", raising=False)
+    from src.seller_console import market_credentials as module
+    importlib.reload(module)
+    return module
+
+
+class TestStoreRoundtrip:
+    def test_save_and_get(self, mc):
+        mc.save("seller1", "coupang", {
+            "COUPANG_ACCESS_KEY": "ak123456",
+            "COUPANG_SECRET_KEY": "sk123456",
+            "COUPANG_VENDOR_ID": "A001",
+        })
+        got = mc.get("seller1", "coupang")
+        assert got["COUPANG_ACCESS_KEY"] == "ak123456"
+        assert got["COUPANG_VENDOR_ID"] == "A001"
+
+    def test_save_filters_unknown_and_empty(self, mc):
+        saved = mc.save("seller1", "elevenst", {
+            "ELEVENST_API_KEY": "key1",
+            "UNKNOWN_FIELD": "x",
+            "ELEVENST_DISP_CTGR_NO": "  ",
+        })
+        assert saved == {"ELEVENST_API_KEY": "key1"}
+
+    def test_delete(self, mc):
+        mc.save("seller1", "coupang", {"COUPANG_ACCESS_KEY": "a", "COUPANG_SECRET_KEY": "b", "COUPANG_VENDOR_ID": "c"})
+        assert mc.delete("seller1", "coupang") is True
+        assert mc.get("seller1", "coupang") == {}
+        assert mc.delete("seller1", "coupang") is False
+
+    def test_per_seller_isolation(self, mc):
+        mc.save("sellerA", "elevenst", {"ELEVENST_API_KEY": "AAA"})
+        mc.save("sellerB", "elevenst", {"ELEVENST_API_KEY": "BBB"})
+        assert mc.get("sellerA", "elevenst")["ELEVENST_API_KEY"] == "AAA"
+        assert mc.get("sellerB", "elevenst")["ELEVENST_API_KEY"] == "BBB"
+
+    def test_unknown_market_raises(self, mc):
+        with pytest.raises(KeyError):
+            mc.save("seller1", "gmarket", {"X": "y"})
+
+
+class TestEncryption:
+    def test_secret_not_plaintext_on_disk(self, mc, tmp_path):
+        mc.save("seller1", "shopify", {
+            "SHOPIFY_SHOP": "x.myshopify.com",
+            "SHOPIFY_AUTO_TOKEN": "atk_supersecret_value",
+        })
+        # 디스크 파일에 비밀값이 평문으로 남지 않아야 한다
+        path = os.path.join(str(tmp_path), "seller1.json")
+        with open(path, "r", encoding="utf-8") as fp:
+            raw = fp.read()
+        assert "atk_supersecret_value" not in raw
+        assert '"_enc": true' in raw.replace(" ", "").replace("\n", "") or '"_enc":true' in raw.replace(" ", "")
+
+    def test_plaintext_fallback_without_keys(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MARKET_CRED_DIR", str(tmp_path))
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.delenv("MARKET_CRED_ENC_KEY", raising=False)
+        from src.seller_console import market_credentials as module
+        importlib.reload(module)
+        module.save("s", "elevenst", {"ELEVENST_API_KEY": "k"})
+        # 키 없으면 평문이라도 조회는 정상 (개발용)
+        assert module.get("s", "elevenst")["ELEVENST_API_KEY"] == "k"
+
+
+class TestConnectionStatus:
+    def test_is_connected_with_stored(self, mc):
+        assert mc.is_connected("s", "elevenst") is False
+        mc.save("s", "elevenst", {"ELEVENST_API_KEY": "k"})
+        assert mc.is_connected("s", "elevenst") is True
+
+    def test_is_connected_falls_back_to_global_env(self, mc, monkeypatch):
+        monkeypatch.setenv("ELEVENST_API_KEY", "global-key")
+        assert mc.is_connected("s", "elevenst") is True
+
+    def test_status_masks_secrets(self, mc):
+        mc.save("s", "coupang", {"COUPANG_ACCESS_KEY": "ak12345678", "COUPANG_SECRET_KEY": "sk", "COUPANG_VENDOR_ID": "A001"})
+        st = mc.status("s", "coupang")
+        fields = {f["env"]: f for f in st["fields"]}
+        # 비밀값은 마스킹, 일반값은 그대로
+        assert "12345678" not in fields["COUPANG_ACCESS_KEY"]["display"]
+        assert "••••" in fields["COUPANG_ACCESS_KEY"]["display"]
+        assert fields["COUPANG_VENDOR_ID"]["display"] == "A001"
+        assert st["connected"] is True
+
+
+class TestEnvInjection:
+    def test_seller_market_env_injects_and_restores(self, mc, monkeypatch):
+        monkeypatch.delenv("ELEVENST_API_KEY", raising=False)
+        mc.save("s", "elevenst", {"ELEVENST_API_KEY": "seller-key"})
+        assert os.getenv("ELEVENST_API_KEY") is None
+        with mc.seller_market_env("s", "elevenst"):
+            assert os.getenv("ELEVENST_API_KEY") == "seller-key"
+        assert os.getenv("ELEVENST_API_KEY") is None
+
+    def test_extra_overrides_pending_values(self, mc, monkeypatch):
+        monkeypatch.delenv("ELEVENST_API_KEY", raising=False)
+        with mc.seller_market_env("s", "elevenst", extra={"ELEVENST_API_KEY": "typed-now"}):
+            assert os.getenv("ELEVENST_API_KEY") == "typed-now"
+        assert os.getenv("ELEVENST_API_KEY") is None
+
+
+class TestConnectRoutes:
+    @pytest.fixture
+    def client(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MARKET_CRED_DIR", str(tmp_path))
+        monkeypatch.setenv("SECRET_KEY", "route-test-secret")
+        from src.seller_console import market_credentials as module
+        importlib.reload(module)
+        import src.order_webhook as wh
+        wh.app.config["TESTING"] = True
+        with wh.app.test_client() as c:
+            yield c
+
+    def test_connect_page_200(self, client):
+        resp = client.get("/seller/markets/connect")
+        assert resp.status_code == 200
+        assert "마켓 연결" in resp.get_data(as_text=True)
+
+    def test_save_and_status(self, client):
+        resp = client.post("/seller/markets/connect/coupang", json={"values": {
+            "COUPANG_ACCESS_KEY": "ak", "COUPANG_SECRET_KEY": "sk", "COUPANG_VENDOR_ID": "A1"}})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert data["status"]["connected"] is True
+
+    def test_save_unsupported_market_404(self, client):
+        resp = client.post("/seller/markets/connect/gmarket", json={"values": {"X": "y"}})
+        assert resp.status_code == 404
+
+    def test_save_bad_values_400(self, client):
+        resp = client.post("/seller/markets/connect/coupang", json={"values": "not-a-dict"})
+        assert resp.status_code == 400
+
+    def test_test_route_returns_status(self, client):
+        resp = client.post("/seller/markets/connect/elevenst/test", json={"values": {}})
+        assert resp.status_code == 200
+        assert "result" in resp.get_json()
+
+    def test_disconnect(self, client):
+        client.post("/seller/markets/connect/coupang", json={"values": {
+            "COUPANG_ACCESS_KEY": "ak", "COUPANG_SECRET_KEY": "sk", "COUPANG_VENDOR_ID": "A1"}})
+        resp = client.post("/seller/markets/connect/coupang/disconnect", json={})
+        assert resp.status_code == 200
+        assert resp.get_json()["removed"] is True

--- a/tests/test_markets_guide.py
+++ b/tests/test_markets_guide.py
@@ -1,0 +1,53 @@
+"""tests/test_markets_guide.py — 인앱 마켓 API 키 발급 가이드 검증."""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_guide_data_covers_all_connect_markets():
+    from src.seller_console.market_guide import get_guide
+    from src.seller_console.market_credentials import SUPPORTED_MARKETS
+    keys = {g["key"] for g in get_guide()}
+    assert set(SUPPORTED_MARKETS).issubset(keys)
+
+
+def test_guide_entries_have_required_shape():
+    from src.seller_console.market_guide import get_guide
+    for g in get_guide():
+        assert g["official_url"].startswith("http")
+        assert g["flow"] and g["steps"] and g["fields"]
+        for fld in g["fields"]:
+            assert fld["env"] and fld["label"]
+
+
+class TestGuidePage:
+    def test_guide_page_200_with_image_and_sections(self, client):
+        resp = client.get("/seller/markets/guide")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert "<svg" in html  # 개념 일러스트(이미지)
+        assert "guide-stepper" in html  # 시각 흐름
+        for key in ("coupang", "smartstore", "elevenst", "shopify", "woocommerce"):
+            assert f"guide-{key}" in html
+        assert "COUPANG_ACCESS_KEY" in html
+
+    def test_markets_page_has_guide_button(self, client):
+        html = client.get("/seller/markets").get_data(as_text=True)
+        assert "/seller/markets/guide" in html
+
+    def test_connect_page_has_guide_button(self, client):
+        html = client.get("/seller/markets/connect").get_data(as_text=True)
+        assert "/seller/markets/guide" in html

--- a/tests/test_phase_163_favicon_assets.py
+++ b/tests/test_phase_163_favicon_assets.py
@@ -31,7 +31,9 @@ def test_base_templates_include_favicon_links():
         assert 'rel="apple-touch-icon"' in text
         assert "manifest.webmanifest" in text
         assert ("?v=172" in text) or ("v='172'" in text)
-        assert '#020010' in text
+        # 테마 색상은 라이트/다크 리비전마다 달라질 수 있으므로(예: Phase 189 라이트 복구)
+        # 특정 색상값이 아니라 theme-color 메타 존재만 검증한다.
+        assert 'name="theme-color"' in text
 
 
 def test_favicon_svg_uses_orbit_globe_design():

--- a/tests/test_seller_console.py
+++ b/tests/test_seller_console.py
@@ -477,6 +477,33 @@ class TestDashboardHomeContext:
         assert onboarding["visible"] is True
 
 
+class TestDashboardResilience:
+    """대시보드는 하위 위젯 서비스가 실패해도 500 없이 정직하게 degrade한다."""
+
+    def test_dashboard_200_when_widget_builder_raises(self, client):
+        """build_all_widgets()가 예외를 던져도 대시보드는 200으로 렌더된다."""
+        with patch(
+            "src.seller_console.widgets.build_all_widgets",
+            side_effect=RuntimeError("sheets unavailable"),
+        ):
+            resp = client.get("/seller/dashboard")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        # 위젯이 없어도 핵심 섹션 골격은 유지된다(빈 상태 degrade)
+        assert "마켓 연동 상태" in html
+        assert "마켓별 등록/동기화 현황" in html
+        assert "실시간 환율" in html
+
+    def test_dashboard_renders_empty_states_with_no_widgets(self, client):
+        """위젯이 비어도 최근 활동/최근 상품 영역의 빈 상태가 정직하게 표시된다."""
+        with patch("src.seller_console.widgets.build_all_widgets", return_value=[]):
+            resp = client.get("/seller/dashboard")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert "최근 활동이 없습니다." in html
+        assert "표시할 최근 상품이 없습니다." in html
+
+
 # ---------------------------------------------------------------------------
 # 3. ManualCollectorService — 어댑터 라우팅 + 스키마 검증
 # ---------------------------------------------------------------------------

--- a/tests/test_verify_market_connections.py
+++ b/tests/test_verify_market_connections.py
@@ -1,0 +1,88 @@
+"""tests/test_verify_market_connections.py — 마켓 라이브 검증 도구 + 별칭 env 검증.
+
+라이브 검증 스크립트가 진단/디스패처의 서로 다른 키 네임스페이스를 올바르게 잇고,
+실제 업로드 경로가 쓰는 환경변수 별칭(WOO_*, NAVER_COMMERCE_*)을
+prevalidate가 정확히 인정하는지 고정한다.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class TestPrevalidateEnvAliases:
+    """실제 업로드 경로가 쓰는 환경변수 별칭을 prevalidate가 인정한다."""
+
+    def _prevalidate(self, market):
+        from src.seller_console.upload_dispatcher import UploadDispatcher
+        prod = {"title": "T", "sell_price_krw": 19900, "price": 19900, "currency": "KRW"}
+        return UploadDispatcher().prevalidate(prod, [market])[0]
+
+    def test_woocommerce_accepts_woo_names(self, monkeypatch):
+        for k in ("WC_URL", "WC_KEY", "WC_SECRET"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("WOO_BASE_URL", "https://x")
+        monkeypatch.setenv("WOO_CK", "ck")
+        monkeypatch.setenv("WOO_CS", "cs")
+        r = self._prevalidate("woocommerce")
+        assert r.ok is True
+
+    def test_woocommerce_accepts_wc_names(self, monkeypatch):
+        for k in ("WOO_BASE_URL", "WOO_CK", "WOO_CS"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("WC_URL", "https://x")
+        monkeypatch.setenv("WC_KEY", "ck")
+        monkeypatch.setenv("WC_SECRET", "cs")
+        r = self._prevalidate("woocommerce")
+        assert r.ok is True
+
+    def test_woocommerce_missing_is_token_missing(self, monkeypatch):
+        for k in ("WC_URL", "WC_KEY", "WC_SECRET", "WOO_BASE_URL", "WOO_CK", "WOO_CS"):
+            monkeypatch.delenv(k, raising=False)
+        r = self._prevalidate("woocommerce")
+        assert r.ok is False
+        assert r.error_code == "token_missing"
+
+    def test_smartstore_accepts_commerce_names(self, monkeypatch):
+        for k in ("NAVER_CLIENT_ID", "NAVER_CLIENT_SECRET"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("NAVER_COMMERCE_CLIENT_ID", "id")
+        monkeypatch.setenv("NAVER_COMMERCE_CLIENT_SECRET", "sec")
+        r = self._prevalidate("smartstore")
+        assert r.ok is True
+
+
+class TestVerifyScript:
+    """verify_market_connections 도구 동작."""
+
+    def test_11st_maps_to_dispatcher_elevenst(self, monkeypatch):
+        # 진단 키 '11st' → 디스패처 키 'elevenst'로 변환되어 unsupported_market이 아니어야 한다
+        for k in ("ELEVENST_API_KEY",):
+            monkeypatch.delenv(k, raising=False)
+        from scripts.verify_market_connections import verify_market
+        row = verify_market("11st")
+        assert row["market"] == "11st"
+        pv = row["prevalidation"]
+        assert pv is not None
+        assert pv["error_code"] != "unsupported_market"
+        assert pv["error_code"] == "token_missing"
+
+    def test_verify_market_reports_status(self, monkeypatch):
+        for k in ("COUPANG_ACCESS_KEY", "COUPANG_SECRET_KEY", "COUPANG_VENDOR_ID"):
+            monkeypatch.delenv(k, raising=False)
+        from scripts.verify_market_connections import verify_market
+        row = verify_market("coupang")
+        assert row["status"] == "token_missing"
+        assert row["docs_path"].endswith("COUPANG.md")
+
+    def test_all_market_guides_verifiable(self):
+        from scripts.verify_market_connections import verify_market
+        from src.seller_console.market_integration_diagnostics import MARKET_GUIDES
+        for market in MARKET_GUIDES:
+            row = verify_market(market)
+            assert row["market"] == market
+            # 사전검증이 unsupported_market으로 깨지지 않아야 한다(키 매핑 정합성)
+            pv = row.get("prevalidation") or {}
+            assert pv.get("error_code") != "unsupported_market"


### PR DESCRIPTION
## 개요
UX/UI 디테일 + 각 버튼 실동작 + 마켓 실연동을 한 번에 진행했습니다. 핵심은 **소비자(셀러)가 Render 환경변수 없이 사이트 안에서 직접 마켓 키를 넣고 연결**할 수 있게 한 것 + 라이브 검증으로 드러난 **실제 어댑터 버그 수정**입니다.

## 주요 변경

### 1) 셀프서비스 마켓 연결 (SaaS 대비)
- `src/seller_console/market_credentials.py`: 셀러별 자격증명 **Fernet 암호화 저장**(키 없으면 SECRET_KEY 파생), 셀러별 격리, 전역 env 폴백.
- `GET /seller/markets/connect` + `markets_connect.html`: 마켓별 키 입력/저장/연결 테스트/해제, 비밀값 마스킹.
- `/seller/markets` 라이브 진단 3종을 셀러 저장 키로 구동(검증: 저장 전 `token_missing` → 저장 후 실제 API 도달).
- `/collect/upload`·`/collect/prevalidate`도 셀러 키로 구동.

### 2) 라이브 검증으로 드러난 어댑터 버그 수정
- **스마트스토어 토큰 발급**: 네이버 커머스 OAuth2는 `client_secret` 평문이 아니라 **bcrypt 전자서명** 필요 → 교정(자격증명이 맞아도 실패하던 진짜 버그).
- **WooCommerce HTTP 406**: WP 호스트 WAF가 막던 것 → User-Agent/Accept 헤더 추가.
- 쿠팡/11번가/우커머스 진단 실패 시 실제 응답 본문 + 상태코드별 힌트 노출.

### 3) 인앱 API 키 발급 가이드 (그림 포함)
- `GET /seller/markets/guide` + `markets_guide.html`: SVG 개념 일러스트 + 마켓별 시각 스텝퍼 + 단계별 설명 + 받은값→입력칸 매핑표 + 공식 링크. `/seller/markets`·연결 화면·사이드바에서 진입.

### 4) UX/UI 디테일 (앞선 작업 포함)
- 전역 토스트(`pcToast`)로 차단형 `alert()` 제거, 네이티브 `confirm()` → 스타일드 모달(`pcConfirm`).
- 쿠팡/스마트스토어/11번가 실 채널 업로더 연결(`channel_sync` 브리지), env 별칭 정합성 수정.
- 라이브 검증 도구 `scripts/verify_market_connections.py` + `docs/operations/LIVE_VERIFICATION_GUIDE.md`.

## 테스트
- 전체 **9861 passed, 2 skipped, 0 failed**.
- 신규: 토스트/모달, 채널 업로더, 11번가, 셀러 자격증명, 어댑터 라이브 수정, 발급 가이드, 검증 도구 등.

## 운영 메모
- 운영에서 `MARKET_CRED_ENC_KEY`(Fernet) 설정 권장(셀러 저장 키 암호화).
- 배포 후 `/seller/markets/connect`에서 키 입력 → [연결 테스트]로 라이브 확인 가능.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_