### PR TITLE
fix(coupang): 업로드 응답 data=null/숫자 처리 (NoneType 크래시 수정)

### DIFF
--- a/src/uploaders/coupang_uploader.py
+++ b/src/uploaders/coupang_uploader.py
@@ -68,7 +68,19 @@ class CoupangUploader(BaseUploader):
             result = self._api_request('POST', path, data=payload)
             if 'error' in result:
                 return {'success': False, 'error': result['error'], 'sku': product.get('sku', '')}
-            product_id = str(result.get('data', {}).get('sellerProductId', ''))
+            # 쿠팡 응답의 data는 sellerProductId(숫자) 또는 {"sellerProductId": ...} 또는 null일 수 있다.
+            data = result.get('data')
+            if isinstance(data, dict):
+                product_id = str(data.get('sellerProductId') or '')
+            elif isinstance(data, (int, str)):
+                product_id = str(data)
+            else:
+                product_id = ''
+            code = str(result.get('code') or '').upper()
+            if not product_id and code and code not in ('SUCCESS', '200', 'OK'):
+                # data null + 비성공 코드 = 등록 거부 → 가짜 성공 금지(정직)
+                msg = result.get('message') or f'코드 {code}'
+                return {'success': False, 'error': f'쿠팡 등록 거부: {msg}', 'sku': product.get('sku', '')}
             url = f'https://www.coupang.com/vp/products/{product_id}' if product_id else ''
             return {'success': True, 'product_id': product_id, 'url': url, 'sku': product.get('sku', '')}
         except Exception as exc:
@@ -105,7 +117,7 @@ class CoupangUploader(BaseUploader):
             if 'error' in result:
                 logger.warning('get_categories failed: %s', result['error'])
                 return []
-            return result.get('data', [])
+            return result.get('data') or []
         except Exception as exc:
             logger.error('get_categories failed: %s', exc)
             return []

--- a/tests/test_uploaders.py
+++ b/tests/test_uploaders.py
@@ -231,6 +231,29 @@ class TestCoupangUploadProduct:
             result = coupang_uploader.upload_product(prepared)
         assert result['success'] is False
 
+    def test_upload_product_data_is_number(self, coupang_uploader):
+        """쿠팡은 data를 sellerProductId 숫자로 직접 반환 — 크래시 없이 매핑."""
+        prepared = coupang_uploader.prepare_product(SAMPLE_COLLECTED)
+        with patch.object(coupang_uploader, '_api_request',
+                          return_value={'code': 'SUCCESS', 'data': 12345678}):
+            result = coupang_uploader.upload_product(prepared)
+        assert result['success'] is True
+        assert result['product_id'] == '12345678'
+
+    def test_upload_product_data_null_rejected(self, coupang_uploader):
+        """data=null + 비성공 코드 → 가짜 성공이 아니라 정직한 실패 (NoneType 크래시 금지)."""
+        prepared = coupang_uploader.prepare_product(SAMPLE_COLLECTED)
+        with patch.object(coupang_uploader, '_api_request',
+                          return_value={'code': 'ERROR', 'message': '카테고리 오류', 'data': None}):
+            result = coupang_uploader.upload_product(prepared)
+        assert result['success'] is False
+        assert '카테고리 오류' in result['error']
+
+    def test_get_categories_data_null(self, coupang_uploader):
+        """get_categories도 data=null 시 빈 리스트 (크래시 금지)."""
+        with patch.object(coupang_uploader, '_api_request', return_value={'code': 'SUCCESS', 'data': None}):
+            assert coupang_uploader.get_categories() == []
+
     def test_update_product(self, coupang_uploader):
         with patch.object(coupang_uploader, '_api_request', return_value={}):
             result = coupang_uploader.update_product('12345', {'salePrice': 9000})


### PR DESCRIPTION
## 개요
오너 화면에서 발견된 **쿠팡 업로드 실패** 버그 수정: `쿠팡 업로드 실패: 'NoneType' object has no attribute 'get'` (오류코드 api_error). 같은 요청에서 Shopify 업로드는 성공.

## 원인 (팩트)
`src/uploaders/coupang_uploader.py`의 `upload_product`:
```python
product_id = str(result.get('data', {}).get('sellerProductId', ''))
```
쿠팡 Wing API의 `seller-products` 생성 응답은 `data`를 **sellerProductId 숫자로 직접** 반환하거나(`{"data": 12345678}`), 거부 시 `{"data": null}`로 반환한다. 따라서:
- `data=null` → `result.get('data', {})`가 `None` → `None.get(...)` 크래시 (오너가 본 에러)
- `data=숫자` → `int.get(...)` 크래시

## 수정
- `data`가 dict / int / str / None 모든 형태를 안전 처리해 `sellerProductId`(또는 숫자 자체) 추출.
- `data=null` + 비성공 `code` → **가짜 성공이 아니라 정직한 실패**(`쿠팡 등록 거부: {message}`)로 반환.
- `get_categories`의 `result.get('data', [])`도 `data=null` 시 크래시 방지(`or []`).

## 테스트
- 신규: `data`=숫자 성공 매핑, `data`=null 거부 정직 실패, `get_categories` null 안전.
- 전체 `python -m pytest tests/ -q` → **9928 passed, 2 skipped** (회귀 0).

## 비고
- 이 PR은 응답 파싱 크래시만 수정. 실제 등록 성공은 쿠팡 자격증명(`COUPANG_ACCESS_KEY/SECRET/VENDOR_ID`) + Wing 허용 IP 등록이 전제(오너측, 기존 메모 유지).

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_