### PR TITLE
fix: 쿠팡 health 엔드포인트 권한 정합 + 저장 병합

### DIFF
--- a/src/seller_console/market_adapters/coupang_adapter.py
+++ b/src/seller_console/market_adapters/coupang_adapter.py
@@ -459,9 +459,9 @@ class CoupangAdapter(MarketAdapter):
 
         try:
             vendor_id = os.getenv("COUPANG_VENDOR_ID", "").strip()
-            # 인증/연결 확인용: 반품지 목록 조회(유효한 v4 엔드포인트, vendorId도 함께 검증).
-            url_path = f"/v2/providers/openapi/apis/api/v4/vendors/{vendor_id}/returnShippingCenters"
-            query = "pageNum=1&pageSize=10"
+            # 연결 확인용: 셀러 상품 목록 1건 조회(상품 등록 키가 가진 권한과 동일 — 권한 false-403 방지).
+            url_path = "/v2/providers/seller_api/apis/api/v1/marketplace/seller-products"
+            query = f"vendorId={vendor_id}&maxPerPage=1"
             import requests
             headers = _hmac_sign("GET", url_path, query)
             resp = requests.get(f"{_BASE_URL}{url_path}?{query}", headers=headers, timeout=5)
@@ -469,10 +469,12 @@ class CoupangAdapter(MarketAdapter):
                 return {"status": "ok", "detail": "쿠팡 API 연결 성공"}
             body = (resp.text or "").strip().replace("\n", " ")[:200]
             hint = ""
-            if resp.status_code == 404:
+            if resp.status_code == 401:
+                hint = "COUPANG_ACCESS_KEY/SECRET_KEY 값을 확인하세요(앞뒤 공백 없이 정확히)."
+            elif resp.status_code == 403:
+                hint = "쿠팡 Wing에서 해당 API 권한이 켜져 있는지, Vendor ID가 이 키의 업체와 일치하는지 확인하세요."
+            elif resp.status_code == 404:
                 hint = "COUPANG_VENDOR_ID 값이 올바른지(A+숫자 형식) 확인하세요."
-            elif resp.status_code in (401, 403):
-                hint = "COUPANG_ACCESS_KEY/SECRET_KEY 가 올바른지 확인하세요."
             return {"status": "fail", "detail": f"HTTP {resp.status_code}: {body}", "hint": hint}
         except Exception as exc:
             logger.warning("쿠팡 health_check 실패: %s", exc)

--- a/src/seller_console/market_credentials.py
+++ b/src/seller_console/market_credentials.py
@@ -162,9 +162,12 @@ def save(seller_id: str, market: str, values: Dict[str, str]) -> Dict[str, str]:
         if env in allowed and str(val).strip()
     }
     data = _load_all(seller_id)
-    data[market] = cleaned
+    # 병합: 입력한 필드만 갱신하고 나머지(예: 비워둔 비밀값)는 기존 값 유지.
+    existing = data.get(market) if isinstance(data.get(market), dict) else {}
+    merged = {**existing, **cleaned}
+    data[market] = merged
     _save_all(seller_id, data)
-    return cleaned
+    return merged
 
 
 def delete(seller_id: str, market: str) -> bool:

--- a/tests/test_market_credentials.py
+++ b/tests/test_market_credentials.py
@@ -42,6 +42,16 @@ class TestStoreRoundtrip:
         })
         assert saved == {"ELEVENST_API_KEY": "key1"}
 
+    def test_save_merges_keeps_existing_secret(self, mc):
+        # 비밀값 포함 전체 저장
+        mc.save("s2", "coupang", {
+            "COUPANG_ACCESS_KEY": "ak", "COUPANG_SECRET_KEY": "sk", "COUPANG_VENDOR_ID": "A1"})
+        # 비밀값 칸을 비운 채 Vendor ID만 갱신 → 기존 비밀값 유지되어야 함
+        merged = mc.save("s2", "coupang", {"COUPANG_VENDOR_ID": "A2"})
+        assert merged["COUPANG_ACCESS_KEY"] == "ak"
+        assert merged["COUPANG_SECRET_KEY"] == "sk"
+        assert merged["COUPANG_VENDOR_ID"] == "A2"
+
     def test_delete(self, mc):
         mc.save("seller1", "coupang", {"COUPANG_ACCESS_KEY": "a", "COUPANG_SECRET_KEY": "b", "COUPANG_VENDOR_ID": "c"})
         assert mc.delete("seller1", "coupang") is True


### PR DESCRIPTION
## 배경
오너가 인앱에 쿠팡 키를 저장해도 실패 → 직접 검증한 결과:

**인앱 키 주입은 정상 작동**합니다(인앱 저장 키가 실제 HMAC 서명에 사용됨을 로컬에서 확인). 그리고 에러 분류상 인앱 쿠팡은 **403(scope_insufficient)** = **서명은 통과**(401 아님), 즉 **키는 정확**합니다. 문제는 제가 고른 health-check 엔드포인트(반품지 조회)가 업로드용 상품키에 없는 권한을 요구해 403이 난 것.

## 변경
- **쿠팡 health_check를 셀러 상품 목록 조회(`seller-products`)로 교정** — 업로드용 상품키와 동일 권한이라 false-403 방지. 401/403/404별 정확한 힌트.
- **`market_credentials.save` 병합(merge)화** — 비밀값 칸을 비운 채 일부 필드만 저장해도 기존 비밀값 유지(흔한 입력 실수 방지).

## 테스트
- 전체 **9870 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_