### PR TITLE
fix: Shopify atkn_ 폴백 시 누락 CLIENT_ID/SECRET 명시

### DIFF
--- a/src/markets/adapters/shopify.py
+++ b/src/markets/adapters/shopify.py
@@ -231,9 +231,17 @@ class ShopifyAdapter(MarketAdapter):
         elif token and not token.startswith(valid_prefixes):
             message += " ⚠️ 토큰 종류 확인: Admin API access token(shpat_)이어야 합니다."
         elif token and token.startswith("atkn_"):
-            message += (" 사실: 이 토큰은 'atkn_'(앱 자동화 토큰)입니다. 401은 스코프 문제가 아니라 토큰 인증 거부 —"
-                        " Shopify가 이 토큰을 상점 Admin API 액세스 토큰으로 인식하지 않습니다."
-                        " Admin Develop apps에서 발급하는 'Admin API access token(shpat_)'을 사용하세요.")
+            cid, csec = self._client_credentials()
+            if not (cid and csec):
+                missing_cc = []
+                if not cid:
+                    missing_cc.append("SHOPIFY_CLIENT_ID")
+                if not csec:
+                    missing_cc.append("SHOPIFY_CLIENT_SECRET")
+                message += (f" 원인: {', '.join(missing_cc)} 미설정 → client_credentials 발급을 못 하고 atkn_로 폴백 중입니다."
+                            f" atkn_은 Admin API에서 거부됩니다. {', '.join(missing_cc)}를 설정하면 자동으로 shpat_를 발급해 연결됩니다.")
+            else:
+                message += " atkn_ 토큰 사용 중(client_credentials 발급 실패 가능) — CLIENT_ID/SECRET 값을 확인하세요."
         else:
             message += " 401은 스코프가 아니라 토큰 인증 거부입니다(Admin API access token이 맞는지/유효한지 확인)."
         return message


### PR DESCRIPTION
## 배경
오너 화면에 Shopify가 여전히 `토큰 접두사: atkn_`로 401. 팩트: 새 코드는 `SHOPIFY_CLIENT_ID`+`SHOPIFY_CLIENT_SECRET`이 둘 다 있을 때만 client_credentials로 shpat_ 발급. atkn_로 폴백 중 = 둘 중 하나가 미설정.

## 변경
- atkn_ 폴백 시, **누락된 변수(SHOPIFY_CLIENT_ID/SECRET)를 진단 메시지에 정확히 명시**. → 사용자가 무엇을 설정해야 하는지 즉시 확인.

## 오너 액션
- `SHOPIFY_CLIENT_ID`=`68aa23f31fbb4f50e50357c68d5e8008` 추가(원래 env 목록에 없었음).
- `SHOPIFY_CLIENT_SECRET`=`shpss_…`(대시보드 암호) 확인.

## 테스트
- 전체 **9874 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_