### PR TITLE
feat: 마켓별 단독 연결 페이지

### DIFF
--- a/src/seller_console/templates/markets.html
+++ b/src/seller_console/templates/markets.html
@@ -68,7 +68,7 @@
             <button class="btn btn-outline-primary btn-sm" type="button" data-market-action="connection" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'connection')">연결 확인</button>
             <button class="btn btn-outline-secondary btn-sm" type="button" data-market-action="scope" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'scope')">권한 확인</button>
             <button class="btn btn-outline-warning btn-sm" type="button" data-market-action="retry" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'retry')">재시도</button>
-            <a class="btn btn-outline-primary btn-sm" href="/seller/markets/connect">🔑 키 입력</a>
+            <a class="btn btn-outline-primary btn-sm" href="/seller/markets/connect/{{ hub.marketplace }}">🔑 키 입력</a>
           </div>
           <div class="small text-muted mt-2">필수 권한: {{ hub.required_scopes|join(', ') }}</div>
           <div class="small text-muted mt-1">필수 env: {{ hub.required_env|join(', ') }}</div>

--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -5,13 +5,31 @@
 <section class="mb-4">
   <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
     <div>
+      {% if single_market %}
+      <h1 class="h4 mb-1">{{ market_statuses[0].label }} 연결</h1>
+      <p class="text-muted mb-0">{{ market_statuses[0].label }} API 키를 입력하고, 저장 전에 연결을 테스트하세요.</p>
+      {% else %}
       <h1 class="h4 mb-1">마켓 연결</h1>
       <p class="text-muted mb-0">내 마켓 API 키를 직접 입력하고, 저장 전에 연결을 테스트할 수 있어요.</p>
+      {% endif %}
     </div>
     <div class="d-flex gap-2">
+      {% if single_market %}
+      <a href="/seller/markets/connect" class="btn btn-outline-secondary btn-sm">전체 마켓 보기</a>
+      {% endif %}
       <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm">📖 발급 가이드</a>
       <a href="/seller/markets" class="btn btn-outline-secondary btn-sm">← 마켓 현황으로</a>
     </div>
+  </div>
+
+  <!-- 마켓 전환 칩 -->
+  <div class="d-flex flex-wrap gap-2 mb-3">
+    {% for chip in market_chips %}
+    <a href="/seller/markets/connect/{{ chip.market }}"
+       class="btn btn-sm {{ 'btn-primary' if single_market == chip.market else 'btn-outline-secondary' }}">
+      {{ chip.label }} {{ '✅' if chip.connected else '' }}
+    </a>
+    {% endfor %}
   </div>
 
   <div class="alert alert-light border d-flex gap-2 align-items-start mb-4" role="note">
@@ -22,9 +40,28 @@
     </div>
   </div>
 
+  {% if single_market and guide_entry %}
+  <div class="card console-card mb-3">
+    <div class="card-body">
+      <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+        <h2 class="h6 mb-0">📖 {{ guide_entry.label }} 키 발급 방법</h2>
+        <a href="{{ guide_entry.official_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm">🔗 {{ guide_entry.official_label }}</a>
+      </div>
+      <ol class="small mb-0">
+        {% for s in guide_entry.steps %}
+        <li class="mb-1"><span class="fw-semibold">{{ s.t }}</span> — <span class="text-muted">{{ s.d }}</span></li>
+        {% endfor %}
+      </ol>
+      {% if guide_entry.tips %}
+      <div class="small text-muted mt-2">{% for tip in guide_entry.tips %}<div>💡 {{ tip }}</div>{% endfor %}</div>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
+
   <div class="row g-3">
     {% for m in market_statuses %}
-    <div class="col-12 col-lg-6">
+    <div class="{{ 'col-12' if single_market else 'col-12 col-lg-6' }}">
       <div class="card console-card h-100" data-market="{{ m.market }}">
         <div class="card-body">
           <div class="d-flex align-items-center justify-content-between gap-2 mb-3">

--- a/src/seller_console/templates/markets_guide.html
+++ b/src/seller_console/templates/markets_guide.html
@@ -123,7 +123,7 @@
       {% if g.status == 'planned' %}
       <span class="text-muted small">🔧 어댑터 연동 적용 후 입력칸이 열립니다.</span>
       {% else %}
-      <a href="/seller/markets/connect" class="btn btn-success btn-sm">✅ {{ g.label }} 키 입력하러 가기</a>
+      <a href="/seller/markets/connect/{{ g.key }}" class="btn btn-success btn-sm">✅ {{ g.label }} 키 입력하러 가기</a>
       {% endif %}
     </div>
   </div>

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -2383,15 +2383,48 @@ def _diag_market_key(market: str) -> str:
     return "11st" if market == "elevenst" else market
 
 
+def _connect_market_key(market: str) -> str:
+    """진단/URL 키 → 자격증명 저장 키 (11st → elevenst)."""
+    m = (market or "").strip().lower()
+    return "elevenst" if m == "11st" else m
+
+
 @bp.get("/markets/connect")
 def markets_connect():
-    """셀프서비스 마켓 연결 관리 화면."""
+    """셀프서비스 마켓 연결 관리 화면 (전체)."""
     if not _check_auth():
         return redirect(url_for("auth.login", next=request.url))
     from . import market_credentials as mc
 
-    statuses = mc.all_status(_seller_id())
-    return render_template("markets_connect.html", page="markets", market_statuses=statuses)
+    seller = _seller_id()
+    statuses = mc.all_status(seller)
+    chips = [{"market": s["market"], "label": s["label"], "connected": s["connected"]} for s in statuses]
+    return render_template(
+        "markets_connect.html", page="markets",
+        market_statuses=statuses, market_chips=chips, single_market=None, guide_entry=None,
+    )
+
+
+@bp.get("/markets/connect/<market>")
+def markets_connect_one(market):
+    """마켓별 단독 연결 페이지 (키 발급 안내 + 입력칸)."""
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.url))
+    from . import market_credentials as mc
+    from .market_guide import get_guide
+
+    market = _connect_market_key(market)
+    if market not in mc.MARKET_CRED_FIELDS:
+        return redirect(url_for("seller_console.markets_connect"))
+
+    seller = _seller_id()
+    chips = [{"market": s["market"], "label": s["label"], "connected": s["connected"]} for s in mc.all_status(seller)]
+    guide_entry = next((g for g in get_guide() if g.get("key") == market), None)
+    return render_template(
+        "markets_connect.html", page="markets",
+        market_statuses=[mc.status(seller, market)], market_chips=chips,
+        single_market=market, guide_entry=guide_entry,
+    )
 
 
 @bp.get("/markets/guide")

--- a/tests/test_market_credentials.py
+++ b/tests/test_market_credentials.py
@@ -188,6 +188,23 @@ class TestConnectRoutes:
         assert resp.status_code == 200
         assert "result" in resp.get_json()
 
+    def test_per_market_page_renders(self, client):
+        resp = client.get("/seller/markets/connect/coupang")
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert "쿠팡 연결" in html
+        assert "키 발급 방법" in html  # 인라인 가이드
+        assert "전체 마켓 보기" in html
+
+    def test_per_market_11st_maps_to_elevenst(self, client):
+        resp = client.get("/seller/markets/connect/11st")
+        assert resp.status_code == 200
+        assert "11번가 연결" in resp.get_data(as_text=True)
+
+    def test_per_market_invalid_redirects(self, client):
+        resp = client.get("/seller/markets/connect/foobar")
+        assert resp.status_code in (301, 302)
+
     def test_disconnect(self, client):
         client.post("/seller/markets/connect/coupang", json={"values": {
             "COUPANG_ACCESS_KEY": "ak", "COUPANG_SECRET_KEY": "sk", "COUPANG_VENDOR_ID": "A1"}})


### PR DESCRIPTION
## 변경
오너 요청: "키 입력을 누르면 전체 입력으로 가는데, 마켓마다 **별도 페이지/공간**이 있어야 한다."

- **`GET /seller/markets/connect/<market>`**: 해당 마켓만 보여주는 단독 페이지
  - 인라인 **키 발급 가이드**(단계+공식 링크+팁) + 입력칸 + 연결 테스트/저장
  - 상단 **마켓 전환 칩**(연결됨 ✅ 표시) + "전체 마켓 보기"
- `/seller/markets` 카드의 "🔑 키 입력" + 발급 가이드 CTA를 **per-market 링크**로 변경
- `11st → elevenst` 키 매핑, 잘못된 마켓은 전체 페이지로 리다이렉트

## 테스트
- 전체 **9869 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_