### PR TITLE
fix: Shopify atkn_ 건너뛰고 SHOPIFY_ACCESS_TOKEN 사용

### DIFF
--- a/src/markets/adapters/shopify.py
+++ b/src/markets/adapters/shopify.py
@@ -37,13 +37,16 @@ class ShopifyAdapter(MarketAdapter):
         return raw.strip("/").lower()
 
     def _direct_token(self) -> str:
-        """환경변수에 직접 저장된 액세스 토큰(in-admin custom app shpat_ 등)."""
-        return (
-            os.getenv("SHOPIFY_AUTO_TOKEN")
-            or os.getenv("SHOPIFY_ACCESS_TOKEN")
-            or os.getenv("SHOPIFY_ADMIN_TOKEN")
-            or ""
-        ).strip()
+        """환경변수에 직접 저장된 액세스 토큰.
+
+        atkn_(앱 자동화 토큰)은 Admin API에서 401로 거부되므로 직접 토큰으로 쓰지 않고 건너뛴다.
+        우선순위: SHOPIFY_AUTO_TOKEN → SHOPIFY_ACCESS_TOKEN → SHOPIFY_ADMIN_TOKEN.
+        """
+        for name in ("SHOPIFY_AUTO_TOKEN", "SHOPIFY_ACCESS_TOKEN", "SHOPIFY_ADMIN_TOKEN"):
+            val = (os.getenv(name) or "").strip()
+            if val and not val.startswith("atkn_"):
+                return val
+        return ""
 
     def _client_credentials(self) -> Tuple[str, str]:
         # Shopify에서 Client ID = API key. 명명 혼용을 흡수해 여러 이름을 허용한다.


### PR DESCRIPTION
## 원인 (오너 확인: SHOPIFY_ACCESS_TOKEN이 정확한 변수)
유효 토큰이 `SHOPIFY_ACCESS_TOKEN`에 있는데, 코드가 `SHOPIFY_AUTO_TOKEN`(atkn_)을 먼저 읽어 가려서 401.

## 변경
- `_direct_token()`: `atkn_`(앱 자동화 토큰)은 Admin API에서 거부되므로 **직접 토큰 후보에서 건너뜀**. AUTO_TOKEN이 atkn_이면 `SHOPIFY_ACCESS_TOKEN`(유효 토큰)을 사용.
- 우선순위 유지(AUTO_TOKEN→ACCESS_TOKEN→ADMIN_TOKEN), 단 atkn_만 스킵.

## 테스트
- 전체 **9874 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_