### PR TITLE
fix: 자격증명 공백 방어(strip) + 스마트스토어 IP 오류 정확 안내

### DIFF
--- a/src/seller_console/market_adapters/coupang_adapter.py
+++ b/src/seller_console/market_adapters/coupang_adapter.py
@@ -42,8 +42,8 @@ def _hmac_sign(method: str, url_path: str, query: str = "") -> dict:
     Returns:
         Authorization 헤더를 포함한 dict
     """
-    access_key = os.getenv("COUPANG_ACCESS_KEY", "")
-    secret_key = os.getenv("COUPANG_SECRET_KEY", "")
+    access_key = os.getenv("COUPANG_ACCESS_KEY", "").strip()
+    secret_key = os.getenv("COUPANG_SECRET_KEY", "").strip()
 
     dt = datetime.now(tz=timezone.utc)
     # 쿠팡 윙 OpenAPI 규격: 2자리 연도 (%y) 사용 (예: 261023T143512Z)
@@ -458,7 +458,7 @@ class CoupangAdapter(MarketAdapter):
             return {"status": "dry_run", "detail": "ADAPTER_DRY_RUN=1"}
 
         try:
-            vendor_id = os.getenv("COUPANG_VENDOR_ID", "")
+            vendor_id = os.getenv("COUPANG_VENDOR_ID", "").strip()
             # 인증/연결 확인용: 반품지 목록 조회(유효한 v4 엔드포인트, vendorId도 함께 검증).
             url_path = f"/v2/providers/openapi/apis/api/v4/vendors/{vendor_id}/returnShippingCenters"
             query = "pageNum=1&pageSize=10"

--- a/src/seller_console/market_adapters/eleven_adapter.py
+++ b/src/seller_console/market_adapters/eleven_adapter.py
@@ -33,7 +33,7 @@ def _dry_run() -> bool:
 
 
 def _auth_headers() -> dict:
-    return {"openapikey": os.getenv("ELEVENST_API_KEY", "")}
+    return {"openapikey": os.getenv("ELEVENST_API_KEY", "").strip()}
 
 
 def _stub_response(action: str = "fetch_inventory") -> dict:

--- a/src/seller_console/market_adapters/smartstore_adapter.py
+++ b/src/seller_console/market_adapters/smartstore_adapter.py
@@ -36,7 +36,7 @@ def _naver_creds() -> tuple[str, str]:
     """
     client_id = os.getenv("NAVER_COMMERCE_CLIENT_ID") or os.getenv("NAVER_CLIENT_ID", "")
     client_secret = os.getenv("NAVER_COMMERCE_CLIENT_SECRET") or os.getenv("NAVER_CLIENT_SECRET", "")
-    return client_id or "", client_secret or ""
+    return (client_id or "").strip(), (client_secret or "").strip()
 
 
 def _api_active() -> bool:
@@ -425,8 +425,13 @@ class SmartStoreAdapter(MarketAdapter):
         if token:
             return {"status": "ok", "detail": "스마트스토어 OAuth 토큰 발급 성공"}
         last_error = _token_cache.get("last_error") or "클라이언트 ID/시크릿 확인 필요"
+        if "IP" in last_error:
+            hint = ("네이버 커머스 API센터 → 애플리케이션 설정 → ‘허용 IP’에 서버 고정 IP를 등록하세요"
+                    "(또는 IP 제한을 해제). 인증 자체는 성공한 상태입니다.")
+        else:
+            hint = "Client ID/Secret 값과 형식($2a$…)을 확인하세요. 네이버 커머스 API센터에서 발급한 값이어야 합니다."
         return {
             "status": "fail",
             "detail": f"토큰 발급 실패 — {last_error}",
-            "hint": "Client ID/Secret 값과 형식($2a$…)을 확인하세요. 네이버 커머스 API센터에서 발급한 값이어야 합니다.",
+            "hint": hint,
         }

--- a/tests/test_market_adapter_live_fixes.py
+++ b/tests/test_market_adapter_live_fixes.py
@@ -73,6 +73,48 @@ class TestSmartstoreNaverSignature:
         ss._token_cache.clear()
 
 
+class TestCredentialStripping:
+    """Render env에 끼어든 공백/줄바꿈이 서명을 깨지 않도록 strip."""
+
+    def test_coupang_hmac_ignores_whitespace(self, monkeypatch):
+        from src.seller_console.market_adapters import coupang_adapter as cp
+        monkeypatch.setenv("COUPANG_ACCESS_KEY", "ak")
+        monkeypatch.setenv("COUPANG_SECRET_KEY", "sk")
+        clean = cp._hmac_sign("GET", "/x")["Authorization"]
+        monkeypatch.setenv("COUPANG_ACCESS_KEY", " ak\n")
+        monkeypatch.setenv("COUPANG_SECRET_KEY", " sk\n")
+        dirty = cp._hmac_sign("GET", "/x")["Authorization"]
+        # 서명 시각(초)이 같을 때 동일해야 한다(공백 무시). 시각 차이 가능성은 access-key 비교로 보강.
+        assert "access-key=ak," in clean and "access-key=ak," in dirty
+
+    def test_naver_creds_stripped(self, monkeypatch):
+        from src.seller_console.market_adapters import smartstore_adapter as ss
+        for k in ("NAVER_COMMERCE_CLIENT_ID", "NAVER_COMMERCE_CLIENT_SECRET"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("NAVER_CLIENT_ID", "  cid\n")
+        monkeypatch.setenv("NAVER_CLIENT_SECRET", "csec  ")
+        assert ss._naver_creds() == ("cid", "csec")
+
+
+class TestSmartstoreIpHint:
+    def test_ip_error_gives_ip_hint(self, monkeypatch):
+        from src.seller_console.market_adapters import smartstore_adapter as ss
+        import bcrypt
+        ss._token_cache.clear()
+        monkeypatch.setenv("NAVER_COMMERCE_CLIENT_ID", "cid")
+        monkeypatch.setenv("NAVER_COMMERCE_CLIENT_SECRET", bcrypt.gensalt().decode())
+        monkeypatch.delenv("ADAPTER_DRY_RUN", raising=False)
+
+        resp = MagicMock()
+        resp.status_code = 403
+        resp.text = '{"code":"GW.IP_NOT_ALLOWED","message":"호출이 허용되지 않은 IP입니다."}'
+        with patch("requests.post", return_value=resp):
+            result = ss.SmartStoreAdapter().health_check()
+        assert result["status"] == "fail"
+        assert "허용 IP" in result["hint"]
+        ss._token_cache.clear()
+
+
 class TestWooCommerceHeaders:
     def test_health_check_sends_user_agent_and_accept(self, monkeypatch):
         from src.seller_console.market_adapters import woocommerce_adapter as wc


### PR DESCRIPTION
## 배경
"렌더에 값을 제대로 넣었는데 계속 실패" — 복사·붙여넣기 시 끼어드는 **보이지 않는 공백/줄바꿈**이 흔한 원인이라 방어 처리.

## 변경
- 쿠팡 `ACCESS/SECRET KEY` + `Vendor ID`, 11번가 `openapikey`, 네이버 `client id/secret` 읽기에 **`.strip()`** 적용. (Shopify는 기존에 strip됨)
  - 쿠팡 `Invalid signature(401)`가 시크릿 끝 공백 때문이면 이 수정으로 해결됩니다.
- 스마트스토어 `403 GW.IP_NOT_ALLOWED`일 때 화면 힌트를 **"네이버 ‘허용 IP’에 서버 IP 등록"** 으로 정확히 안내(인증은 이미 통과, IP 허용만 남음).

## 남은 마켓별 액션(코드 외)
- **스마트스토어**: 네이버 커머스 API센터 → 애플리케이션 설정 → ‘허용 IP’에 Render 고정 아웃바운드 IP 등록(또는 IP 제한 해제).
- **쿠팡**: (이 PR 배포 후에도 Invalid signature면) SECRET_KEY 재복사.
- **11번가**: OpenAPI 사용 승인 + 키 확인.
- **Shopify**: 토큰 재발급.

## 테스트
- 전체 **9866 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_