### PR TITLE
fix: Shopify 연결 확인 REST → GraphQL 전환

### DIFF
--- a/src/markets/adapters/shopify.py
+++ b/src/markets/adapters/shopify.py
@@ -144,10 +144,9 @@ class ShopifyAdapter(MarketAdapter):
     @staticmethod
     def _friendly_http_reason(status_code: int, summary: str, *, action: str) -> str:
         if status_code == 401:
-            return (f"{action} 인증 실패. 'Admin API access token(shpat_…)'을 넣었는지 확인하세요"
-                    " (API key 아님). 토큰을 만든 상점과 SHOPIFY_SHOP 도메인이 같아야 합니다. (Shopify는 IP 제한 없음)")
+            return f"{action} 인증 실패(401)."
         if status_code == 403:
-            return f"{action} 권한이 부족합니다. Shopify 앱 스코프(write_products/read_products 등)를 확인하세요."
+            return f"{action} 권한 부족(403). Shopify 앱 스코프(read_products/write_products 등)를 확인하세요."
         if status_code == 404:
             return f"{action} 대상 스토어를 찾지 못했습니다. SHOPIFY_SHOP 도메인을 확인하세요."
         if status_code == 429:
@@ -157,6 +156,20 @@ class ShopifyAdapter(MarketAdapter):
         if summary:
             return summary
         return "요청이 거절되었습니다."
+
+    def _append_auth_diagnostics(self, message: str) -> str:
+        """401/인증 실패 시 테스트 상점·토큰 접두사·종류 진단을 덧붙인다."""
+        token = self._access_token()
+        token_prefix = (token.split("_")[0] + "_…") if (token and "_" in token) else (token[:4] + "…" if token else "(없음)")
+        message += f" [테스트한 상점: {self._shop_domain()} · 토큰 접두사: {token_prefix}]"
+        valid_prefixes = ("shpat_", "atkn_", "shpca_")
+        if token and token.startswith("shpss_"):
+            message += " ⚠️ 'shpss_'는 Client secret(암호)입니다 — 토큰칸엔 '앱 자동화 토큰(atkn_)' 또는 'shpat_'를 넣으세요."
+        elif token and not token.startswith(valid_prefixes):
+            message += " ⚠️ 토큰 종류 확인: '앱 자동화 토큰(atkn_)' 또는 'Admin API access token(shpat_)'이어야 합니다."
+        else:
+            message += " 토큰 형식은 정상입니다 → 앱 권한(scope)에 read_products 등이 포함됐는지, 도메인이 정확한지 확인하세요."
+        return message
 
     def check_connection(self) -> Dict[str, Any]:
         missing_env = self._missing_config_env()
@@ -170,23 +183,15 @@ class ShopifyAdapter(MarketAdapter):
             }
 
         try:
-            response = self._request_with_retry("GET", "/shop.json")
+            # GraphQL Admin API 사용(신규 개발자대시보드 앱은 REST가 막혀 GraphQL만 동작).
+            query = "{ shop { name myshopifyDomain currencyCode plan { displayName } } }"
+            response = self._request_with_retry("POST", "/graphql.json", json_body={"query": query})
+
             if not (200 <= response.status_code < 300):
                 summary = self._error_summary(response)
                 message = self._friendly_http_reason(response.status_code, summary, action="Shopify 연결 확인")
-                if response.status_code == 401:
-                    token = self._access_token()
-                    token_prefix = (token.split("_")[0] + "_…") if (token and "_" in token) else (token[:4] + "…" if token else "(없음)")
-                    message += f" [테스트한 상점: {self._shop_domain()} · 토큰 접두사: {token_prefix}]"
-                    # 유효한 Shopify 토큰 접두사: shpat_(Admin API access token), atkn_(앱 자동화 토큰), shpca_
-                    valid_prefixes = ("shpat_", "atkn_", "shpca_")
-                    if token and token.startswith("shpss_"):
-                        message += " ⚠️ 'shpss_'는 Client secret(암호)입니다 — 토큰칸엔 '앱 자동화 토큰(atkn_)' 또는 'shpat_'를 넣으세요."
-                    elif token and not token.startswith(valid_prefixes):
-                        message += " ⚠️ 토큰 종류 확인: '앱 자동화 토큰(atkn_)' 또는 'Admin API access token(shpat_)'이어야 합니다."
-                    else:
-                        message += (" 토큰 형식은 정상입니다 → 이 토큰을 발급한 앱이 '테스트한 상점'에 설치되어 있는지,"
-                                    " 상점 도메인이 정확한지 확인하세요(토큰은 설치된 그 상점에서만 동작).")
+                if response.status_code in (401, 403):
+                    message = self._append_auth_diagnostics(message)
                 return {
                     "ok": False,
                     "status": "api_error",
@@ -195,18 +200,37 @@ class ShopifyAdapter(MarketAdapter):
                     "message": message,
                 }
 
-            body = response.json()
-            shop = body.get("shop", {}) if isinstance(body, dict) else {}
+            try:
+                body = response.json()
+            except ValueError:
+                body = {}
+            errors = body.get("errors") if isinstance(body, dict) else None
+            shop = ((body.get("data") or {}).get("shop")) if isinstance(body, dict) else None
+
+            if errors or not isinstance(shop, dict):
+                err_msg = ""
+                if isinstance(errors, list) and errors:
+                    err_msg = str(errors[0].get("message") or "").strip()
+                message = self._append_auth_diagnostics(
+                    f"Shopify GraphQL 인증/권한 오류. {err_msg}".strip()
+                )
+                return {
+                    "ok": False,
+                    "status": "scope_insufficient" if "access" in err_msg.lower() or "scope" in err_msg.lower() else "api_error",
+                    "http_status": response.status_code,
+                    "reason": err_msg or "GraphQL shop 조회 실패",
+                    "message": message,
+                }
+
+            plan = shop.get("plan") if isinstance(shop.get("plan"), dict) else {}
             return {
                 "ok": True,
                 "status": "connected",
-                "message": "Shopify 연결 확인 완료",
+                "message": "Shopify 연결 확인 완료 (GraphQL)",
                 "shop_name": str(shop.get("name") or "").strip(),
-                "shop_domain": str(shop.get("myshopify_domain") or self._shop_domain()).strip(),
-                "currency": str(shop.get("currency") or "").strip(),
-                "plan_name": str(shop.get("plan_name") or "").strip(),
-                "email": str(shop.get("email") or "").strip(),
-                "primary_locale": str(shop.get("primary_locale") or "").strip(),
+                "shop_domain": str(shop.get("myshopifyDomain") or self._shop_domain()).strip(),
+                "currency": str(shop.get("currencyCode") or "").strip(),
+                "plan_name": str(plan.get("displayName") or "").strip(),
             }
         except requests.RequestException:
             return {

--- a/tests/test_shopify_market_adapter_phase183.py
+++ b/tests/test_shopify_market_adapter_phase183.py
@@ -57,7 +57,7 @@ def test_access_token_prefers_auto_token_header(shopify_env, monkeypatch):
 
     monkeypatch.setenv("SHOPIFY_ACCESS_TOKEN", "shpat_legacy")
     session = Mock()
-    session.request.return_value = _mock_response(200, {"shop": {"name": "Phase184"}})
+    session.request.return_value = _mock_response(200, {"data": {"shop": {"name": "Phase184"}}})
 
     adapter = ShopifyAdapter(session=session, sleep_fn=lambda _: None)
     result = adapter.check_connection()
@@ -72,16 +72,17 @@ def test_check_connection_success(shopify_env):
     from src.markets.adapters.shopify import ShopifyAdapter
 
     session = Mock()
+    # GraphQL Admin API 응답 형식
     session.request.return_value = _mock_response(
         200,
         {
-            "shop": {
-                "name": "Catdyy",
-                "myshopify_domain": "phase183-test.myshopify.com",
-                "currency": "USD",
-                "plan_name": "development",
-                "email": "owner@example.com",
-                "primary_locale": "en-US",
+            "data": {
+                "shop": {
+                    "name": "Catdyy",
+                    "myshopifyDomain": "phase183-test.myshopify.com",
+                    "currencyCode": "USD",
+                    "plan": {"displayName": "Developer Preview"},
+                }
             }
         },
     )


### PR DESCRIPTION
## 원인 확정 (오너 화면 검증)
- 토큰: `atkn_` 앱 자동화 토큰 — 정상
- 앱 설치: `kohgane-uploader5`가 KOHGANE 상점에 설치됨 — 정상
- 상점 도메인: KOHGANE의 myshopify 도메인이 **바로 `catdyy-p0.myshopify.com`** — 정상
- 토큰 만료: 2026-11-29 — 정상

→ 전부 정상인데 **REST `/shop.json`이 401**. **신규 개발자 대시보드 앱은 REST Admin API가 막혀 GraphQL만 동작**하는 것이 원인.

## 변경
- `check_connection`을 **GraphQL Admin API**(`POST /graphql.json`, `{ shop { name myshopifyDomain currencyCode plan { displayName } } }`)로 전환.
- GraphQL `data.shop` 파싱(성공), `errors`/HTTP 인증실패 시 `scope_insufficient`/`api_error` + 진단(테스트 상점·토큰 접두사) 노출.
- 테스트를 GraphQL 응답 형식으로 갱신.

## 테스트
- 전체 **9872 passed, 0 failed**.

## 후속
- 업로드 경로(`upload_product`)도 신규 앱에선 GraphQL 필요할 수 있음 → 연결 확인 후 별도 점검.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_