### PR TITLE
feat: Shopify client_credentials grant (atkn_ → shpat_ 자동 발급)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,15 @@
 - **스마트스토어(네이버)**: 인증·서명 정상. 차단 원인 = **네이버 허용 IP(앱당 최대 3개)에 서버 IP 미등록**.
   bcrypt 전자서명(client_secret_sign) 필요(수정됨).
 - **11번가**: 997 "등록된 API 정보 없음" = 키/OpenAPI 승인 문제(IP 아님).
-- **Shopify** (검증된 팩트, 미해결):
-  - 토큰 `atkn_…` = 개발자 대시보드 '앱 자동화 토큰'. 앱 `kohgane-uploader5`가 상점 KOHGANE(`catdyy-p0.myshopify.com`)에 설치됨. scope에 read_products/write_products 포함. 토큰 만료 2026-11-29.
-  - **검증 결과**: 이 `atkn_` 토큰을 `X-Shopify-Access-Token`으로 REST(`/shop.json`)·GraphQL(`/graphql.json`) 둘 다 호출 시 **401 "Invalid API key or access token"**.
-  - **따라서**: 401은 스코프 문제 아님(스코프 정상). Shopify가 `atkn_` 토큰을 **상점 Admin API 액세스 토큰으로 인식하지 않음**.
-  - 다음 단계(미확정): 올바른 Admin API 액세스 토큰(보통 `shpat_`, in-admin Develop apps에서 발급) 확보 또는 atkn_ 토큰의 정식 사용법 확인. (이 환경은 egress 차단으로 Shopify 직접 호출/문서 접근 불가)
+- **Shopify** (해법 확정 — 오너 제공, 2026-06-14):
+  - `atkn_…`(앱 자동화 토큰)은 **Admin API 액세스 토큰으로 인식 안 됨** → 버린다.
+  - **해법**: 앱의 `SHOPIFY_CLIENT_ID`/`SHOPIFY_CLIENT_SECRET`(=암호 `shpss_…`)으로
+    `POST https://{shop}/admin/oauth/access_token` (grant_type=`client_credentials`) 호출 →
+    `shpat_…` 액세스 토큰 발급 → `X-Shopify-Access-Token`에 사용.
+  - 구현: `ShopifyAdapter.fetch_token_via_client_credentials()` (캐시), `_access_token()`이
+    client_id/secret 있으면 client_credentials 우선·없으면 직접 토큰 폴백. 연결확인은 GraphQL.
+  - 오너 액션: Render에 `SHOPIFY_CLIENT_ID`=`68aa23f3…`, `SHOPIFY_CLIENT_SECRET`=`shpss_…` 설정
+    (atkn_ SHOPIFY_AUTO_TOKEN은 없어도 됨).
 
 ## 🛠 인앱 마켓 연결 (셀프서비스)
 - `/seller/markets/connect`(+`/<market>` 단독) — 셀러별 Fernet 암호화 저장(`market_credentials.py`).

--- a/src/markets/adapters/shopify.py
+++ b/src/markets/adapters/shopify.py
@@ -11,6 +11,9 @@ import requests
 
 from .base import ListingPayload, ListingResult, MarketAdapter, OrderStatus
 
+# client_credentials grant로 발급한 Admin API 액세스 토큰 캐시: key "{shop}:{client_id}" -> {token, expires_at}
+_cc_token_cache: Dict[str, Dict[str, Any]] = {}
+
 
 class ShopifyAdapter(MarketAdapter):
     market = "shopify"
@@ -33,13 +36,72 @@ class ShopifyAdapter(MarketAdapter):
             raw = raw[len("http://"):]
         return raw.strip("/").lower()
 
-    def _access_token(self) -> str:
+    def _direct_token(self) -> str:
+        """환경변수에 직접 저장된 액세스 토큰(in-admin custom app shpat_ 등)."""
         return (
             os.getenv("SHOPIFY_AUTO_TOKEN")
             or os.getenv("SHOPIFY_ACCESS_TOKEN")
             or os.getenv("SHOPIFY_ADMIN_TOKEN")
             or ""
         ).strip()
+
+    def _client_credentials(self) -> Tuple[str, str]:
+        return (os.getenv("SHOPIFY_CLIENT_ID") or "").strip(), (os.getenv("SHOPIFY_CLIENT_SECRET") or "").strip()
+
+    def _has_client_credentials(self) -> bool:
+        cid, csec = self._client_credentials()
+        return bool(cid and csec and self._shop_domain())
+
+    def fetch_token_via_client_credentials(self) -> Optional[str]:
+        """client_credentials grant로 Admin API 액세스 토큰(shpat_) 발급.
+
+        개발자 대시보드 앱은 atkn_(앱 자동화 토큰)이 Admin API 액세스 토큰으로 인식되지 않으므로,
+        client_id/client_secret으로 POST /admin/oauth/access_token (grant_type=client_credentials)
+        하여 shpat_ 토큰을 받아 캐시한다.
+        """
+        cid, csec = self._client_credentials()
+        shop = self._shop_domain()
+        if not (cid and csec and shop):
+            return None
+        key = f"{shop}:{cid}"
+        now = time.time()
+        cached = _cc_token_cache.get(key)
+        if cached and cached.get("expires_at", 0) > now + 30:
+            return cached["token"]
+        try:
+            resp = self._session.post(
+                f"https://{shop}/admin/oauth/access_token",
+                json={"client_id": cid, "client_secret": csec, "grant_type": "client_credentials"},
+                timeout=float(os.getenv("SHOPIFY_TIMEOUT_SEC", "10") or 10),
+            )
+            if resp.status_code != 200:
+                return None
+            data = resp.json() if callable(getattr(resp, "json", None)) else {}
+            token = str((data or {}).get("access_token") or "").strip()
+            if not token:
+                return None
+            try:
+                ttl = float(data.get("expires_in")) if data.get("expires_in") else 3600.0
+            except (TypeError, ValueError):
+                ttl = 3600.0
+            _cc_token_cache[key] = {"token": token, "expires_at": now + ttl}
+            return token
+        except requests.RequestException:
+            return None
+        except Exception:
+            return None
+
+    def _access_token(self) -> str:
+        """실제 요청에 사용할 Admin API 액세스 토큰.
+
+        client_id/secret이 있으면 client_credentials grant로 받은 shpat_ 토큰을 우선 사용,
+        실패하거나 미설정이면 환경변수의 직접 토큰으로 폴백.
+        """
+        if self._has_client_credentials():
+            token = self.fetch_token_via_client_credentials()
+            if token:
+                return token
+        return self._direct_token()
 
     def _has_legacy_token(self) -> bool:
         return bool((os.getenv("SHOPIFY_ACCESS_TOKEN") or os.getenv("SHOPIFY_ADMIN_TOKEN") or "").strip())
@@ -48,15 +110,16 @@ class ShopifyAdapter(MarketAdapter):
         return (os.getenv("SHOPIFY_API_VERSION") or os.getenv("SHOPIFY_ADMIN_API_VERSION") or "2026-04").strip() or "2026-04"
 
     def is_configured(self) -> bool:
-        return bool(self._shop_domain()) and bool(self._access_token())
+        # 네트워크 없이 자격증명 존재 여부만 확인 (client_credentials 또는 직접 토큰).
+        return bool(self._shop_domain()) and (self._has_client_credentials() or bool(self._direct_token()))
 
     def _missing_config_env(self) -> list[str]:
         missing = []
         if not self._shop_domain():
             missing.append("SHOPIFY_SHOP")
-        auto_token = (os.getenv("SHOPIFY_AUTO_TOKEN") or "").strip()
-        if not auto_token and not self._has_legacy_token():
-            missing.append("SHOPIFY_AUTO_TOKEN")
+        # client_id+secret(권장) 또는 직접 토큰 중 하나가 있어야 함
+        if not self._has_client_credentials() and not self._direct_token():
+            missing.append("SHOPIFY_CLIENT_ID/SECRET 또는 SHOPIFY_AUTO_TOKEN")
         return missing
 
     def _base_url(self) -> str:
@@ -185,6 +248,18 @@ class ShopifyAdapter(MarketAdapter):
                 "missing_env": missing_env,
                 "required_env": ["SHOPIFY_CLIENT_ID", "SHOPIFY_CLIENT_SECRET", "SHOPIFY_AUTO_TOKEN", "SHOPIFY_API_VERSION", "SHOPIFY_SHOP"],
             }
+
+        # client_credentials grant 방식이면 토큰 발급부터 명확히 검증.
+        if self._has_client_credentials():
+            cc_token = self.fetch_token_via_client_credentials()
+            if not cc_token:
+                return {
+                    "ok": False,
+                    "status": "api_error",
+                    "message": ("client_credentials 토큰 발급 실패 — POST /admin/oauth/access_token이 거부됨."
+                                f" [상점: {self._shop_domain()}] SHOPIFY_CLIENT_ID/SECRET 값과 상점 도메인을 확인하세요"
+                                " (atkn_ 앱 자동화 토큰 대신 client_id/secret로 발급)."),
+                }
 
         try:
             # GraphQL Admin API 사용(신규 개발자대시보드 앱은 REST가 막혀 GraphQL만 동작).

--- a/src/seller_console/market_credentials.py
+++ b/src/seller_console/market_credentials.py
@@ -45,8 +45,9 @@ MARKET_CRED_FIELDS: Dict[str, List[Dict[str, Any]]] = {
     ],
     "shopify": [
         {"env": "SHOPIFY_SHOP", "label": "상점 도메인 (xxx.myshopify.com)", "secret": False, "required": True},
-        {"env": "SHOPIFY_AUTO_TOKEN", "label": "토큰 (앱 자동화 atkn_… 또는 shpat_…)", "secret": True, "required": True},
-        {"env": "SHOPIFY_CLIENT_SECRET", "label": "Client Secret (선택)", "secret": True, "required": False},
+        {"env": "SHOPIFY_CLIENT_ID", "label": "Client ID", "secret": False, "required": True},
+        {"env": "SHOPIFY_CLIENT_SECRET", "label": "Client Secret (shpss_…)", "secret": True, "required": True},
+        {"env": "SHOPIFY_AUTO_TOKEN", "label": "직접 토큰 (shpat_, 선택)", "secret": True, "required": False},
     ],
     "woocommerce": [
         {"env": "WC_URL", "label": "사이트 URL", "secret": False, "required": True},

--- a/src/seller_console/market_guide.py
+++ b/src/seller_console/market_guide.py
@@ -104,9 +104,10 @@ MARKET_GUIDE: List[Dict[str, Any]] = [
             {"env": "SHOPIFY_CLIENT_SECRET", "label": "Client Secret(선택)", "where": "shpss_… 웹훅 검증용(있으면 입력)"},
         ],
         "tips": [
+            "개발자 대시보드 앱은 ‘앱 자동화 토큰(atkn_)’이 Admin API에서 401납니다. 대신 Client ID/Secret을 넣으면 "
+            "시스템이 client_credentials로 shpat_ 토큰을 자동 발급해 사용합니다(권장).",
             "Shopify는 IP 허용목록이 없습니다 → 401은 IP가 아니라 토큰/상점 문제입니다.",
-            "유효 토큰: 앱 자동화 토큰(atkn_…) 또는 Admin API access token(shpat_…). Client secret(shpss_…)/API key는 토큰이 아닙니다.",
-            "토큰 형식이 맞는데도 401이면 → 그 앱이 ‘상점 도메인’의 상점에 설치돼 있는지, 도메인이 정확한지 확인하세요.",
+            "여전히 실패하면 → 그 앱이 ‘상점 도메인’의 상점에 설치돼 있는지, 도메인이 정확한지 확인하세요.",
         ],
     },
     {

--- a/src/seller_console/upload_dispatcher.py
+++ b/src/seller_console/upload_dispatcher.py
@@ -169,9 +169,10 @@ class UploadDispatcher:
         # Shopify: SHOPIFY_AUTO_TOKEN 또는 SHOPIFY_ACCESS_TOKEN 중 하나만 있어도 됨
         # (required_envs에는 SHOPIFY_SHOP만 있어서 토큰 별도 체크 필요)
         if market == "shopify":
-            has_token = bool(os.getenv("SHOPIFY_AUTO_TOKEN") or os.getenv("SHOPIFY_ACCESS_TOKEN"))
+            has_client_creds = bool(os.getenv("SHOPIFY_CLIENT_ID") and os.getenv("SHOPIFY_CLIENT_SECRET"))
+            has_token = bool(os.getenv("SHOPIFY_AUTO_TOKEN") or os.getenv("SHOPIFY_ACCESS_TOKEN") or has_client_creds)
             if not has_token:
-                missing.append("SHOPIFY_AUTO_TOKEN (또는 SHOPIFY_ACCESS_TOKEN)")
+                missing.append("SHOPIFY_CLIENT_ID/SECRET (또는 SHOPIFY_AUTO_TOKEN)")
 
         # 스마트스토어: NAVER_CLIENT_* 또는 NAVER_COMMERCE_CLIENT_* 어느 쪽이든 허용
         if market == "smartstore":

--- a/tests/test_shopify_market_adapter_phase183.py
+++ b/tests/test_shopify_market_adapter_phase183.py
@@ -68,6 +68,63 @@ def test_access_token_prefers_auto_token_header(shopify_env, monkeypatch):
     assert "2026-04" in args[1]
 
 
+def test_client_credentials_grant_and_connect(monkeypatch):
+    """atkn_ 대신 client_id/secret으로 shpat_ 발급 → 그 토큰으로 GraphQL 연결."""
+    from src.markets.adapters import shopify as shopify_mod
+    from src.markets.adapters.shopify import ShopifyAdapter
+
+    shopify_mod._cc_token_cache.clear()
+    monkeypatch.setenv("SHOPIFY_SHOP", "catdyy-p0.myshopify.com")
+    monkeypatch.setenv("SHOPIFY_CLIENT_ID", "68aa23f31fbb")
+    monkeypatch.setenv("SHOPIFY_CLIENT_SECRET", "shpss_secret")
+    monkeypatch.setenv("SHOPIFY_API_VERSION", "2026-04")
+    monkeypatch.delenv("SHOPIFY_AUTO_TOKEN", raising=False)
+    monkeypatch.delenv("SHOPIFY_ACCESS_TOKEN", raising=False)
+
+    session = Mock()
+    session.post.return_value = _mock_response(200, {"access_token": "shpat_minted", "expires_in": 3600})
+    session.request.return_value = _mock_response(
+        200,
+        {"data": {"shop": {"name": "KOHGANE", "myshopifyDomain": "catdyy-p0.myshopify.com",
+                           "currencyCode": "KRW", "plan": {"displayName": "Basic"}}}},
+    )
+
+    adapter = ShopifyAdapter(session=session, sleep_fn=lambda _: None)
+    result = adapter.check_connection()
+
+    assert result["ok"] is True
+    assert result["shop_name"] == "KOHGANE"
+    # grant가 client_credentials였고
+    assert session.post.call_args.kwargs["json"]["grant_type"] == "client_credentials"
+    assert "/admin/oauth/access_token" in session.post.call_args.args[0]
+    # GraphQL 호출 헤더에 발급된 shpat_ 토큰 사용
+    _, kwargs = session.request.call_args
+    assert kwargs["headers"]["X-Shopify-Access-Token"] == "shpat_minted"
+    shopify_mod._cc_token_cache.clear()
+
+
+def test_client_credentials_grant_failure(monkeypatch):
+    from src.markets.adapters import shopify as shopify_mod
+    from src.markets.adapters.shopify import ShopifyAdapter
+
+    shopify_mod._cc_token_cache.clear()
+    monkeypatch.setenv("SHOPIFY_SHOP", "catdyy-p0.myshopify.com")
+    monkeypatch.setenv("SHOPIFY_CLIENT_ID", "cid")
+    monkeypatch.setenv("SHOPIFY_CLIENT_SECRET", "shpss_bad")
+    monkeypatch.delenv("SHOPIFY_AUTO_TOKEN", raising=False)
+    monkeypatch.delenv("SHOPIFY_ACCESS_TOKEN", raising=False)
+
+    session = Mock()
+    session.post.return_value = _mock_response(401, {"error": "invalid_client"})
+
+    adapter = ShopifyAdapter(session=session, sleep_fn=lambda _: None)
+    result = adapter.check_connection()
+
+    assert result["ok"] is False
+    assert "client_credentials 토큰 발급 실패" in result["message"]
+    shopify_mod._cc_token_cache.clear()
+
+
 def test_check_connection_success(shopify_env):
     from src.markets.adapters.shopify import ShopifyAdapter
 


### PR DESCRIPTION
## 해법 (오너 제공 — 검증 일치)
`atkn_`(앱 자동화 토큰)은 Admin API 액세스 토큰으로 인식 안 됨(라이브 401 확인). 해법: 앱의 **client_id/client_secret**으로 `POST /admin/oauth/access_token` (grant_type=`client_credentials`) → **`shpat_` 발급** → `X-Shopify-Access-Token` 사용.

## 변경
- `ShopifyAdapter.fetch_token_via_client_credentials()` + 토큰 캐시.
- `_access_token()`: client_id/secret 있으면 client_credentials 우선, 없으면 직접 토큰 폴백.
- `is_configured`/`_missing_config_env`: 네트워크 없이 (client_id+secret OR 직접토큰) 존재 검증.
- `check_connection`: client_credentials 발급 실패를 명확히 보고. 연결확인은 GraphQL.
- 연결 화면 Shopify 필드에 **Client ID/Secret(필수)** 추가, 직접 토큰은 선택.
- 업로드 prevalidate도 client_id/secret 인정.
- CLAUDE.md/가이드에 해법 반영.

## 오너 액션
- Render(또는 연결 화면)에 `SHOPIFY_CLIENT_ID`=`68aa23f3…`, `SHOPIFY_CLIENT_SECRET`=`shpss_…` 설정. (atkn_ SHOPIFY_AUTO_TOKEN은 없어도 됨)

## 테스트
- 전체 **9874 passed, 0 failed** (client_credentials 발급·연결·실패 테스트 포함).

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_