### PR TITLE
라이브 진단 후속 수정 — 쿠팡 엔드포인트 + 스마트스토어 env 폴백/에러 노출

### DIFF
--- a/src/seller_console/market_adapters/coupang_adapter.py
+++ b/src/seller_console/market_adapters/coupang_adapter.py
@@ -459,10 +459,12 @@ class CoupangAdapter(MarketAdapter):
 
         try:
             vendor_id = os.getenv("COUPANG_VENDOR_ID", "")
-            url_path = f"/v2/providers/openapi/apis/api/v1/vendors/{vendor_id}"
+            # 인증/연결 확인용: 반품지 목록 조회(유효한 v4 엔드포인트, vendorId도 함께 검증).
+            url_path = f"/v2/providers/openapi/apis/api/v4/vendors/{vendor_id}/returnShippingCenters"
+            query = "pageNum=1&pageSize=10"
             import requests
-            headers = _hmac_sign("GET", url_path)
-            resp = requests.get(f"{_BASE_URL}{url_path}", headers=headers, timeout=5)
+            headers = _hmac_sign("GET", url_path, query)
+            resp = requests.get(f"{_BASE_URL}{url_path}?{query}", headers=headers, timeout=5)
             if resp.status_code == 200:
                 return {"status": "ok", "detail": "쿠팡 API 연결 성공"}
             body = (resp.text or "").strip().replace("\n", " ")[:200]

--- a/src/seller_console/market_adapters/smartstore_adapter.py
+++ b/src/seller_console/market_adapters/smartstore_adapter.py
@@ -28,8 +28,20 @@ _NAVER_BASE_URL = "https://api.commerce.naver.com"
 _token_cache: dict = {}
 
 
+def _naver_creds() -> tuple[str, str]:
+    """네이버 커머스 자격증명(client_id, client_secret).
+
+    인앱 연결/Render 환경변수 명명 혼용을 흡수: NAVER_COMMERCE_* 우선,
+    없으면 NAVER_CLIENT_* 폴백.
+    """
+    client_id = os.getenv("NAVER_COMMERCE_CLIENT_ID") or os.getenv("NAVER_CLIENT_ID", "")
+    client_secret = os.getenv("NAVER_COMMERCE_CLIENT_SECRET") or os.getenv("NAVER_CLIENT_SECRET", "")
+    return client_id or "", client_secret or ""
+
+
 def _api_active() -> bool:
-    return all(os.getenv(v) for v in ["NAVER_COMMERCE_CLIENT_ID", "NAVER_COMMERCE_CLIENT_SECRET"])
+    client_id, client_secret = _naver_creds()
+    return bool(client_id and client_secret)
 
 
 def _naver_signature(client_id: str, client_secret: str, timestamp_ms: str) -> Optional[str]:
@@ -64,13 +76,13 @@ def _get_access_token() -> Optional[str]:
     if cached and cached.get("expires_at", 0) > now + 60:
         return cached["access_token"]
 
-    client_id = os.getenv("NAVER_COMMERCE_CLIENT_ID", "")
-    client_secret = os.getenv("NAVER_COMMERCE_CLIENT_SECRET", "")
+    client_id, client_secret = _naver_creds()
 
     # 네이버 커머스 API는 client_secret 평문이 아니라 bcrypt 전자서명을 요구한다.
     timestamp = str(int(now * 1000))
     sign = _naver_signature(client_id, client_secret, timestamp)
     if not sign:
+        _token_cache["last_error"] = "전자서명 생성 실패 — Client Secret이 '$2a$…' 형식인지 확인하세요."
         logger.warning("스마트스토어 토큰 발급 실패: 전자서명 생성 불가(시크릿 형식 확인)")
         return None
 
@@ -88,7 +100,11 @@ def _get_access_token() -> Optional[str]:
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=10,
         )
-        resp.raise_for_status()
+        if resp.status_code != 200:
+            body = (resp.text or "").strip().replace("\n", " ")[:200]
+            _token_cache["last_error"] = f"HTTP {resp.status_code}: {body}"
+            logger.warning("스마트스토어 토큰 발급 실패 HTTP %s: %s", resp.status_code, body)
+            return None
         token_data = resp.json()
         access_token = token_data.get("access_token")
         expires_in = int(token_data.get("expires_in", 3600))
@@ -96,9 +112,11 @@ def _get_access_token() -> Optional[str]:
             "access_token": access_token,
             "expires_at": now + expires_in,
         }
+        _token_cache.pop("last_error", None)
         logger.info("스마트스토어 OAuth 토큰 발급 성공")
         return access_token
     except Exception as exc:
+        _token_cache["last_error"] = str(exc)
         logger.warning("스마트스토어 토큰 발급 실패: %s", exc)
         return None
 
@@ -406,4 +424,9 @@ class SmartStoreAdapter(MarketAdapter):
         token = _get_access_token()
         if token:
             return {"status": "ok", "detail": "스마트스토어 OAuth 토큰 발급 성공"}
-        return {"status": "fail", "detail": "토큰 발급 실패 — 클라이언트 ID/시크릿 확인 필요"}
+        last_error = _token_cache.get("last_error") or "클라이언트 ID/시크릿 확인 필요"
+        return {
+            "status": "fail",
+            "detail": f"토큰 발급 실패 — {last_error}",
+            "hint": "Client ID/Secret 값과 형식($2a$…)을 확인하세요. 네이버 커머스 API센터에서 발급한 값이어야 합니다.",
+        }

--- a/tests/test_market_adapter_live_fixes.py
+++ b/tests/test_market_adapter_live_fixes.py
@@ -31,6 +31,16 @@ class TestSmartstoreNaverSignature:
         # bcrypt salt 형식이 아니면 None (정직 실패)
         assert ss._naver_signature("c", "not-a-valid-bcrypt-salt", "123") is None
 
+    def test_creds_fallback_to_naver_client_names(self, monkeypatch):
+        from src.seller_console.market_adapters import smartstore_adapter as ss
+        for k in ("NAVER_COMMERCE_CLIENT_ID", "NAVER_COMMERCE_CLIENT_SECRET"):
+            monkeypatch.delenv(k, raising=False)
+        # 인앱 연결이 저장하는 NAVER_CLIENT_* 도 인식해야 한다
+        monkeypatch.setenv("NAVER_CLIENT_ID", "cid")
+        monkeypatch.setenv("NAVER_CLIENT_SECRET", "csec")
+        assert ss._naver_creds() == ("cid", "csec")
+        assert ss._api_active() is True
+
     def test_token_request_sends_sign_not_plaintext_secret(self, monkeypatch):
         import bcrypt
         from src.seller_console.market_adapters import smartstore_adapter as ss
@@ -45,6 +55,7 @@ class TestSmartstoreNaverSignature:
         def fake_post(url, data=None, headers=None, timeout=None):
             captured["data"] = data
             resp = MagicMock()
+            resp.status_code = 200
             resp.raise_for_status.return_value = None
             resp.json.return_value = {"access_token": "TOK", "expires_in": 3600}
             return resp


### PR DESCRIPTION
## 배경
PR #196 배포 후 `/seller/markets` 라이브 진단 결과(개선된 상세 응답 메시지)로 추가 원인을 파악해 수정.

- **WooCommerce** ✅ 연결 성공 (406 헤더 수정 적중)
- **쿠팡**: `No exactly matching API specification for /api/v1/vendors/{id} ... check if you specified URL correctly` → 무효 엔드포인트. **유효한 v4 반품지 목록(`returnShippingCenters`) 으로 교정** (vendorId도 함께 검증).
- **스마트스토어**: 진단 어댑터가 인앱 저장 키(`NAVER_CLIENT_*`)도 인식하도록 `_naver_creds()` 폴백 + **토큰 실패 시 실제 원인(서명 실패/HTTP 본문)을 화면에 노출**.
- **11번가**(`997 등록된 API 정보 없음`) / **Shopify**(`Invalid token`)는 자격증명/계정(승인) 문제 → 오너 확인 사항.

## 테스트
- 전체 **9862 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_