### PR TITLE
feat: Shopify 401 토큰 접두사 경고

### DIFF
--- a/src/markets/adapters/shopify.py
+++ b/src/markets/adapters/shopify.py
@@ -173,12 +173,19 @@ class ShopifyAdapter(MarketAdapter):
             response = self._request_with_retry("GET", "/shop.json")
             if not (200 <= response.status_code < 300):
                 summary = self._error_summary(response)
+                message = self._friendly_http_reason(response.status_code, summary, action="Shopify 연결 확인")
+                if response.status_code == 401:
+                    token = self._access_token()
+                    if token and not token.startswith("shpat_"):
+                        prefix = token.split("_")[0] if "_" in token else token[:4]
+                        message += (f" ⚠️ 현재 토큰이 '{prefix}_…'로 시작합니다 — "
+                                    "Admin API access token은 'shpat_'로 시작해야 합니다(잘못된 값일 수 있음).")
                 return {
                     "ok": False,
                     "status": "api_error",
                     "http_status": response.status_code,
                     "reason": summary,
-                    "message": self._friendly_http_reason(response.status_code, summary, action="Shopify 연결 확인"),
+                    "message": message,
                 }
 
             body = response.json()


### PR DESCRIPTION
## 배경
연결 화면에서 Shopify 저장 토큰이 **`at•••••72`** 로 마스킹됨 → 토큰이 `at`로 시작 = **Shopify Admin API access token이 아님**(반드시 `shpat_`). "잘 된다"던 값이 사실 잘못된 토큰(예: 옛 `atk_`)일 가능성.

## 변경
- Shopify 401 시, 저장된 토큰이 `shpat_`로 시작하지 않으면 **실제 접두사를 노출**해(`atk_…` 등) "Admin API access token이 아닐 수 있음"을 즉시 안내. 값 전체가 아니라 접두사만.

## 오너 액션
- Shopify Admin → app → API credentials → **Admin API access token(`shpat_…`)** 복사 → 토큰칸에 입력(API key 아님). 상점 도메인이 토큰의 상점과 동일한지 확인.

## 테스트
- 전체 **9872 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_