### PR TITLE
feat: 연결 테스트에 마켓 원문 응답 표시

### DIFF
--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -143,13 +143,30 @@ function renderTestResult(form, result) {
   const box = form.querySelector('[data-role="test-result"]');
   if (!box) return;
   box.classList.remove('d-none', 'text-success', 'text-danger', 'text-warning');
+  box.innerHTML = '';
   if (result && result.status === 'connected') {
     box.classList.add('text-success');
     box.textContent = '✅ 연결 성공 — ' + (result.summary || '');
-  } else {
-    box.classList.add('text-warning');
-    const code = result ? (result.status || '실패') : '실패';
-    box.textContent = '⚠️ ' + code + ' — ' + ((result && (result.hint || result.summary)) || '연결을 확인하세요.');
+    return;
+  }
+  box.classList.add('text-warning');
+  const code = result ? (result.status || '실패') : '실패';
+  const head = document.createElement('div');
+  head.textContent = '⚠️ ' + code;
+  box.appendChild(head);
+  // 마켓이 보낸 원문 응답(디버깅용) — 그대로 표시
+  if (result && result.summary) {
+    const raw = document.createElement('div');
+    raw.className = 'text-muted mt-1';
+    raw.style.wordBreak = 'break-all';
+    raw.textContent = '마켓 응답: ' + result.summary;
+    box.appendChild(raw);
+  }
+  if (result && result.hint) {
+    const hint = document.createElement('div');
+    hint.className = 'mt-1';
+    hint.textContent = '💡 조치: ' + result.hint;
+    box.appendChild(hint);
   }
 }
 


### PR DESCRIPTION
## 변경
쿠팡 403 등 연결 실패 시, 마켓이 보낸 **실제 응답(HTTP 코드 + JSON 본문)** 을 연결 테스트 결과에 그대로 노출. 정확한 원인(권한/약관/서명)을 식별하기 위함. XSS 방지(textContent).

## 진단 근거
- 쿠팡: 올바른 키 → **403**(서명 통과, 인증됨), 틀린 키 → **401**(서명 거부). 이 일관성은 **서명 알고리즘이 정확**함을 증명.
- 남은 403은 Coupang 측 **API 권한/약관 동의** 이슈로 추정 → 원문 메시지로 확정 예정.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_