### PR TITLE
feat(orders): Shopify 주문수집·배송추적 실연동 (Phase 206)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,18 @@
      편집 페이지(④) 즉시 프리필. `translate:false`로 끌 수 있음. 이력 상위 title=한국어.
    - manifest 1.0.0→1.1.0. README 사용법(방법3) 추가.
 
+## 🚀 로드맵 소진 후 — 후속 작업 (오너 지시 2026-06-16, "1,2,3 순서대로 가라")
+번호 로드맵(멀티유저 1~5) 전부 완료 후 후속 3건을 순서대로 진행:
+1. ✅ **Shopify 주문수집 + 배송추적** (완료, Phase 206): Shopify는 업로드만 됐고 주문/배송 미연동이었음.
+   - `seller_console/market_adapters/shopify_adapter.py`에 `fetch_orders`/`fetch_orders_unified`(GraphQL
+     orders 커서 페이지네이션 → 통합 주문 dict, 구매자 마스킹) + `update_tracking`(fulfillmentOrders 조회
+     → `fulfillmentCreateV2`) 추가. 토큰은 검증된 client_credentials 경로 재사용(markets 어댑터에 공개
+     `graphql()` 추가). `OrderSyncService.adapters`에 `"shopify"` 등록 → 4개 마켓처럼 풀 펀넬.
+   - 정직성: GraphQL errors/userErrors/HTTP 오류·미설정 시 거짓 성공 금지(빈 리스트/False). dry-run 안전.
+   - 오너 액션: 없음(Shopify는 이미 연결됨). 단 read_orders/write_fulfillments 스코프 필요할 수 있음.
+2. ⏳ **이미지 처리 실구현** (현재 stub) — 진행 예정.
+3. ⏳ **신규 마켓 자동발행** — 일부 오너측 마켓 승인/IP 필요 — 진행 예정.
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/src/markets/adapters/shopify.py
+++ b/src/markets/adapters/shopify.py
@@ -198,6 +198,17 @@ class ShopifyAdapter(MarketAdapter):
             return response
         raise RuntimeError("Shopify request retry limit exhausted")
 
+    def graphql(self, query: str, variables: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """GraphQL Admin API 호출 (검증된 토큰·재시도 로직 재사용).
+
+        신규 개발자대시보드 앱은 REST가 막혀 GraphQL만 동작하므로, 주문수집/배송추적 등
+        다른 모듈이 같은 토큰 발급(client_credentials)·재시도를 재사용하도록 공개 메서드로 제공한다.
+        """
+        body: Dict[str, Any] = {"query": query}
+        if variables is not None:
+            body["variables"] = variables
+        return self._request_with_retry("POST", "/graphql.json", json_body=body)
+
     @staticmethod
     def _locale_region(locale: str, country: str) -> str:
         normalized = (locale or "").strip()

--- a/src/seller_console/market_adapters/shopify_adapter.py
+++ b/src/seller_console/market_adapters/shopify_adapter.py
@@ -1,10 +1,13 @@
-"""src/seller_console/market_adapters/shopify_adapter.py — Shopify 자체몰 어댑터 (Phase 130).
+"""src/seller_console/market_adapters/shopify_adapter.py — Shopify 자체몰 어댑터 (Phase 130, 주문수집·배송추적 Phase 206).
 
-Admin API 2024-04 연동. 키 미설정 시 stub 모드.
-ADAPTER_DRY_RUN=1 시 실 API 호출 차단.
+키 미설정 시 stub 모드. ADAPTER_DRY_RUN=1 시 실 API 호출 차단.
+
+주문수집/배송추적은 검증된 토큰 발급(client_credentials → shpat_)과 GraphQL Admin API를
+재사용한다(`src/markets/adapters/shopify.py`). 신규 개발자대시보드 앱은 REST가 막혀 GraphQL만 동작.
 
 환경변수:
-  SHOPIFY_AUTO_TOKEN    — Admin API 앱 자동화 토큰(atk_)
+  SHOPIFY_CLIENT_ID / SHOPIFY_CLIENT_SECRET — client_credentials 발급(권장, 주문/배송에 사용)
+  SHOPIFY_AUTO_TOKEN    — Admin API 앱 자동화 토큰(레거시 인벤토리/업로드 경로)
   SHOPIFY_ACCESS_TOKEN  — 하위호환 토큰
   SHOPIFY_SHOP          — 숍 도메인 (예: myshop.myshopify.com)
 """
@@ -12,7 +15,8 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import List
+from datetime import datetime
+from typing import List, Optional
 
 from src.seller_console.market_status import MarketStatusItem
 from .base import MarketAdapter
@@ -35,6 +39,27 @@ def _base_url() -> str:
     shop = os.getenv("SHOPIFY_SHOP", "")
     api_version = os.getenv("SHOPIFY_API_VERSION", "2026-04")
     return f"https://{shop}/admin/api/{api_version}"
+
+
+def _mask_name(name: str) -> str:
+    """이름 마스킹 (첫 글자만 공개)."""
+    if not name:
+        return ""
+    return name[0] + "*" * max(len(name) - 1, 0)
+
+
+def _mask_phone(phone: str) -> str:
+    """전화번호 마스킹 (뒤 4자리 마스킹)."""
+    if not phone:
+        return ""
+    if len(phone) > 4:
+        return phone[:-4] + "****"
+    return "****"
+
+
+def _gid_tail(gid: str) -> str:
+    """gid://shopify/Order/12345 → '12345'."""
+    return str(gid or "").rsplit("/", 1)[-1]
 
 
 class ShopifyAdapter(MarketAdapter):
@@ -116,6 +141,233 @@ class ShopifyAdapter(MarketAdapter):
         except Exception as exc:
             logger.warning("Shopify upload_product 실패: %s", exc)
             return {"status": "error", "detail": str(exc)}
+
+    # ------------------------------------------------------------------
+    # 주문수집 · 배송추적 (Phase 206) — GraphQL Admin API + client_credentials
+    # ------------------------------------------------------------------
+    def _market(self):
+        """검증된 토큰 발급·GraphQL 실행을 담당하는 markets 어댑터 인스턴스."""
+        if getattr(self, "_market_adapter", None) is None:
+            from src.markets.adapters.shopify import ShopifyAdapter as _MarketShopify
+            self._market_adapter = _MarketShopify()
+        return self._market_adapter
+
+    def _orders_configured(self) -> bool:
+        """주문/배송용 자격증명 존재 여부(client_credentials 또는 직접 토큰)."""
+        try:
+            return bool(self._market().is_configured())
+        except Exception:
+            return False
+
+    def fetch_orders(self, since: Optional[datetime] = None) -> list:
+        """Shopify 주문 목록 조회 (GraphQL, 커서 페이지네이션).
+
+        Args:
+            since: 이 시각 이후 생성 주문만 조회 (None이면 마켓 기본)
+
+        Returns:
+            통합 주문 dict 리스트 (자격증명 미설정·dry-run·실패 시 빈 리스트)
+        """
+        if not self._orders_configured():
+            logger.warning("Shopify 자격증명 미설정 — fetch_orders stub")
+            return []
+        if _dry_run():
+            logger.info("ADAPTER_DRY_RUN=1 — Shopify fetch_orders dry-run")
+            return []
+
+        search = ""
+        if since is not None:
+            try:
+                search = f"created_at:>={since.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+            except Exception:
+                search = ""
+
+        query = """
+        query($q: String, $after: String) {
+          orders(first: 50, after: $after, query: $q, sortKey: CREATED_AT) {
+            edges {
+              node {
+                id name createdAt processedAt cancelledAt
+                displayFinancialStatus displayFulfillmentStatus
+                totalPriceSet { shopMoney { amount currencyCode } }
+                totalShippingPriceSet { shopMoney { amount } }
+                customer { firstName lastName }
+                shippingAddress { phone city }
+                lineItems(first: 50) {
+                  edges { node { sku title quantity originalUnitPriceSet { shopMoney { amount } } } }
+                }
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        """
+        orders: list = []
+        after: Optional[str] = None
+        try:
+            for _ in range(20):  # 최대 1000건 안전 캡
+                resp = self._market().graphql(query, {"q": search or None, "after": after})
+                if not (200 <= resp.status_code < 300):
+                    logger.warning("Shopify fetch_orders HTTP %s", resp.status_code)
+                    break
+                body = resp.json() if callable(getattr(resp, "json", None)) else {}
+                if body.get("errors"):
+                    logger.warning("Shopify fetch_orders GraphQL 오류: %s", body["errors"])
+                    break
+                conn = ((body.get("data") or {}).get("orders") or {})
+                for edge in conn.get("edges") or []:
+                    node = edge.get("node") or {}
+                    orders.append(self._shopify_order_to_unified(node))
+                page = conn.get("pageInfo") or {}
+                if not page.get("hasNextPage"):
+                    break
+                after = page.get("endCursor")
+                if not after:
+                    break
+            return orders
+        except Exception as exc:
+            logger.warning("Shopify fetch_orders 실패: %s", exc)
+            return orders
+
+    def fetch_orders_unified(self, since=None, until=None) -> list:
+        """OrderSyncService 호환 메서드 — fetch_orders() 위임."""
+        return self.fetch_orders(since=since)
+
+    def _shopify_order_to_unified(self, node: dict) -> dict:
+        """Shopify GraphQL 주문 노드 → 통합 주문 dict 변환."""
+        total = (((node.get("totalPriceSet") or {}).get("shopMoney")) or {})
+        shipping = (((node.get("totalShippingPriceSet") or {}).get("shopMoney")) or {})
+        customer = node.get("customer") or {}
+        full_name = ((customer.get("firstName") or "") + (customer.get("lastName") or "")).strip()
+        ship_addr = node.get("shippingAddress") or {}
+
+        items = []
+        for edge in ((node.get("lineItems") or {}).get("edges") or []):
+            li = edge.get("node") or {}
+            unit = (((li.get("originalUnitPriceSet") or {}).get("shopMoney")) or {})
+            items.append({
+                "sku": li.get("sku") or "",
+                "title": li.get("title", ""),
+                "qty": li.get("quantity", 1),
+                "unit_price_krw": unit.get("amount") if unit.get("amount") is not None else "0",
+            })
+
+        return {
+            "order_id": _gid_tail(node.get("id", "")),
+            "marketplace": "shopify",
+            "status": self._map_order_status(
+                str(node.get("displayFinancialStatus") or ""),
+                str(node.get("displayFulfillmentStatus") or ""),
+                bool(node.get("cancelledAt")),
+            ),
+            "placed_at": node.get("createdAt", ""),
+            "paid_at": node.get("processedAt", "") or "",
+            "buyer_name_masked": _mask_name(full_name),
+            "buyer_phone_masked": _mask_phone(ship_addr.get("phone", "") or ""),
+            "buyer_address_masked": ship_addr.get("city", "") or "",
+            "total_krw": total.get("amount", "0") if total.get("amount") is not None else "0",
+            "shipping_fee_krw": shipping.get("amount", "0") if shipping.get("amount") is not None else "0",
+            "order_name": node.get("name", ""),
+            "currency": total.get("currencyCode", "") or "",
+            "items": items,
+            "raw": node,
+        }
+
+    def _map_order_status(self, financial: str, fulfillment: str, cancelled: bool) -> str:
+        """Shopify 재무/배송 상태 → 통합 상태 매핑."""
+        if cancelled:
+            return "canceled"
+        fin = (financial or "").upper()
+        ful = (fulfillment or "").upper()
+        if fin in ("REFUNDED", "PARTIALLY_REFUNDED"):
+            return "returned"
+        if ful == "FULFILLED":
+            return "delivered"
+        if fin == "PAID":
+            return "paid"
+        return "new"
+
+    def update_tracking(self, order_id: str, courier: str = "", tracking_no: str = "") -> bool:
+        """Shopify 주문에 운송장 등록 (GraphQL fulfillmentCreateV2).
+
+        주문의 open fulfillmentOrder를 조회해 운송장 정보로 이행(fulfillment) 생성.
+        실패·오류 시 False(거짓 성공 보고 금지). dry-run/미설정 시 안전 처리.
+        """
+        if not self._orders_configured():
+            logger.warning("Shopify 자격증명 미설정 — update_tracking stub")
+            return False
+        if _dry_run():
+            logger.info("ADAPTER_DRY_RUN=1 — Shopify update_tracking dry-run (%s)", order_id)
+            return True
+
+        gid = order_id if str(order_id).startswith("gid://") else f"gid://shopify/Order/{order_id}"
+        try:
+            fo_query = """
+            query($id: ID!) {
+              order(id: $id) {
+                fulfillmentOrders(first: 10) { edges { node { id status } } }
+              }
+            }
+            """
+            resp = self._market().graphql(fo_query, {"id": gid})
+            if not (200 <= resp.status_code < 300):
+                logger.warning("Shopify fulfillmentOrders HTTP %s", resp.status_code)
+                return False
+            body = resp.json() if callable(getattr(resp, "json", None)) else {}
+            if body.get("errors"):
+                logger.warning("Shopify fulfillmentOrders 오류: %s", body["errors"])
+                return False
+            order = ((body.get("data") or {}).get("order") or {})
+            fo_ids = []
+            for edge in ((order.get("fulfillmentOrders") or {}).get("edges") or []):
+                fnode = edge.get("node") or {}
+                status = str(fnode.get("status") or "").upper()
+                if fnode.get("id") and status not in ("CLOSED", "CANCELLED"):
+                    fo_ids.append(fnode["id"])
+            if not fo_ids:
+                logger.warning("Shopify 이행 가능한 fulfillmentOrder 없음: order=%s", order_id)
+                return False
+
+            mutation = """
+            mutation($fulfillment: FulfillmentV2Input!) {
+              fulfillmentCreateV2(fulfillment: $fulfillment) {
+                fulfillment { id status }
+                userErrors { field message }
+              }
+            }
+            """
+            tracking_info: dict = {}
+            if tracking_no:
+                tracking_info["number"] = tracking_no
+            if courier:
+                tracking_info["company"] = courier
+            variables = {
+                "fulfillment": {
+                    "lineItemsByFulfillmentOrder": [{"fulfillmentOrderId": fid} for fid in fo_ids],
+                    "trackingInfo": tracking_info,
+                    "notifyCustomer": False,
+                }
+            }
+            resp2 = self._market().graphql(mutation, variables)
+            if not (200 <= resp2.status_code < 300):
+                logger.warning("Shopify fulfillmentCreateV2 HTTP %s", resp2.status_code)
+                return False
+            body2 = resp2.json() if callable(getattr(resp2, "json", None)) else {}
+            if body2.get("errors"):
+                logger.warning("Shopify fulfillmentCreateV2 GraphQL 오류: %s", body2["errors"])
+                return False
+            result = (((body2.get("data") or {}).get("fulfillmentCreateV2")) or {})
+            user_errors = result.get("userErrors") or []
+            if user_errors:
+                logger.warning("Shopify 운송장 등록 userErrors: %s", user_errors)
+                return False
+            if result.get("fulfillment"):
+                logger.info("Shopify 운송장 등록 완료: order=%s, %s/%s", order_id, courier, tracking_no)
+                return True
+            return False
+        except Exception as exc:
+            logger.warning("Shopify update_tracking 실패: %s", exc)
+            return False
 
     def health_check(self) -> dict:
         """Shopify API 상태 확인."""

--- a/src/seller_console/orders/sync_service.py
+++ b/src/seller_console/orders/sync_service.py
@@ -17,6 +17,7 @@ class OrderSyncService:
         from src.seller_console.market_adapters.smartstore_adapter import SmartStoreAdapter
         from src.seller_console.market_adapters.eleven_adapter import ElevenAdapter
         from src.seller_console.market_adapters.woocommerce_adapter import WooCommerceAdapter
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
 
         self.sheets = OrderSheetsAdapter()
         self.adapters = {
@@ -25,6 +26,8 @@ class OrderSyncService:
             "11st": ElevenAdapter(),
             # Phase 132: kohganemultishop → woocommerce (kohganemultishop.org 실연동)
             "woocommerce": WooCommerceAdapter(),
+            # Phase 206: Shopify 주문수집·배송추적 (GraphQL + client_credentials)
+            "shopify": ShopifyAdapter(),
         }
 
     def sync_all(self, since: datetime = None) -> dict:

--- a/tests/test_orders_sync_shopify.py
+++ b/tests/test_orders_sync_shopify.py
@@ -1,0 +1,192 @@
+"""tests/test_orders_sync_shopify.py — Shopify 주문수집·배송추적 (Phase 206).
+
+- OrderSyncService.adapters에 shopify 포함
+- ShopifyAdapter.fetch_orders_unified GraphQL mock 검증 + 상태 매핑
+- update_tracking: fulfillmentOrders 조회 → fulfillmentCreateV2 성공/실패/userErrors
+- 자격증명 미설정·ADAPTER_DRY_RUN 안전 처리
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _resp(status_code: int, payload: dict):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = payload
+    return r
+
+
+MOCK_ORDERS_PAGE = {
+    "data": {
+        "orders": {
+            "edges": [
+                {
+                    "node": {
+                        "id": "gid://shopify/Order/450789469",
+                        "name": "#1001",
+                        "createdAt": "2026-06-10T10:00:00Z",
+                        "processedAt": "2026-06-10T10:05:00Z",
+                        "cancelledAt": None,
+                        "displayFinancialStatus": "PAID",
+                        "displayFulfillmentStatus": "UNFULFILLED",
+                        "totalPriceSet": {"shopMoney": {"amount": "79000", "currencyCode": "KRW"}},
+                        "totalShippingPriceSet": {"shopMoney": {"amount": "3000"}},
+                        "customer": {"firstName": "철", "lastName": "수"},
+                        "shippingAddress": {"phone": "010-1234-5678", "city": "서울"},
+                        "lineItems": {
+                            "edges": [
+                                {"node": {"sku": "SHP-1", "title": "테스트 상품", "quantity": 2,
+                                          "originalUnitPriceSet": {"shopMoney": {"amount": "38000"}}}}
+                            ]
+                        },
+                    }
+                }
+            ],
+            "pageInfo": {"hasNextPage": False, "endCursor": "c1"},
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. OrderSyncService 등록
+# ---------------------------------------------------------------------------
+
+class TestSyncServiceRegistration:
+    def test_shopify_in_adapters(self):
+        with patch("src.seller_console.orders.sheets_adapter.OrderSheetsAdapter") as MockSheets:
+            MockSheets.return_value = MagicMock()
+            from src.seller_console.orders.sync_service import OrderSyncService
+            svc = OrderSyncService()
+        assert "shopify" in svc.adapters
+
+
+# ---------------------------------------------------------------------------
+# 2. fetch_orders_unified
+# ---------------------------------------------------------------------------
+
+class TestShopifyOrdersFetch:
+    @pytest.fixture
+    def configured(self, monkeypatch):
+        monkeypatch.setenv("SHOPIFY_SHOP", "testshop.myshopify.com")
+        monkeypatch.setenv("SHOPIFY_CLIENT_ID", "cid_test")
+        monkeypatch.setenv("SHOPIFY_CLIENT_SECRET", "shpss_test")
+        monkeypatch.delenv("ADAPTER_DRY_RUN", raising=False)
+
+    def test_fetch_orders_unified_mock(self, configured):
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        adapter = ShopifyAdapter()
+        with patch.object(adapter, "_market") as m:
+            m.return_value.is_configured.return_value = True
+            m.return_value.graphql.return_value = _resp(200, MOCK_ORDERS_PAGE)
+            orders = adapter.fetch_orders_unified()
+
+        assert len(orders) == 1
+        o = orders[0]
+        assert o["order_id"] == "450789469"
+        assert o["marketplace"] == "shopify"
+        assert o["status"] == "paid"  # PAID + UNFULFILLED
+        assert o["total_krw"] == "79000"
+        assert o["order_name"] == "#1001"
+        assert o["currency"] == "KRW"
+        assert len(o["items"]) == 1
+        assert o["items"][0]["sku"] == "SHP-1"
+        assert o["items"][0]["qty"] == 2
+        # 마스킹 검증
+        assert o["buyer_phone_masked"].endswith("****")
+        assert o["buyer_name_masked"][0] == "철"
+
+    def test_fetch_orders_not_configured(self, monkeypatch):
+        for k in ("SHOPIFY_SHOP", "SHOPIFY_CLIENT_ID", "SHOPIFY_CLIENT_SECRET",
+                  "SHOPIFY_AUTO_TOKEN", "SHOPIFY_ACCESS_TOKEN", "SHOPIFY_ADMIN_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        assert ShopifyAdapter().fetch_orders_unified() == []
+
+    def test_fetch_orders_dry_run(self, configured, monkeypatch):
+        monkeypatch.setenv("ADAPTER_DRY_RUN", "1")
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        assert ShopifyAdapter().fetch_orders_unified() == []
+
+    def test_fetch_orders_graphql_error_returns_empty(self, configured):
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        adapter = ShopifyAdapter()
+        with patch.object(adapter, "_market") as m:
+            m.return_value.is_configured.return_value = True
+            m.return_value.graphql.return_value = _resp(200, {"errors": [{"message": "access denied"}]})
+            assert adapter.fetch_orders_unified() == []
+
+    def test_status_mapping(self):
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        a = ShopifyAdapter()
+        assert a._map_order_status("PAID", "UNFULFILLED", False) == "paid"
+        assert a._map_order_status("PAID", "FULFILLED", False) == "delivered"
+        assert a._map_order_status("REFUNDED", "FULFILLED", False) == "returned"
+        assert a._map_order_status("PAID", "FULFILLED", True) == "canceled"
+        assert a._map_order_status("PENDING", "UNFULFILLED", False) == "new"
+
+
+# ---------------------------------------------------------------------------
+# 3. update_tracking
+# ---------------------------------------------------------------------------
+
+FO_PAGE = {
+    "data": {"order": {"fulfillmentOrders": {"edges": [
+        {"node": {"id": "gid://shopify/FulfillmentOrder/77", "status": "OPEN"}}
+    ]}}}
+}
+FULFILL_OK = {"data": {"fulfillmentCreateV2": {"fulfillment": {"id": "gid://shopify/Fulfillment/9", "status": "SUCCESS"}, "userErrors": []}}}
+FULFILL_ERR = {"data": {"fulfillmentCreateV2": {"fulfillment": None, "userErrors": [{"field": ["x"], "message": "bad"}]}}}
+
+
+class TestShopifyUpdateTracking:
+    @pytest.fixture
+    def configured(self, monkeypatch):
+        monkeypatch.setenv("SHOPIFY_SHOP", "testshop.myshopify.com")
+        monkeypatch.setenv("SHOPIFY_CLIENT_ID", "cid_test")
+        monkeypatch.setenv("SHOPIFY_CLIENT_SECRET", "shpss_test")
+        monkeypatch.delenv("ADAPTER_DRY_RUN", raising=False)
+
+    def test_update_tracking_success(self, configured):
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        adapter = ShopifyAdapter()
+        with patch.object(adapter, "_market") as m:
+            m.return_value.is_configured.return_value = True
+            m.return_value.graphql.side_effect = [_resp(200, FO_PAGE), _resp(200, FULFILL_OK)]
+            assert adapter.update_tracking("450789469", "CJ대한통운", "12345678") is True
+
+    def test_update_tracking_user_errors(self, configured):
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        adapter = ShopifyAdapter()
+        with patch.object(adapter, "_market") as m:
+            m.return_value.is_configured.return_value = True
+            m.return_value.graphql.side_effect = [_resp(200, FO_PAGE), _resp(200, FULFILL_ERR)]
+            assert adapter.update_tracking("450789469", "CJ", "123") is False
+
+    def test_update_tracking_no_fulfillment_orders(self, configured):
+        empty = {"data": {"order": {"fulfillmentOrders": {"edges": []}}}}
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        adapter = ShopifyAdapter()
+        with patch.object(adapter, "_market") as m:
+            m.return_value.is_configured.return_value = True
+            m.return_value.graphql.return_value = _resp(200, empty)
+            assert adapter.update_tracking("450789469", "CJ", "123") is False
+
+    def test_update_tracking_not_configured(self, monkeypatch):
+        for k in ("SHOPIFY_SHOP", "SHOPIFY_CLIENT_ID", "SHOPIFY_CLIENT_SECRET",
+                  "SHOPIFY_AUTO_TOKEN", "SHOPIFY_ACCESS_TOKEN", "SHOPIFY_ADMIN_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        assert ShopifyAdapter().update_tracking("1", "CJ", "123") is False
+
+    def test_update_tracking_dry_run(self, configured, monkeypatch):
+        monkeypatch.setenv("ADAPTER_DRY_RUN", "1")
+        from src.seller_console.market_adapters.shopify_adapter import ShopifyAdapter
+        assert ShopifyAdapter().update_tracking("1", "CJ", "123") is True


### PR DESCRIPTION
## 개요
오너 지시 "후속 1,2,3 순서대로 가라"의 **①번** — Shopify 풀 펀넬 완성.

기존 상태: Shopify는 상품 **업로드만** 실연동, 주문수집·배송추적은 미연동/stub. 쿠팡·스마트스토어·11번가·WooCommerce는 이미 '수집→업로드→주문→배송추적' 풀 프로덕션. 이 PR로 Shopify도 동일 수준으로 끌어올림.

## 변경
- `seller_console/market_adapters/shopify_adapter.py`
  - `fetch_orders` / `fetch_orders_unified`: GraphQL `orders` 커서 페이지네이션(최대 1000건 캡) → 통합 주문 dict 변환. 구매자 이름·전화 마스킹. 재무/배송 상태 → 통합 상태(`new/paid/delivered/returned/canceled`) 매핑.
  - `update_tracking`: 주문의 open `fulfillmentOrders` 조회 → `fulfillmentCreateV2`로 운송장(company/number) 등록.
  - 토큰은 **검증된 client_credentials 경로 재사용** — `markets/adapters/shopify.py`에 공개 `graphql()` 추가(토큰 발급·429 재시도 로직 공유). 신규 개발자대시보드 앱은 REST가 막혀 GraphQL만 동작하므로 GraphQL 사용.
- `seller_console/orders/sync_service.py`: `OrderSyncService.adapters`에 `"shopify"` 등록 → `sync_all`/`update_tracking` 자동 포함.

## 정직성 (거짓 성공/데이터 금지)
- GraphQL `errors`·`userErrors`·비2xx·자격증명 미설정 시 **빈 리스트/False** 반환 (가짜 주문·거짓 등록 성공 보고 안 함).
- `ADAPTER_DRY_RUN=1` 시 실 호출 차단(수집=빈 리스트, 운송장=차단 후 True).

## 테스트
- 신규 `tests/test_orders_sync_shopify.py`: 어댑터 등록, 주문수집 GraphQL mock, 상태 매핑, 배송추적 성공/userErrors/이행오더없음/미설정/dry-run.
- 전체 `python -m pytest tests/ -q` → **9909 passed, 2 skipped** (회귀 0).

## 오너 액션
- 없음 (Shopify는 이미 연결됨). 다만 운영 시 앱 스코프에 `read_orders`/`write_merchant_managed_fulfillment_orders`(운송장 등록) 권한이 필요할 수 있음 — 없으면 정직하게 실패 처리됨.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_