### PR TITLE
feat: Shopify 401에 상점/토큰 접두사 노출 (인증경로 전수검토)

### DIFF
--- a/src/markets/adapters/shopify.py
+++ b/src/markets/adapters/shopify.py
@@ -176,10 +176,11 @@ class ShopifyAdapter(MarketAdapter):
                 message = self._friendly_http_reason(response.status_code, summary, action="Shopify 연결 확인")
                 if response.status_code == 401:
                     token = self._access_token()
+                    token_prefix = (token.split("_")[0] + "_…") if (token and "_" in token) else (token[:4] + "…" if token else "(없음)")
+                    message += (f" [테스트한 상점: {self._shop_domain()} · 토큰 접두사: {token_prefix}]"
+                                " — 이 상점이 토큰을 발급한 상점과 같은지 확인하세요.")
                     if token and not token.startswith("shpat_"):
-                        prefix = token.split("_")[0] if "_" in token else token[:4]
-                        message += (f" ⚠️ 현재 토큰이 '{prefix}_…'로 시작합니다 — "
-                                    "Admin API access token은 'shpat_'로 시작해야 합니다(잘못된 값일 수 있음).")
+                        message += " ⚠️ 토큰이 'shpat_'로 시작하지 않습니다(Admin API access token이 맞는지 확인)."
                 return {
                     "ok": False,
                     "status": "api_error",


### PR DESCRIPTION
## 전수 검토 (오너 요청)
Shopify 인증 경로를 코드 레벨에서 샅샅이 확인:
1. **요청 코드 정확**: 헤더 `X-Shopify-Access-Token`, URL `https://{shop}/admin/api/{ver}/shop.json` — Shopify 표준.
2. **저장소 roundtrip 검증**: `shpat_…`(70자) 토큰을 저장→복원 시 값/길이 동일, 마스킹 `sh••••`. 공백 포함도 strip 후 정확 보존. **손상 버그 없음.**

→ 코드 무결. 401은 Shopify가 (상점, 토큰) 조합을 거부한 것.

## 변경
- Shopify 401 메시지에 **테스트한 상점 도메인 + 토큰 접두사**를 노출 → 사용자가 (상점-토큰 일치 여부, 토큰 종류 `shpat_`)를 직접 확인 가능.

## 진단 포인트
- 저장된 토큰이 `at•••••72`로 마스킹됨 = 저장값이 `at`로 시작(마스킹은 앞 2글자 그대로). Shopify 토큰은 `shpat_`로 시작해야 함 → 현재 값은 다른 토큰일 가능성, 또는 상점 도메인(`catdyy-p0`)이 토큰의 상점과 다름.

## 테스트
- 전체 **9872 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_