### PR TITLE
feat(listing): 자동발행을 실 업로더에 연동 (Phase 208)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,15 @@
      **원본 URL 유지**(거짓 호스팅 URL 미보고). `IMAGE_CDN_UPLOAD_ENABLED`(기본1)로 토글.
    - 오너 액션(durable): Render에 `CLOUDINARY_CLOUD_NAME`/`CLOUDINARY_API_KEY`/`CLOUDINARY_API_SECRET`
      (+선택 `CLOUDINARY_FOLDER`) 설정해야 실제 재호스팅됨. 없으면 원본 URL 그대로 사용.
-3. ⏳ **신규 마켓 자동발행** — 일부 오너측 마켓 승인/IP 필요 — 진행 예정.
+3. ✅ **자동발행 실 업로더 연동** (코드-온리 부분 완료, Phase 208): `listing/auto_publish.py`의
+   `auto_publish()`가 쿠팡=**mock 퍼블리셔**(`CoupangPublisher`, 가짜 uuid), 스마트스토어/11번가=
+   **가짜 UUID stub**으로 발행을 흉내냈음(#2와 같은 '작업 버림' 패턴). → `_upload_to_channel`을
+   수동 업로드(UploadDispatcher)와 **동일한 실 업로더**(`channel_sync.{coupang,smartstore,elevenst}_uploader`
+   → `src.uploaders.*`)로 재배선. 자격증명 미설정·API 실패 시 가짜 성공 대신 **success=False+사유**(정직).
+   - 오너 액션(durable): 실 자동발행하려면 `LISTING_AUTO_PUBLISH=1` + 각 채널 자격증명
+     (`COUPANG_ACCESS_KEY/SECRET/VENDOR_ID`, `NAVER_CLIENT_ID/SECRET`(+네이버 허용IP), `ELEVENST_API_KEY`).
+   - **외부 승인에 막힌 항목(코드 아님, 오너측)**: Amazon SP-API / eBay / Shopee = 셀러 등록·OAuth 승인·
+     키 발급 필요(`markets/adapters/{amazon,ebay,shopee}.py`는 스캐폴드 stub 유지). 승인 완료 후 실연동 착수.
 
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.

--- a/src/listing/auto_publish.py
+++ b/src/listing/auto_publish.py
@@ -1,11 +1,17 @@
-"""src/listing/auto_publish.py — 상품 등록 자동화 (Phase 143).
+"""src/listing/auto_publish.py — 상품 등록 자동화 (Phase 143, 실 업로더 연동 Phase 208).
 
 후보 승인 → 이미지 처리 + 번역 + 채널 적응 → 쿠팡/스마트스토어/11번가 동시 업로드.
 부분 실패 허용 (일부 채널 실패해도 성공 채널 결과 반환).
 
+Phase 208: 기존 mock 퍼블리셔/가짜 UUID stub 제거 → 수동 업로드(UploadDispatcher)와 동일한
+실 업로더(`channel_sync.*_uploader` → `src.uploaders.*`)로 발행. 자격증명 미설정·API 실패 시
+가짜 성공이 아니라 정직하게 실패(success=False)로 기록한다.
+(Amazon/eBay/Shopee는 마켓 승인·OAuth 발급이 필요해 미연동 — 오너측 액션 대기.)
+
 환경변수:
-  LISTING_AUTO_PUBLISH=0                  자동 등록 활성화 (기본: 0, 비활성)
+  LISTING_AUTO_PUBLISH=0                  자동 등록 활성화 (기본: 0, 비활성=드라이런)
   LISTING_AUTO_PUBLISH_CHANNELS=coupang,smartstore  대상 채널
+  (실 발행은 각 채널 자격증명 필요: COUPANG_*, NAVER_CLIENT_ID/SECRET, ELEVENST_API_KEY)
 """
 from __future__ import annotations
 
@@ -232,38 +238,61 @@ def adapt_for_channel(product: Product, channel: str) -> ChannelListing:
     )
 
 
+# 자동발행 채널명 → 실 업로드 브리지 모듈 (수동 업로드 UploadDispatcher와 동일 경로)
+_CHANNEL_BRIDGE: Dict[str, str] = {
+    "coupang": "coupang_uploader",
+    "smartstore": "smartstore_uploader",
+    "11st": "elevenst_uploader",
+}
+
+
+def _listing_to_product_data(listing: ChannelListing) -> Dict[str, Any]:
+    """ChannelListing → 채널 브리지(_channel_bridge.to_collected)용 product_data."""
+    return {
+        "sku": listing.product_id,
+        "title_ko": listing.title,
+        "title": listing.title,
+        "sell_price_krw": listing.price,
+        "category_code": listing.channel_category_id,
+        "description": listing.description,
+        "images": listing.image_urls,
+        "options": listing.options,
+    }
+
+
 def _upload_to_channel(listing: ChannelListing) -> ChannelUploadResult:
-    """단일 채널 업로드. 실패해도 예외 미전파."""
+    """단일 채널 실 업로드. 실패해도 예외 미전파.
+
+    수동 업로드(UploadDispatcher)와 동일한 실 업로더(`channel_sync.*_uploader` →
+    `src.uploaders.*`)를 사용한다. 자격증명 미설정·API 실패 시 가짜 성공이 아니라
+    정직하게 success=False + 사유를 반환한다(거짓 발행 보고 금지).
+    """
     channel = listing.channel
+    bridge_name = _CHANNEL_BRIDGE.get(channel)
+    if not bridge_name:
+        return ChannelUploadResult(channel=channel, success=False, error=f"미지원 채널: {channel}")
+
+    import importlib
+    from src.channel_sync._channel_bridge import ChannelCredentialsMissing, ChannelUploadError
+
     try:
-        if channel == "coupang":
-            from src.channel_sync.publishers.coupang import CoupangPublisher
-            pub = CoupangPublisher()
-            result = pub.publish({
-                "product_id": listing.product_id,
-                "title": listing.title,
-                "price": listing.price,
-                "stock": 99,
-                "category": listing.channel_category_id,
-                "description": listing.description,
-            })
-            return ChannelUploadResult(
-                channel=channel,
-                success=result.success,
-                listing_id=result.listing_id,
-                channel_listing_id=result.listing_id,
-                error=result.error,
-            )
-        else:
-            # smartstore / 11st — stub (API 미연동)
-            mock_lid = f"{channel}-{uuid.uuid4().hex[:8]}"
-            logger.info("auto_publish stub: channel=%s product=%s listing_id=%s", channel, listing.product_id, mock_lid)
-            return ChannelUploadResult(
-                channel=channel,
-                success=True,
-                listing_id=mock_lid,
-                channel_listing_id=mock_lid,
-            )
+        bridge = importlib.import_module(f"src.channel_sync.{bridge_name}")
+        result = bridge.upload(_listing_to_product_data(listing))
+        product_id = (result or {}).get("product_id")
+        logger.info("auto_publish 실 업로드 성공: channel=%s product=%s id=%s",
+                    channel, listing.product_id, product_id)
+        return ChannelUploadResult(
+            channel=channel,
+            success=True,
+            listing_id=product_id,
+            channel_listing_id=product_id,
+        )
+    except ChannelCredentialsMissing as exc:
+        logger.info("auto_publish 자격증명 미설정: channel=%s — %s", channel, exc)
+        return ChannelUploadResult(channel=channel, success=False, error=f"자격증명 미설정: {exc}")
+    except ChannelUploadError as exc:
+        logger.warning("auto_publish 업로드 실패: channel=%s — %s", channel, exc)
+        return ChannelUploadResult(channel=channel, success=False, error=str(exc))
     except Exception as exc:
         logger.error("_upload_to_channel 오류: channel=%s error=%s", channel, exc)
         return ChannelUploadResult(channel=channel, success=False, error=str(exc))

--- a/tests/test_listing_auto_publish.py
+++ b/tests/test_listing_auto_publish.py
@@ -286,3 +286,70 @@ class TestChannelUploadResult:
         assert d["success"] is True
         assert d["listing_id"] == "lid1"
         assert "uploaded_at" in d
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _upload_to_channel — 실 업로더 연동 (Phase 208, 정직성)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestUploadToChannelReal:
+    def _listing(self, channel="coupang"):
+        from src.listing.auto_publish import ChannelListing
+        return ChannelListing(
+            channel=channel, product_id="p1", title="테스트 상품",
+            description="설명", price=55000, channel_category_id="56137",
+            image_urls=["https://example.com/a.jpg"], options=[],
+        )
+
+    def test_credentials_missing_is_honest_failure(self, monkeypatch):
+        """자격증명 미설정 시 가짜 성공이 아니라 success=False."""
+        for k in ("COUPANG_ACCESS_KEY", "COUPANG_SECRET_KEY", "COUPANG_VENDOR_ID"):
+            monkeypatch.delenv(k, raising=False)
+        from src.listing.auto_publish import _upload_to_channel
+        result = _upload_to_channel(self._listing("coupang"))
+        assert result.success is False
+        assert "자격증명" in (result.error or "")
+
+    def test_smartstore_no_fake_uuid(self, monkeypatch):
+        """스마트스토어도 더 이상 가짜 UUID 성공을 만들지 않음."""
+        for k in ("NAVER_CLIENT_ID", "NAVER_CLIENT_SECRET",
+                  "NAVER_COMMERCE_CLIENT_ID", "NAVER_COMMERCE_CLIENT_SECRET"):
+            monkeypatch.delenv(k, raising=False)
+        from src.listing.auto_publish import _upload_to_channel
+        result = _upload_to_channel(self._listing("smartstore"))
+        assert result.success is False
+        assert result.listing_id is None
+
+    def test_unsupported_channel(self):
+        from src.listing.auto_publish import _upload_to_channel
+        result = _upload_to_channel(self._listing("amazon"))
+        assert result.success is False
+        assert "미지원" in (result.error or "")
+
+    def test_real_upload_success_mapped(self, monkeypatch):
+        """브리지가 성공 dict를 반환하면 listing_id에 product_id 매핑."""
+        import sys
+        from types import ModuleType
+        fake = ModuleType("src.channel_sync.coupang_uploader")
+        fake.upload = lambda product_data: {"product_id": "CP-999", "url": "https://coupang/CP-999"}
+        monkeypatch.setitem(sys.modules, "src.channel_sync.coupang_uploader", fake)
+        from src.listing.auto_publish import _upload_to_channel
+        result = _upload_to_channel(self._listing("coupang"))
+        assert result.success is True
+        assert result.listing_id == "CP-999"
+
+    def test_upload_error_mapped_to_failure(self, monkeypatch):
+        import sys
+        from types import ModuleType
+        from src.channel_sync._channel_bridge import ChannelUploadError
+
+        def _boom(product_data):
+            raise ChannelUploadError("쿠팡 업로드 실패: API 500")
+
+        fake = ModuleType("src.channel_sync.coupang_uploader")
+        fake.upload = _boom
+        monkeypatch.setitem(sys.modules, "src.channel_sync.coupang_uploader", fake)
+        from src.listing.auto_publish import _upload_to_channel
+        result = _upload_to_channel(self._listing("coupang"))
+        assert result.success is False
+        assert "API 500" in (result.error or "")


### PR DESCRIPTION
## 개요
오너 지시 "후속 1,2,3 순서대로 가라"의 **③번** — 신규 마켓 자동발행. 코드만으로 가능한 부분과 외부 승인이 막는 부분을 팩트로 구분해 처리.

기존 상태: `listing/auto_publish.py`의 `auto_publish()`가 실제로는 **아무 마켓에도 진짜로 발행하지 않았음** —
- 쿠팡: `CoupangPublisher`(파일 첫 줄 "**mock 구현**", 가짜 uuid 반환)
- 스마트스토어/11번가: `f"{channel}-{uuid4}"` **가짜 UUID stub** + `success=True`

즉 #2(이미지 파이프라인 끝단 버림)와 동일한 "작업을 흉내만 내고 버리는" 패턴이었음.

## 변경 (코드-온리, 외부 승인 불필요)
- `auto_publish._upload_to_channel`을 **수동 업로드(`UploadDispatcher`)와 동일한 실 업로더 경로**로 재배선:
  `channel_sync.{coupang,smartstore,elevenst}_uploader` → `src.uploaders.*`(쿠팡 Wing HMAC / 네이버 OAuth2 bcrypt / 11번가 OpenAPI XML).
- `ChannelListing` → 브리지 `product_data` 변환 헬퍼 추가, `_CHANNEL_BRIDGE` 매핑.

## 정직성 (가짜 발행 보고 금지)
- 자격증명 미설정 → `ChannelCredentialsMissing` → **success=False + "자격증명 미설정: …"** (기존엔 가짜 성공).
- API 실패/판매가 0 → `ChannelUploadError` → success=False + 사유.
- 미지원 채널 → success=False. 실 성공 시에만 listing_id에 실제 product_id 매핑.

## 외부 승인에 막힌 항목 (코드 아님 — 오너측 액션)
- **Amazon SP-API / eBay / Shopee**: 셀러 등록·OAuth 승인·키 발급 필요 → `markets/adapters/{amazon,ebay,shopee}.py`는 스캐폴드 stub 유지. 승인 완료 후 별도 실연동 PR로 진행.

## 오너 액션 (durable, 실 자동발행 시)
- `LISTING_AUTO_PUBLISH=1` + 채널 자격증명: `COUPANG_ACCESS_KEY/SECRET/VENDOR_ID`, `NAVER_CLIENT_ID/SECRET`(+네이버 허용 IP), `ELEVENST_API_KEY`.

## 테스트
- `tests/test_listing_auto_publish.py` 신규 케이스: 자격증명 미설정 정직 실패, 가짜 UUID 미생성, 미지원 채널, 성공 매핑, 업로드 오류 매핑.
- 전체 `python -m pytest tests/ -q` → **9925 passed, 2 skipped** (회귀 0).

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_