### PR TITLE
feat(media): 이미지 파이프라인 CDN 업로드 실구현 (Phase 207)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,15 @@
      `graphql()` 추가). `OrderSyncService.adapters`에 `"shopify"` 등록 → 4개 마켓처럼 풀 펀넬.
    - 정직성: GraphQL errors/userErrors/HTTP 오류·미설정 시 거짓 성공 금지(빈 리스트/False). dry-run 안전.
    - 오너 액션: 없음(Shopify는 이미 연결됨). 단 read_orders/write_fulfillments 스코프 필요할 수 있음.
-2. ⏳ **이미지 처리 실구현** (현재 stub) — 진행 예정.
+2. ✅ **이미지 처리 실구현** (완료, Phase 207): 파이프라인(`media/image_pipeline.py`)은 워터마크
+   감지·제거(OpenCV)·리사이즈/크롭·WebP(Pillow)까지 실제 처리했으나 **마지막 CDN 업로드가 stub**
+   (`processed_url = image_url`)이라 결과물을 버렸음. → `_upload_to_cdn()` 신설: 처리본 바이트를
+   Cloudinary(`cloudinary` 1.41.0 기존 의존성)에 업로드해 `secure_url` 발급, `processed_url`에 반영.
+   `ImageProcessResult.cdn_uploaded` 추가, stats에 `cdn_uploaded`/`cdn_configured` 노출.
+   - 정직성: `CLOUDINARY_*` 미설정·라이브러리 미설치·`ADAPTER_DRY_RUN=1`·업로드 실패 시 None →
+     **원본 URL 유지**(거짓 호스팅 URL 미보고). `IMAGE_CDN_UPLOAD_ENABLED`(기본1)로 토글.
+   - 오너 액션(durable): Render에 `CLOUDINARY_CLOUD_NAME`/`CLOUDINARY_API_KEY`/`CLOUDINARY_API_SECRET`
+     (+선택 `CLOUDINARY_FOLDER`) 설정해야 실제 재호스팅됨. 없으면 원본 URL 그대로 사용.
 3. ⏳ **신규 마켓 자동발행** — 일부 오너측 마켓 승인/IP 필요 — 진행 예정.
 
 ## 작업 방식

--- a/src/media/image_pipeline.py
+++ b/src/media/image_pipeline.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 _PIPELINE_ENABLED = os.getenv("IMAGE_PIPELINE_ENABLED", "1") == "1"
 _INPAINT_ENABLED = os.getenv("IMAGE_INPAINT_ENABLED", "1") == "1"
+# 처리본을 CDN(Cloudinary)에 업로드해 새 URL을 발급할지. 기본 on이지만 자격증명 없으면 자동 비활성.
+_CDN_UPLOAD_ENABLED = os.getenv("IMAGE_CDN_UPLOAD_ENABLED", "1") == "1"
 
 # 채널별 크롭 비율 (width : height)
 _CHANNEL_CROP_RATIOS: Dict[str, Tuple[int, int]] = {
@@ -57,7 +59,7 @@ class ImageProcessResult:
     """이미지 처리 결과."""
 
     original_url: str
-    processed_url: str        # 처리 완료 URL (stub: 원본 반환)
+    processed_url: str        # 처리 완료 URL (CDN 업로드 성공 시 호스팅 URL, 아니면 원본)
     processed_bytes: Optional[bytes] = None
     width: int = 0
     height: int = 0
@@ -66,6 +68,7 @@ class ImageProcessResult:
     watermark_removed: bool = False
     background_unified: bool = False
     webp_converted: bool = False
+    cdn_uploaded: bool = False   # 처리본을 CDN에 업로드해 새 URL을 발급했는지
     file_size_bytes: int = 0
     error: Optional[str] = None
     success: bool = True
@@ -81,6 +84,7 @@ class ImageProcessResult:
             "watermark_removed": self.watermark_removed,
             "background_unified": self.background_unified,
             "webp_converted": self.webp_converted,
+            "cdn_uploaded": self.cdn_uploaded,
             "file_size_bytes": self.file_size_bytes,
             "error": self.error,
             "success": self.success,
@@ -212,6 +216,57 @@ def _convert_to_webp(image_bytes: bytes, quality: int = 85) -> bytes:
 
 
 # ---------------------------------------------------------------------------
+# CDN 업로드 (Cloudinary graceful)
+# ---------------------------------------------------------------------------
+
+def _cloudinary_configured() -> bool:
+    """Cloudinary 자격증명(cloud_name/api_key/api_secret) 모두 존재하는지."""
+    return bool(
+        os.getenv("CLOUDINARY_CLOUD_NAME")
+        and os.getenv("CLOUDINARY_API_KEY")
+        and os.getenv("CLOUDINARY_API_SECRET")
+    )
+
+
+def _upload_to_cdn(image_bytes: bytes, *, prefer_webp: bool = False) -> Optional[str]:
+    """처리된 이미지 바이트를 Cloudinary에 업로드하고 보안 URL을 반환.
+
+    자격증명 미설정·라이브러리 미설치·업로드 실패 시 None을 반환(호출부는 원본 URL 유지).
+    거짓 성공을 보고하지 않기 위해 실패는 None으로 정직하게 전달한다.
+    """
+    if not _CDN_UPLOAD_ENABLED or not _cloudinary_configured() or not image_bytes:
+        return None
+    if os.getenv("ADAPTER_DRY_RUN", "0") == "1":
+        logger.info("ADAPTER_DRY_RUN=1 — CDN 업로드 차단")
+        return None
+    try:
+        import cloudinary
+        import cloudinary.uploader
+
+        cloudinary.config(
+            cloud_name=os.getenv("CLOUDINARY_CLOUD_NAME"),
+            api_key=os.getenv("CLOUDINARY_API_KEY"),
+            api_secret=os.getenv("CLOUDINARY_API_SECRET"),
+            secure=True,
+        )
+        folder = os.getenv("CLOUDINARY_FOLDER", "proxy-commerce")
+        opts: Dict[str, Any] = {"folder": folder, "resource_type": "image"}
+        if prefer_webp:
+            opts["format"] = "webp"
+        result = cloudinary.uploader.upload(io.BytesIO(image_bytes), **opts)
+        url = (result or {}).get("secure_url") or (result or {}).get("url")
+        if url:
+            return str(url)
+        return None
+    except ImportError:
+        logger.debug("cloudinary 미설치 — CDN 업로드 스킵")
+        return None
+    except Exception as exc:
+        logger.warning("CDN 업로드 실패: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
 # 공개 API
 # ---------------------------------------------------------------------------
 
@@ -277,9 +332,10 @@ def process_image(
     except Exception:
         pass
 
-    # 실제 운영 시 처리된 이미지를 CDN에 업로드 후 URL 반환
-    # 현재는 원본 URL 반환 (stub)
-    processed_url = image_url
+    # 처리본을 CDN(Cloudinary)에 업로드해 새 URL 발급. 미설정/실패 시 원본 URL 유지(정직).
+    cdn_url = _upload_to_cdn(image_bytes, prefer_webp=webp_converted)
+    processed_url = cdn_url or image_url
+    cdn_uploaded = bool(cdn_url)
 
     return ImageProcessResult(
         original_url=image_url,
@@ -292,6 +348,7 @@ def process_image(
         watermark_removed=watermark_removed,
         background_unified=False,
         webp_converted=webp_converted,
+        cdn_uploaded=cdn_uploaded,
         file_size_bytes=len(image_bytes),
         success=True,
     )
@@ -323,6 +380,7 @@ def image_pipeline_stats(results: List[ImageProcessResult]) -> Dict[str, Any]:
     wm_detected = sum(1 for r in results if r.watermark_detected)
     wm_removed = sum(1 for r in results if r.watermark_removed)
     webp = sum(1 for r in results if r.webp_converted)
+    cdn_uploaded = sum(1 for r in results if r.cdn_uploaded)
     return {
         "total": total,
         "success": success,
@@ -330,6 +388,8 @@ def image_pipeline_stats(results: List[ImageProcessResult]) -> Dict[str, Any]:
         "watermark_detected": wm_detected,
         "watermark_removed": wm_removed,
         "webp_converted": webp,
+        "cdn_uploaded": cdn_uploaded,
         "pipeline_enabled": _PIPELINE_ENABLED,
         "inpaint_enabled": _INPAINT_ENABLED,
+        "cdn_configured": _cloudinary_configured(),
     }

--- a/tests/test_image_pipeline_cdn.py
+++ b/tests/test_image_pipeline_cdn.py
@@ -1,0 +1,135 @@
+"""tests/test_image_pipeline_cdn.py — Phase 207: 이미지 파이프라인 CDN 업로드 실구현.
+
+처리된 이미지 바이트를 Cloudinary에 업로드해 새 URL을 발급(stub 제거).
+미설정/dry-run/실패 시 정직하게 원본 URL 유지(cdn_uploaded=False).
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+CDN_ENV = {
+    "CLOUDINARY_CLOUD_NAME": "testcloud",
+    "CLOUDINARY_API_KEY": "key123",
+    "CLOUDINARY_API_SECRET": "secret456",
+}
+
+
+def _reload(monkeypatch, **env):
+    # 다른 테스트가 남긴 전역 상태로부터 격리 (순서 비의존).
+    monkeypatch.delenv("ADAPTER_DRY_RUN", raising=False)
+    monkeypatch.delenv("IMAGE_CDN_UPLOAD_ENABLED", raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    import src.media.image_pipeline as m
+    importlib.reload(m)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _cloudinary_configured
+# ---------------------------------------------------------------------------
+
+class TestCloudinaryConfigured:
+    def test_configured_true(self, monkeypatch):
+        m = _reload(monkeypatch, **CDN_ENV)
+        assert m._cloudinary_configured() is True
+
+    def test_configured_false_when_missing(self, monkeypatch):
+        for k in CDN_ENV:
+            monkeypatch.delenv(k, raising=False)
+        import src.media.image_pipeline as m
+        importlib.reload(m)
+        assert m._cloudinary_configured() is False
+
+
+# ---------------------------------------------------------------------------
+# _upload_to_cdn
+# ---------------------------------------------------------------------------
+
+class TestUploadToCdn:
+    def test_returns_none_when_not_configured(self, monkeypatch):
+        for k in CDN_ENV:
+            monkeypatch.delenv(k, raising=False)
+        import src.media.image_pipeline as m
+        importlib.reload(m)
+        assert m._upload_to_cdn(b"abc") is None
+
+    def test_returns_none_when_empty_bytes(self, monkeypatch):
+        m = _reload(monkeypatch, **CDN_ENV)
+        assert m._upload_to_cdn(b"") is None
+
+    def test_returns_none_on_dry_run(self, monkeypatch):
+        m = _reload(monkeypatch, ADAPTER_DRY_RUN="1", **CDN_ENV)
+        assert m._upload_to_cdn(b"abc") is None
+        monkeypatch.delenv("ADAPTER_DRY_RUN", raising=False)
+
+    def test_returns_none_when_disabled(self, monkeypatch):
+        m = _reload(monkeypatch, IMAGE_CDN_UPLOAD_ENABLED="0", **CDN_ENV)
+        assert m._upload_to_cdn(b"abc") is None
+
+    def test_uploads_and_returns_secure_url(self, monkeypatch):
+        m = _reload(monkeypatch, **CDN_ENV)
+        fake_uploader = MagicMock()
+        fake_uploader.upload.return_value = {"secure_url": "https://res.cloudinary.com/testcloud/image/upload/x.webp"}
+        fake_cloudinary = SimpleNamespace(config=MagicMock(), uploader=fake_uploader)
+        monkeypatch.setitem(sys.modules, "cloudinary", fake_cloudinary)
+        monkeypatch.setitem(sys.modules, "cloudinary.uploader", fake_uploader)
+
+        url = m._upload_to_cdn(b"imagebytes", prefer_webp=True)
+        assert url == "https://res.cloudinary.com/testcloud/image/upload/x.webp"
+        # webp 선호 시 format 옵션 전달
+        _, kwargs = fake_uploader.upload.call_args
+        assert kwargs.get("format") == "webp"
+        assert kwargs.get("resource_type") == "image"
+
+    def test_upload_exception_returns_none(self, monkeypatch):
+        m = _reload(monkeypatch, **CDN_ENV)
+        fake_uploader = MagicMock()
+        fake_uploader.upload.side_effect = RuntimeError("boom")
+        fake_cloudinary = SimpleNamespace(config=MagicMock(), uploader=fake_uploader)
+        monkeypatch.setitem(sys.modules, "cloudinary", fake_cloudinary)
+        monkeypatch.setitem(sys.modules, "cloudinary.uploader", fake_uploader)
+        assert m._upload_to_cdn(b"imagebytes") is None
+
+
+# ---------------------------------------------------------------------------
+# process_image 통합 — 미설정 시 정직하게 원본 유지
+# ---------------------------------------------------------------------------
+
+class TestProcessImageCdnHonesty:
+    def test_not_configured_keeps_original_url(self, monkeypatch):
+        for k in CDN_ENV:
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("IMAGE_PIPELINE_ENABLED", "0")  # 다운로드 없이 빠른 경로
+        import src.media.image_pipeline as m
+        importlib.reload(m)
+        res = m.process_image("https://example.com/img.jpg")
+        assert res.processed_url == "https://example.com/img.jpg"
+        assert res.cdn_uploaded is False
+
+    def test_result_dict_has_cdn_uploaded(self, monkeypatch):
+        m = _reload(monkeypatch, IMAGE_PIPELINE_ENABLED="0")
+        res = m.process_image("https://example.com/img.jpg")
+        assert "cdn_uploaded" in res.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# stats — cdn 필드
+# ---------------------------------------------------------------------------
+
+class TestStatsCdn:
+    def test_stats_include_cdn_fields(self, monkeypatch):
+        m = _reload(monkeypatch, **CDN_ENV)
+        from src.media.image_pipeline import ImageProcessResult
+        results = [
+            ImageProcessResult(original_url="a", processed_url="cdn-a", cdn_uploaded=True, success=True),
+            ImageProcessResult(original_url="b", processed_url="b", cdn_uploaded=False, success=True),
+        ]
+        stats = m.image_pipeline_stats(results)
+        assert stats["cdn_uploaded"] == 1
+        assert stats["cdn_configured"] is True


### PR DESCRIPTION
## 개요
오너 지시 "후속 1,2,3 순서대로 가라"의 **②번** — 이미지 처리 stub 실구현.

기존 상태: `media/image_pipeline.py`는 워터마크 감지·제거(OpenCV), 채널별 리사이즈/크롭, WebP 변환(Pillow)까지 **실제로 처리**하지만, 마지막 단계인 CDN 업로드가 stub(`processed_url = image_url`)이라 **처리 결과물을 버리고 원본 URL을 반환**했음. 즉 파이프라인이 돌아도 끝단이 끊겨 있었음.

## 변경
- `media/image_pipeline.py`
  - `_upload_to_cdn(image_bytes, prefer_webp)`: 처리된 바이트를 **Cloudinary에 업로드**(`cloudinary` 1.41.0 — 이미 의존성)하고 `secure_url` 반환. webp 변환본이면 `format=webp`로 업로드.
  - `process_image`: stub 제거 → 업로드 성공 시 `processed_url`을 호스팅 URL로 교체, `cdn_uploaded=True`.
  - `ImageProcessResult.cdn_uploaded` 필드 + `to_dict` 노출. `image_pipeline_stats`에 `cdn_uploaded`/`cdn_configured` 추가.
  - `IMAGE_CDN_UPLOAD_ENABLED`(기본 1) 토글.

## 정직성 (거짓 URL/성공 금지)
- `CLOUDINARY_*` 미설정 · `cloudinary` 미설치 · `ADAPTER_DRY_RUN=1` · 업로드 예외 시 → `None` 반환 → **원본 URL 유지** + `cdn_uploaded=False`. 가짜 호스팅 URL을 만들어내지 않음.

## 테스트
- 신규 `tests/test_image_pipeline_cdn.py`: 설정 감지, 업로드 성공(secure_url/format/resource_type), 미설정·빈바이트·dry-run·비활성·예외 시 None, process_image 정직성(미설정 시 원본 유지), stats CDN 필드. 순서 비의존(전역 `ADAPTER_DRY_RUN` 격리).
- 전체 `python -m pytest tests/ -q` → **9920 passed, 2 skipped** (회귀 0, 랜덤·고정 순서 모두 확인).

## 오너 액션 (durable)
- Render에 `CLOUDINARY_CLOUD_NAME` / `CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET` (+선택 `CLOUDINARY_FOLDER`) 설정 시 **실제 재호스팅** 작동. 미설정이면 기존처럼 원본 URL 사용(무해).

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_