### PR TITLE
fix: Shopify client_id를 SHOPIFY_ACCESS_TOKEN에서도 읽기

### DIFF
--- a/src/markets/adapters/shopify.py
+++ b/src/markets/adapters/shopify.py
@@ -56,6 +56,12 @@ class ShopifyAdapter(MarketAdapter):
             or os.getenv("SHOPIFY_APIKEY")
             or ""
         ).strip()
+        if not client_id:
+            # 일부 설정은 client_id(=API key)를 SHOPIFY_ACCESS_TOKEN 변수에 보관한다.
+            # 값이 액세스 토큰 접두사(shpat_/shppa_/atkn_/shpca_)가 아니면 client_id로 간주.
+            acc = (os.getenv("SHOPIFY_ACCESS_TOKEN") or "").strip()
+            if acc and not acc.startswith(("shpat_", "shppa_", "atkn_", "shpca_")):
+                client_id = acc
         client_secret = (
             os.getenv("SHOPIFY_CLIENT_SECRET")
             or os.getenv("SHOPIFY_API_SECRET_KEY")


### PR DESCRIPTION
## 원인 (오너 화면: 토큰 접두사 68aa…)
`SHOPIFY_ACCESS_TOKEN`에 액세스 토큰이 아니라 **client_id 값(`68aa23f3…`)** 이 들어있음. 그걸 토큰으로 보내 401.

## 변경
- `_client_credentials`: `SHOPIFY_CLIENT_ID/API_KEY`가 없을 때, `SHOPIFY_ACCESS_TOKEN` 값이 **액세스 토큰 접두사(shpat_/shppa_/atkn_/shpca_)가 아니면 client_id로 간주**.
- 이 client_id(68aa…) + `SHOPIFY_CLIENT_SECRET`(shpss_)로 **client_credentials grant → shpat_ 발급 → GraphQL 연결**.
- 검증: grant client_id=68aa…, GraphQL 헤더=발급된 shpat_, status=connected.

## 테스트
- 전체 **9874 passed, 0 failed**.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_