### PR TITLE
fix: 쿠팡 403 IP 차단을 정확히 안내 (서버 IP 허용목록 등록)

### DIFF
--- a/src/seller_console/market_adapters/coupang_adapter.py
+++ b/src/seller_console/market_adapters/coupang_adapter.py
@@ -467,12 +467,20 @@ class CoupangAdapter(MarketAdapter):
             resp = requests.get(f"{_BASE_URL}{url_path}?{query}", headers=headers, timeout=5)
             if resp.status_code == 200:
                 return {"status": "ok", "detail": "쿠팡 API 연결 성공"}
-            body = (resp.text or "").strip().replace("\n", " ")[:200]
+            body = (resp.text or "").strip().replace("\n", " ")[:300]
+            low = body.lower()
             hint = ""
             if resp.status_code == 401:
                 hint = "COUPANG_ACCESS_KEY/SECRET_KEY 값을 확인하세요(앞뒤 공백 없이 정확히)."
+            elif "ip address" in low and "not allowed" in low:
+                # 쿠팡 IP 허용목록 차단 — 서버 IP를 Wing에 등록해야 함
+                import re as _re
+                m = _re.search(r"ip address\s+([0-9.]+)", body, _re.IGNORECASE)
+                ip = m.group(1) if m else "이 서버 IP"
+                hint = (f"이 서버 IP({ip})가 쿠팡 허용목록에 없습니다. 쿠팡 Wing → 오픈API 발급/관리 →"
+                        f" 'API 호출 허용 IP'에 {ip} 를 등록하세요. (키는 정상)")
             elif resp.status_code == 403:
-                hint = "쿠팡 Wing에서 해당 API 권한이 켜져 있는지, Vendor ID가 이 키의 업체와 일치하는지 확인하세요."
+                hint = "쿠팡 Wing에서 해당 API 권한/허용 IP를 확인하세요. Vendor ID가 이 키의 업체와 일치하는지도 확인."
             elif resp.status_code == 404:
                 hint = "COUPANG_VENDOR_ID 값이 올바른지(A+숫자 형식) 확인하세요."
             return {"status": "fail", "detail": f"HTTP {resp.status_code}: {body}", "hint": hint}

--- a/src/seller_console/market_guide.py
+++ b/src/seller_console/market_guide.py
@@ -30,9 +30,10 @@ MARKET_GUIDE: List[Dict[str, Any]] = [
             {"env": "COUPANG_VENDOR_ID", "label": "Vendor ID(업체코드)", "where": "업체정보의 A+숫자 코드"},
         ],
         "tips": [
+            "‘your ip address … is not allowed(403)’가 뜨면 서버 IP가 허용목록에 없는 것입니다. "
+            "쿠팡 Wing → 오픈API 발급/관리 → ‘API 호출 허용 IP’에 우리 서버 IP를 등록하세요(키는 정상).",
             "‘Invalid signature(401)’가 뜨면 ACCESS KEY/SECRET KEY 값이 정확한지(공백·뒤바뀜 없이) 확인하세요.",
             "404가 나면 Vendor ID(A+숫자) 형식이 맞는지 확인하세요.",
-            "오픈API 사용은 일부 계정에서 사전 신청/승인이 필요할 수 있습니다.",
         ],
     },
     {

--- a/tests/test_market_adapter_live_fixes.py
+++ b/tests/test_market_adapter_live_fixes.py
@@ -145,3 +145,21 @@ class TestWooCommerceHeaders:
         h = wc._request_headers()
         assert h["User-Agent"]
         assert h["Accept"] == "application/json"
+
+
+class TestCoupangIpAllowlistHint:
+    def test_403_ip_not_allowed_gives_ip_hint(self, monkeypatch):
+        from src.seller_console.market_adapters import coupang_adapter as cp
+        monkeypatch.setenv("COUPANG_ACCESS_KEY", "ak")
+        monkeypatch.setenv("COUPANG_SECRET_KEY", "sk")
+        monkeypatch.setenv("COUPANG_VENDOR_ID", "A01381223")
+        monkeypatch.delenv("ADAPTER_DRY_RUN", raising=False)
+        resp = MagicMock()
+        resp.status_code = 403
+        resp.text = ('{"path":"/api/v1/marketplace/seller-products","error":"FORBIDDEN",'
+                     '"message":"Your ip address 74.220.49.7 is not allowed for this request."}')
+        with patch("requests.get", return_value=resp):
+            result = cp.CoupangAdapter().health_check()
+        assert result["status"] == "fail"
+        assert "74.220.49.7" in result["hint"]
+        assert "허용 IP" in result["hint"]


### PR DESCRIPTION
## 진짜 원인 확정 (라이브 검증)
쿠팡 연결 테스트 원문 응답:
```
HTTP 403: {"error":"FORBIDDEN","message":"Your ip address 74.220.49.7 is not allowed for this request. ... contact the Coupang seller"}
```
→ **키·서명은 정상**(403 = 인증 통과). 원인은 **서버(Render) 아웃바운드 IP `74.220.49.7`이 쿠팡 ‘API 호출 허용 IP’ 목록에 없어서** 차단. 네이버 `GW.IP_NOT_ALLOWED`와 **동일한 IP 차단** 문제.

"다른 데선 잘 됨" = 그 서버 IP는 등록돼 있고 Render IP만 미등록.

## 변경
- 쿠팡 health_check 403 본문에서 `ip address … not allowed` 감지 시, 응답에서 **서버 IP를 추출**해 "Wing → 오픈API 발급/관리 → 'API 호출 허용 IP'에 등록" 안내로 정확히 표기(키 정상임을 명시).
- 쿠팡 발급 가이드 팁에 IP 허용목록 안내 추가.

## 오너 액션 (코드 외 — 마켓 설정)
- **쿠팡 Wing**: 오픈API 허용 IP에 Render 아웃바운드 IP(`74.220.49.7` 등) 등록.
- **네이버**: 동일하게 허용 IP에 Render IP 등록(3칸 제약 → 슬롯 교체 필요).

## 테스트
- 전체 **9872 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_