### PR TITLE
docs: 발급 가이드에 API 허용 IP 안내 추가

### DIFF
--- a/src/seller_console/templates/markets_guide.html
+++ b/src/seller_console/templates/markets_guide.html
@@ -50,6 +50,20 @@
     </div>
   </div>
 
+  <!-- IP 허용목록 안내 (한국 마켓 공통 관문) -->
+  <div class="alert alert-warning d-flex gap-2 align-items-start mb-4">
+    <i class="bi bi-shield-exclamation"></i>
+    <div class="small mb-0">
+      <strong>🚧 한국 마켓(쿠팡·네이버·11번가)은 ‘API 호출 허용 IP’ 등록이 필요할 수 있어요.</strong>
+      키가 정확해도 <code>your ip ... is not allowed(403)</code> / <code>GW.IP_NOT_ALLOWED</code> 가 뜨면
+      <strong>이 서버의 아웃바운드 IP</strong>를 각 마켓 판매자센터의 허용 IP에 등록하세요.
+      <ul class="mb-0 mt-1">
+        <li>서버 IP 확인: <strong>Render → 서비스 → Settings → “Outbound IP Addresses”</strong> (보통 3개 — <u>전부</u> 등록)</li>
+        <li>쿠팡: 여러 IP를 쉼표로 등록 가능 · 네이버: 최대 3개(슬롯 교체 필요)</li>
+      </ul>
+    </div>
+  </div>
+
   <!-- 마켓 바로가기 -->
   <div class="guide-jump d-flex flex-wrap gap-2 mb-4">
     {% for g in guide %}


### PR DESCRIPTION
## 변경
쿠팡 연결 성공으로 IP 허용목록이 한국 마켓 공통 관문임이 확정. 발급 가이드 상단에 안내 추가:
- 키가 정확해도 `your ip ... not allowed(403)` / `GW.IP_NOT_ALLOWED` → 서버 아웃바운드 IP 등록 필요
- Render → Settings → "Outbound IP Addresses"(보통 3개) 전부 등록
- 쿠팡: 쉼표로 다중 IP / 네이버: 최대 3개

## 진행 상황
- ✅ 쿠팡 연결됨(IP 등록 후), ✅ WooCommerce
- 남음: 스마트스토어(네이버 IP 슬롯), 11번가(OpenAPI 승인), Shopify(토큰 재발급)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_