### PR TITLE
fix: 진단 조치 문구를 마켓별 힌트로 (쿠팡 재발급 오안내 제거)

### DIFF
--- a/src/seller_console/market_integration_diagnostics.py
+++ b/src/seller_console/market_integration_diagnostics.py
@@ -229,6 +229,10 @@ def build_market_ui_state(result: dict[str, Any]) -> dict[str, Any]:
         action_text = "토큰을 재발급한 뒤 재시도 버튼으로 다시 점검하세요."
     else:
         action_text = "재시도 버튼으로 다시 점검하고 지속되면 diagnostics와 판매자센터 로그를 함께 확인하세요."
+    # 어댑터가 마켓별 정확한 조치 힌트를 제공하면 그것을 우선 노출(일반 상태 문구보다 정확).
+    result_hint = str(result.get("hint") or "").strip()
+    if result_hint:
+        action_text = result_hint
     return {
         "badge_label": badge["label"],
         "badge_class": badge["class_name"],

--- a/tests/test_market_integration_diagnostics.py
+++ b/tests/test_market_integration_diagnostics.py
@@ -149,4 +149,18 @@ def test_build_market_ui_state_exposes_technical_detail():
 
     assert ui["badge_label"] == "api_error"
     assert ui["technical_detail"] == "HTTP 500"
-    assert ui["action_text"].startswith("재시도 버튼")
+    # 어댑터 힌트가 있으면 action_text로 우선 노출된다.
+    assert ui["action_text"] == "잠시 후 다시 시도하세요."
+
+
+def test_token_expired_uses_adapter_hint_not_generic_reissue():
+    """쿠팡 401처럼 토큰 재발급 개념이 없는 마켓은 어댑터 힌트가 action_text로 노출된다."""
+    from src.seller_console.market_integration_diagnostics import build_market_ui_state
+    ui = build_market_ui_state({
+        "status": "token_expired",
+        "summary": "HTTP 401: Invalid signature",
+        "hint": "COUPANG_ACCESS_KEY/SECRET_KEY 값을 확인하세요(앞뒤 공백 없이 정확히).",
+        "steps": [{"ok": False, "detail": "HTTP 401", "error_code": "token_expired"}],
+    })
+    assert "재발급" not in ui["action_text"]
+    assert "COUPANG" in ui["action_text"]


### PR DESCRIPTION
## 변경
오너 지적: 쿠팡인데 "토큰 재발급" 안내가 떠서 혼란.

- `build_market_ui_state`가 `token_expired` 등 상태에 무조건 Shopify 전용 "토큰 재발급" 문구를 쓰던 것 → **어댑터가 제공하는 마켓별 정확한 hint를 action_text로 우선 노출**.
- 쿠팡 401은 "ACCESS/SECRET KEY 값 확인(앞뒤 공백 없이)"으로 안내(쿠팡엔 토큰 재발급 개념 없음).

## 참고 — 현재 쿠팡 상태
- 마켓 현황 화면 쿠팡 = **401**(Render 환경변수의 옛 키 사용 → 값 불일치)
- 연결 화면에서 직접 입력한 정확한 키 = **403**(서명 통과, Coupang 권한/약관 이슈)
- 연결 테스트 결과에 마켓 원문 응답을 노출하도록 이미 반영(원인 확정용).

## 테스트
- 전체 **9871 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_