### PR TITLE
feat: ③ 여러 URL 일괄 수집 + ④ 수집이력 일괄 마켓 업로드

### DIFF
--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -98,11 +98,18 @@
   {% if items %}
   <div class="card">
     <div class="card-body p-0">
+      <div class="d-flex flex-wrap align-items-center gap-2 p-2 border-bottom bg-light">
+        <span class="small text-muted">선택 <strong id="selCount">0</strong>개</span>
+        <button type="button" class="btn btn-success btn-sm" id="bulkUploadBtn" onclick="openBulkUploadModal()" disabled>
+          📤 선택 상품 일괄 마켓 등록
+        </button>
+      </div>
       <div class="table-responsive">
         <table class="table table-hover mb-0">
           <thead class="table-light">
             <tr>
-              <th class="ps-3">수집 시각</th>
+              <th class="ps-3"><input type="checkbox" id="chkAll" title="전체 선택" aria-label="전체 선택"></th>
+              <th>수집 시각</th>
               <th>경로</th>
               <th>도메인</th>
               <th>제목</th>
@@ -114,7 +121,8 @@
           <tbody>
           {% for it in items %}
             <tr>
-              <td class="ps-3 text-muted small">{{ it.collected_at[:16] if it.collected_at else "-" }}</td>
+              <td class="ps-3"><input type="checkbox" class="row-chk" value="{{ it.id }}" data-title="{{ it.title or '(제목 없음)' }}" aria-label="선택"></td>
+              <td class="text-muted small">{{ it.collected_at[:16] if it.collected_at else "-" }}</td>
               <td>
                 {% if it.source in ("extension", "chrome_extension") %}
                   <span class="badge bg-primary">확장</span>
@@ -169,4 +177,96 @@
   </div>
   {% endif %}
 </div>
+
+<!-- 일괄 업로드 모달 -->
+<div class="modal fade" id="bulkUploadModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">선택 상품 일괄 마켓 등록</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted">선택한 <strong id="modalSelCount">0</strong>개 상품을 아래 마켓에 등록합니다.</p>
+        <div class="mb-3">
+          <div class="fw-semibold small mb-1">등록 마켓</div>
+          {% for m in upload_markets %}
+          <div class="form-check form-check-inline">
+            <input class="form-check-input bulk-market-chk" type="checkbox" id="bm_{{ m.code }}" value="{{ m.code }}">
+            <label class="form-check-label" for="bm_{{ m.code }}">{{ m.label }}</label>
+          </div>
+          {% endfor %}
+        </div>
+        <div class="mb-2">
+          <label class="form-label small mb-1">목표 마진율 (%)</label>
+          <input type="number" id="bulkMargin" class="form-control form-control-sm" value="22" min="0" max="90" step="1">
+        </div>
+        <div id="bulkUploadResult" class="small mt-2 d-none"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">닫기</button>
+        <button type="button" class="btn btn-success" id="bulkUploadConfirm" onclick="runBulkUpload()">📤 등록 실행</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+function selectedItemIds() {
+  return Array.from(document.querySelectorAll('.row-chk:checked')).map(c => c.value);
+}
+function refreshSelCount() {
+  const n = selectedItemIds().length;
+  const el = document.getElementById('selCount');
+  if (el) el.textContent = n;
+  const btn = document.getElementById('bulkUploadBtn');
+  if (btn) btn.disabled = n === 0;
+}
+document.addEventListener('DOMContentLoaded', function () {
+  const all = document.getElementById('chkAll');
+  if (all) all.addEventListener('change', () => {
+    document.querySelectorAll('.row-chk').forEach(c => { c.checked = all.checked; });
+    refreshSelCount();
+  });
+  document.querySelectorAll('.row-chk').forEach(c => c.addEventListener('change', refreshSelCount));
+});
+function openBulkUploadModal() {
+  const ids = selectedItemIds();
+  if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }
+  document.getElementById('modalSelCount').textContent = ids.length;
+  document.getElementById('bulkUploadResult').classList.add('d-none');
+  new bootstrap.Modal(document.getElementById('bulkUploadModal')).show();
+}
+async function runBulkUpload() {
+  const ids = selectedItemIds();
+  const markets = Array.from(document.querySelectorAll('.bulk-market-chk:checked')).map(c => c.value);
+  if (!markets.length) { pcToast('등록할 마켓을 선택하세요.', 'warning'); return; }
+  const margin = parseFloat(document.getElementById('bulkMargin').value) || null;
+  const btn = document.getElementById('bulkUploadConfirm');
+  setButtonLoading(btn, true, '등록 중…');
+  const box = document.getElementById('bulkUploadResult');
+  try {
+    const resp = await fetch('/seller/collect/bulk-upload', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({item_ids: ids, markets: markets, target_margin_pct: margin}),
+    });
+    const data = await resp.json();
+    if (!data.ok) { pcToast(data.error || '일괄 업로드 실패', 'error'); return; }
+    let html = `<div class="alert alert-info py-2">전체 ${data.total}개 · 성공 <strong>${data.succeeded}</strong> · 실패 ${data.total - data.succeeded}</div><ul class="list-group">`;
+    (data.results || []).forEach(r => {
+      const cls = r.ok ? 'list-group-item-success' : 'list-group-item-warning';
+      const icon = r.ok ? '✅' : '⚠️';
+      html += `<li class="list-group-item ${cls}"><span>${icon} ${(r.title || r.id)}</span></li>`;
+    });
+    html += '</ul>';
+    box.innerHTML = html;
+    box.classList.remove('d-none');
+    pcToast(`${data.succeeded}/${data.total}개 마켓 등록 완료`, 'success');
+  } catch (err) {
+    pcToast('일괄 업로드 요청 실패: ' + err.message, 'error');
+  } finally {
+    setButtonLoading(btn, false);
+  }
+}
+</script>
 {% endblock %}

--- a/src/seller_console/templates/manual_collect.html
+++ b/src/seller_console/templates/manual_collect.html
@@ -36,6 +36,23 @@
   </div>
 </div>
 
+<!-- 여러 URL 일괄 수집 -->
+<div class="card console-card mb-3">
+  <div class="card-body">
+    <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+      <label for="bulkUrls" class="form-label fw-semibold mb-0">📥 여러 URL 한 번에 수집</label>
+      <span class="small text-muted">한 줄에 하나씩 · 최대 30개</span>
+    </div>
+    <textarea id="bulkUrls" class="form-control" rows="4"
+      placeholder="https://www.amazon.com/dp/...&#10;https://item.taobao.com/...&#10;https://detail.1688.com/..."></textarea>
+    <div class="d-flex gap-2 mt-2">
+      <button class="btn btn-primary" id="bulkCollectBtn" onclick="bulkCollect()">일괄 수집 → 이력 저장</button>
+      <a href="/seller/collect/history" class="btn btn-outline-secondary">수집 이력 보기</a>
+    </div>
+    <div id="bulkResult" class="small mt-3 d-none"></div>
+  </div>
+</div>
+
 <div id="loadingSpinner" class="text-center py-4 d-none" aria-live="polite">
   <div class="spinner-border text-primary" role="status"></div>
   <div class="mt-2 text-muted">상품 정보를 수집하고 있습니다...</div>
@@ -174,6 +191,43 @@ function setLoading(flag) {
   document.getElementById('loadingSpinner').classList.toggle('d-none', !flag);
   document.getElementById('extractBtn').disabled = flag;
   document.getElementById('extractBtn').textContent = flag ? '수집 중...' : '미리보기';
+}
+
+async function bulkCollect() {
+  const raw = document.getElementById('bulkUrls').value.trim();
+  if (!raw) { showToast('안내', 'URL을 한 줄에 하나씩 입력하세요.', 'danger'); return; }
+  const btn = document.getElementById('bulkCollectBtn');
+  const box = document.getElementById('bulkResult');
+  const orig = btn.innerHTML;
+  btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>수집 중…';
+  box.classList.add('d-none');
+  try {
+    const resp = await fetch('/seller/collect/bulk', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({urls: raw}),
+    });
+    const data = await resp.json();
+    if (!data.ok) { showToast('오류', data.error || '일괄 수집 실패', 'danger'); return; }
+    let html = `<div class="alert alert-info py-2">전체 ${data.total}개 · 성공 <strong>${data.success}</strong> · 실패 ${data.total - data.success}</div>`;
+    html += '<ul class="list-group">';
+    (data.results || []).forEach(r => {
+      if (r.ok) {
+        html += `<li class="list-group-item list-group-item-success d-flex justify-content-between align-items-center">
+          <span>✅ ${escapeHtml(r.title)}</span>
+          <a href="${r.preview_url}" class="btn btn-sm btn-success py-0">📤 미리보기·등록</a></li>`;
+      } else {
+        html += `<li class="list-group-item list-group-item-warning"><span class="small">⚠️ ${escapeHtml(r.url)} — ${escapeHtml(r.error || '실패')}</span></li>`;
+      }
+    });
+    html += '</ul>';
+    box.innerHTML = html;
+    box.classList.remove('d-none');
+    showToast('일괄 수집 완료', `${data.success}개 수집됨 → 수집 이력/아래에서 등록하세요.`);
+  } catch (err) {
+    showToast('오류', '일괄 수집 요청 실패: ' + err.message, 'danger');
+  } finally {
+    btn.disabled = false; btn.innerHTML = orig;
+  }
 }
 
 function extractProduct() {

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1234,6 +1234,74 @@ def collect_bulk():
     return jsonify({"ok": True, "total": len(urls), "success": success, "results": results})
 
 
+@bp.post("/collect/bulk-upload")
+def collect_bulk_upload():
+    """수집 이력의 여러 상품을 선택해 여러 마켓에 일괄 등록 (④ 일괄 업로드).
+
+    Request: {"item_ids": [...], "markets": [...], "target_margin_pct"?: float}
+    Response: {"ok": true, "total": N, "succeeded": M, "results": [{id, title, ok, result}]}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids") if isinstance(data.get("item_ids"), list) else []
+    item_ids = [str(i) for i in item_ids if str(i).strip()][:50]
+    markets = data.get("markets") if isinstance(data.get("markets"), list) else []
+    markets = [str(m).strip() for m in markets if str(m).strip()]
+    if not item_ids:
+        return jsonify({"ok": False, "error": "등록할 상품을 선택하세요."}), 400
+    if not markets:
+        return jsonify({"ok": False, "error": "등록할 마켓을 선택하세요."}), 400
+
+    target_margin_pct = data.get("target_margin_pct")
+
+    dispatcher = _get_upload_dispatcher()
+    if dispatcher is None:
+        return jsonify({"ok": False, "error": "업로드 디스패처 준비 중입니다."}), 503
+
+    import json as _json
+    from . import collect_history_store
+    from . import market_credentials as mc
+
+    results = []
+    succeeded = 0
+    try:
+        with mc.seller_market_env(_seller_id(), markets):
+            for item_id in item_ids:
+                item = collect_history_store.get(item_id)
+                if not item:
+                    results.append({"id": item_id, "ok": False, "error": "수집 항목을 찾을 수 없습니다."})
+                    continue
+                try:
+                    product = _json.loads(item.get("extra_json") or "{}")
+                except (TypeError, ValueError):
+                    product = {}
+                if not product:
+                    product = {"title": item.get("title"), "url": item.get("url"),
+                               "price": item.get("price"), "currency": item.get("currency")}
+                if target_margin_pct is not None:
+                    try:
+                        product["target_margin_pct"] = float(target_margin_pct)
+                    except (TypeError, ValueError):
+                        pass
+                dispatch_result = dispatcher.dispatch(product, markets)
+                ok = dispatch_result.succeeded > 0
+                if ok:
+                    succeeded += 1
+                results.append({
+                    "id": item_id,
+                    "title": item.get("title") or product.get("title") or "(제목 없음)",
+                    "ok": ok,
+                    "result": dispatch_result.to_dict(),
+                })
+    except Exception as exc:
+        logger.warning("일괄 업로드 오류: %s", exc)
+        return jsonify({"ok": False, "error": "일괄 업로드 중 오류가 발생했습니다."}), 500
+
+    return jsonify({"ok": True, "total": len(item_ids), "succeeded": succeeded, "results": results})
+
+
 @bp.get("/catalog")
 def catalog():
     """상품 카탈로그 페이지 (Phase 128) — Sheets catalog 워크시트 뷰."""
@@ -3572,6 +3640,8 @@ def collect_history():
     except Exception as exc:
         logger.warning("수집 이력 조회 실패: %s", exc)
 
+    from .upload_dispatcher import MARKET_LABELS, SUPPORTED_MARKETS
+    upload_markets = [{"code": m, "label": MARKET_LABELS.get(m, m)} for m in SUPPORTED_MARKETS]
     return render_template(
         "collect_history.html",
         page="collect_history",
@@ -3579,6 +3649,7 @@ def collect_history():
         summary=summ,
         domains=domains,
         filters={"domain": domain, "source": source, "days": days},
+        upload_markets=upload_markets,
     )
 
 

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1172,6 +1172,68 @@ def collect_save():
         return jsonify({"ok": False, "error": "저장 중 오류가 발생했습니다."}), 500
 
 
+@bp.post("/collect/bulk")
+def collect_bulk():
+    """여러 소싱처 URL을 한 번에 수집해 수집 이력에 저장 (③ 일괄 수집).
+
+    Request: {"urls": "url1\nurl2..." 또는 ["url1", "url2"]}
+    Response: {"ok": true, "total": N, "success": M, "results": [{url, ok, title?, preview_url?, error?}]}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+
+    data = request.get_json(force=True, silent=True) or {}
+    raw = data.get("urls")
+    if isinstance(raw, str):
+        urls = [u.strip() for u in raw.splitlines() if u.strip()]
+    elif isinstance(raw, list):
+        urls = [str(u).strip() for u in raw if str(u).strip()]
+    else:
+        urls = []
+    # 중복 제거(순서 유지) + 상한
+    seen = set()
+    urls = [u for u in urls if not (u in seen or seen.add(u))][:30]
+    if not urls:
+        return jsonify({"ok": False, "error": "수집할 URL을 한 줄에 하나씩 입력하세요."}), 400
+
+    service = _get_collector_service()
+    if service is None:
+        return jsonify({"ok": False, "error": "수집기 준비 중입니다."}), 503
+
+    from . import collect_history_store
+
+    results = []
+    success = 0
+    for url in urls:
+        if not (url.startswith("http://") or url.startswith("https://")):
+            results.append({"url": url, "ok": False, "error": "http/https URL이 아닙니다."})
+            continue
+        try:
+            draft = service.extract(url)
+            d = draft.to_dict()
+            title = d.get("title_ko") or d.get("title_en") or "(제목 없음)"
+            images = d.get("images") if isinstance(d.get("images"), list) else []
+            item_id = collect_history_store.append(
+                source="bulk",
+                url=url,
+                title=title,
+                image=images[0] if images else "",
+                price=str(d.get("price_original") or ""),
+                currency=d.get("currency") or "",
+                extra=d,
+            )
+            results.append({
+                "url": url, "ok": True, "title": title,
+                "id": item_id, "preview_url": f"/seller/collect/preview/{item_id}",
+            })
+            success += 1
+        except Exception as exc:
+            logger.warning("벌크 수집 실패 (%s): %s", url, exc)
+            results.append({"url": url, "ok": False, "error": "수집 실패 (URL/소싱처 확인)"})
+
+    return jsonify({"ok": True, "total": len(urls), "success": success, "results": results})
+
+
 @bp.get("/catalog")
 def catalog():
     """상품 카탈로그 페이지 (Phase 128) — Sheets catalog 워크시트 뷰."""

--- a/tests/test_collect_bulk.py
+++ b/tests/test_collect_bulk.py
@@ -76,3 +76,51 @@ def test_bulk_per_url_error_isolated(client):
     data = resp.get_json()
     assert data["success"] == 1
     assert data["total"] == 2
+
+
+# ─── ④ 일괄 업로드 ────────────────────────────────────────────────────────────
+
+def test_bulk_upload_requires_items_and_markets(client):
+    assert client.post("/seller/collect/bulk-upload", json={"item_ids": [], "markets": ["shopify"]}).status_code == 400
+    assert client.post("/seller/collect/bulk-upload", json={"item_ids": ["a"], "markets": []}).status_code == 400
+
+
+def test_bulk_upload_dispatches_per_item(client):
+    disp = MagicMock()
+    dr = MagicMock()
+    dr.succeeded = 1
+    dr.to_dict.return_value = {"succeeded": 1, "failed": 0, "results": []}
+    disp.dispatch.return_value = dr
+    item = {"title": "샘플", "extra_json": '{"title":"샘플","sell_price_krw":19900}'}
+    with patch("src.seller_console.views._get_upload_dispatcher", return_value=disp), \
+         patch("src.seller_console.collect_history_store.get", return_value=item):
+        resp = client.post("/seller/collect/bulk-upload", json={
+            "item_ids": ["id1", "id2"], "markets": ["shopify", "coupang"], "target_margin_pct": 25})
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["total"] == 2
+    assert data["succeeded"] == 2
+    assert disp.dispatch.call_count == 2
+    # 마진율이 product에 주입됐는지
+    called_product = disp.dispatch.call_args.args[0]
+    assert called_product.get("target_margin_pct") == 25.0
+
+
+def test_bulk_upload_missing_item_isolated(client):
+    disp = MagicMock()
+    dr = MagicMock()
+    dr.succeeded = 1
+    dr.to_dict.return_value = {"succeeded": 1}
+    disp.dispatch.return_value = dr
+
+    def _get(item_id):
+        return None if item_id == "missing" else {"title": "ok", "extra_json": "{}"}
+    with patch("src.seller_console.views._get_upload_dispatcher", return_value=disp), \
+         patch("src.seller_console.collect_history_store.get", side_effect=_get):
+        resp = client.post("/seller/collect/bulk-upload", json={
+            "item_ids": ["good", "missing"], "markets": ["shopify"]})
+    data = resp.get_json()
+    assert data["total"] == 2
+    assert data["succeeded"] == 1
+    by_ok = {r["ok"] for r in data["results"]}
+    assert False in by_ok and True in by_ok

--- a/tests/test_collect_bulk.py
+++ b/tests/test_collect_bulk.py
@@ -1,0 +1,78 @@
+"""tests/test_collect_bulk.py — 여러 URL 일괄 수집(③) 검증."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _fake_draft(title="샘플", url="https://x"):
+    d = MagicMock()
+    d.to_dict.return_value = {
+        "title_ko": title, "title_en": title, "price_original": 19.9,
+        "currency": "USD", "images": ["https://img/1.jpg"], "url": url,
+    }
+    return d
+
+
+def test_bulk_empty_returns_400(client):
+    resp = client.post("/seller/collect/bulk", json={"urls": ""})
+    assert resp.status_code == 400
+
+
+def test_bulk_collects_and_saves_to_history(client):
+    svc = MagicMock()
+    svc.extract.side_effect = lambda url: _fake_draft(url=url)
+    with patch("src.seller_console.views._get_collector_service", return_value=svc), \
+         patch("src.seller_console.collect_history_store.append", return_value="abc123") as mock_append:
+        resp = client.post("/seller/collect/bulk", json={
+            "urls": "https://www.amazon.com/dp/B1\nhttps://item.taobao.com/2"})
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["total"] == 2
+    assert data["success"] == 2
+    assert all(r["ok"] and r["preview_url"] for r in data["results"])
+    assert mock_append.call_count == 2
+
+
+def test_bulk_rejects_non_http_and_dedupes(client):
+    svc = MagicMock()
+    svc.extract.side_effect = lambda url: _fake_draft(url=url)
+    with patch("src.seller_console.views._get_collector_service", return_value=svc), \
+         patch("src.seller_console.collect_history_store.append", return_value="x"):
+        resp = client.post("/seller/collect/bulk", json={
+            "urls": "ftp://bad\nhttps://ok.com/a\nhttps://ok.com/a"})  # 비http + 중복
+    data = resp.get_json()
+    # 중복 제거 → 2개(ftp, ok), ftp는 실패
+    assert data["total"] == 2
+    by_ok = {r["ok"] for r in data["results"]}
+    assert False in by_ok and True in by_ok
+
+
+def test_bulk_per_url_error_isolated(client):
+    svc = MagicMock()
+
+    def _extract(url):
+        if "bad" in url:
+            raise RuntimeError("extract fail")
+        return _fake_draft(url=url)
+    svc.extract.side_effect = _extract
+    with patch("src.seller_console.views._get_collector_service", return_value=svc), \
+         patch("src.seller_console.collect_history_store.append", return_value="x"):
+        resp = client.post("/seller/collect/bulk", json={
+            "urls": "https://good.com/1\nhttps://bad.com/2"})
+    data = resp.get_json()
+    assert data["success"] == 1
+    assert data["total"] == 2


### PR DESCRIPTION
## ③ 여러 URL 일괄 수집
- `POST /seller/collect/bulk`: URL 여러 개(한 줄 하나, 최대 30, 중복제거) → 각 추출 → 수집 이력 저장. 항목 에러 격리.
- `/seller/collect`에 "📥 여러 URL 한 번에 수집" 카드(textarea + 결과별 미리보기·등록 링크).

## ④ 수집 이력에서 일괄 마켓 업로드
- `POST /seller/collect/bulk-upload`: 선택 item_ids × markets, 셀러 자격증명 주입 후 각 상품을 UploadDispatcher로 등록(마진 반영, 에러 격리).
- 수집 이력: 행 체크박스 + 전체선택 + "📤 선택 상품 일괄 마켓 등록" 툴바 + 마켓/마진 모달 + 결과.

## 테스트
- 전체 **9883 passed, 0 failed** (bulk collect/upload 7개 신규).

이로써 오너 요청 4종(①버튼 ②업로드 ③일괄수집 ④일괄업로드) 완료.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_