### PR TITLE
feat(collect): 편집 페이지 원화 환율 계산기 + 상세설명 에디터 확대

### DIFF
--- a/src/seller_console/templates/collect_preview.html
+++ b/src/seller_console/templates/collect_preview.html
@@ -34,14 +34,14 @@
           </div>
 
           <!-- 가격 + 통화 -->
-          <div class="row g-2 mb-3">
+          <div class="row g-2 mb-2">
             <div class="col-7">
               <label class="form-label small fw-semibold" for="editPrice">가격(원가)</label>
-              <input type="number" step="0.01" min="0" class="form-control" id="editPrice" placeholder="0.00">
+              <input type="number" step="0.01" min="0" class="form-control" id="editPrice" placeholder="0.00" oninput="updateKrwPreview()">
             </div>
             <div class="col-5">
               <label class="form-label small fw-semibold" for="editCurrency">통화</label>
-              <select class="form-select" id="editCurrency">
+              <select class="form-select" id="editCurrency" onchange="updateKrwPreview()">
                 {% for c in ["USD","JPY","CNY","EUR","GBP","KRW"] %}
                 <option value="{{ c }}">{{ c }}</option>
                 {% endfor %}
@@ -49,12 +49,26 @@
             </div>
           </div>
 
-          <!-- 상세설명 -->
-          <div class="mb-2">
-            <label class="form-label small fw-semibold" for="editDescription">상세 설명</label>
-            <textarea class="form-control" id="editDescription" rows="4" placeholder="상품 상세 설명"></textarea>
+          <!-- 원화 환산 (환율 계산기) -->
+          <div class="d-flex align-items-center gap-2 mb-1 flex-wrap">
+            <span class="fw-semibold" id="krwPreview" style="font-size:.95rem;">≈ 원화 —</span>
+            <button type="button" class="btn btn-outline-primary btn-sm py-0 px-2" id="btnConvertKrw"
+                    onclick="convertToKrw()" title="환율을 적용해 가격을 원화(KRW)로 바꿉니다">↻ 원화로 환산</button>
           </div>
+          <div class="text-muted mb-3" id="fxNote" style="font-size:.74rem;"></div>
         </div>
+      </div>
+
+      <!-- 상세 설명 (전체 폭 · 확대 에디터) -->
+      <div class="mt-2">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <label class="form-label small fw-semibold mb-0" for="editDescription">상세 설명</label>
+          <span class="text-muted" style="font-size:.75rem;"><span id="descCharCount">0</span>자</span>
+        </div>
+        <textarea class="form-control" id="editDescription" rows="14"
+                  style="min-height:300px;font-size:.95rem;line-height:1.6;"
+                  placeholder="상품 상세 설명 — 마켓 상세페이지에 노출됩니다. 소재·사이즈·사용법 등 충분히 길게 작성할수록 전환율이 올라갑니다."
+                  oninput="updateDescCount()"></textarea>
       </div>
 
       <hr class="my-3">
@@ -214,6 +228,8 @@
 const _ITEM = {{ item | tojson }};
 const _EXTRA = {{ extra | tojson }};
 const _ITEM_ID = {{ item.id | tojson }};
+const _FX = {{ fx_rates | tojson }};            // {USD:1370.5, JPY:9.12, ..., KRW:1}
+const _FX_MOCK = {{ fx_is_mock | tojson }};      // 실시간 연결 전이면 true(기본값)
 
 function _firstNonEmpty(...vals) {
   for (const v of vals) {
@@ -275,6 +291,66 @@ function refreshPrimaryImage() {
   else { img.removeAttribute('src'); img.style.visibility = 'hidden'; }
 }
 
+// ── 원화 환산 (환율 계산기) ──
+function _fmtKrw(n) { return Math.round(n).toLocaleString('ko-KR'); }
+
+function _currentPriceCur() {
+  const price = parseFloat(document.getElementById('editPrice').value);
+  const cur = document.getElementById('editCurrency').value;
+  return { price: isNaN(price) ? 0 : price, cur };
+}
+
+function updateKrwPreview() {
+  const { price, cur } = _currentPriceCur();
+  const prevEl = document.getElementById('krwPreview');
+  const noteEl = document.getElementById('fxNote');
+  const btn = document.getElementById('btnConvertKrw');
+  const srcLabel = _FX_MOCK ? '기본값(실시간 연결 전)' : '실시간';
+
+  if (cur === 'KRW') {
+    prevEl.textContent = price > 0 ? `원화 ${_fmtKrw(price)}원` : '원화 입력';
+    prevEl.className = 'fw-semibold text-success';
+    noteEl.textContent = '이미 원화(KRW)입니다.';
+    btn.disabled = true;
+    return;
+  }
+  const rate = _FX[cur];
+  if (!rate) {
+    prevEl.textContent = '≈ 원화 — (환율 미지원 통화)';
+    prevEl.className = 'fw-semibold text-muted';
+    noteEl.textContent = `${cur}→KRW 환율이 없어 자동 환산할 수 없습니다. 직접 원화로 입력하세요.`;
+    btn.disabled = true;
+    return;
+  }
+  btn.disabled = !(price > 0);
+  if (price > 0) {
+    prevEl.textContent = `≈ 원화 약 ${_fmtKrw(price * rate)}원`;
+    prevEl.className = 'fw-semibold text-primary';
+  } else {
+    prevEl.textContent = '≈ 원화 —';
+    prevEl.className = 'fw-semibold text-muted';
+  }
+  noteEl.textContent = `적용 환율 1 ${cur} = ${rate.toLocaleString('ko-KR')}원 (${srcLabel})`;
+}
+
+function convertToKrw() {
+  const { price, cur } = _currentPriceCur();
+  if (cur === 'KRW' || !(price > 0)) return;
+  const rate = _FX[cur];
+  if (!rate) return;
+  document.getElementById('editPrice').value = Math.round(price * rate);
+  document.getElementById('editCurrency').value = 'KRW';
+  updateKrwPreview();
+  if (window.pcToast) pcToast(`${cur} → 원화로 환산했습니다.`, 'success');
+}
+
+// ── 상세 설명 글자수 ──
+function updateDescCount() {
+  const el = document.getElementById('editDescription');
+  const cnt = document.getElementById('descCharCount');
+  if (el && cnt) cnt.textContent = (el.value || '').length.toLocaleString('ko-KR');
+}
+
 function initEditor() {
   document.getElementById('editTitle').value =
     _firstNonEmpty(_EXTRA.title_ko, _EXTRA.title, _ITEM.title);
@@ -293,6 +369,8 @@ function initEditor() {
   if (document.querySelectorAll('#imageRows .img-row').length === 0) addImageRow('');
   _initOptions().forEach(o => addOptionRow(o.name, o.values));
   refreshPrimaryImage();
+  updateKrwPreview();
+  updateDescCount();
 }
 
 // ── 폼 → 상품 데이터 ──

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -3793,11 +3793,29 @@ def collect_preview_by_id(item_id: str):
     except Exception:
         pass
 
+    # 원화 환산용 환율 주입 (편집 페이지 환율 계산기). 실패해도 편집은 동작.
+    fx_rates: dict = {"KRW": 1.0}
+    fx_is_mock = True
+    fx_updated = ""
+    try:
+        from .data_aggregator import get_fx_rates
+        fxd = get_fx_rates() or {}
+        for code in ("USD", "JPY", "CNY", "EUR"):
+            if isinstance(fxd.get(code), (int, float)):
+                fx_rates[code] = float(fxd[code])
+        fx_is_mock = bool(fxd.get("is_mock", True))
+        fx_updated = str(fxd.get("updated_at") or "")
+    except Exception as exc:
+        logger.debug("FX 환율 주입 실패: %s", exc)
+
     return render_template(
         "collect_preview.html",
         page="collect_history",
         item=item,
         extra=extra,
+        fx_rates=fx_rates,
+        fx_is_mock=fx_is_mock,
+        fx_updated=fx_updated,
     )
 
 

--- a/tests/test_collect_preview_view.py
+++ b/tests/test_collect_preview_view.py
@@ -68,3 +68,22 @@ class TestCollectPreviewView:
             resp = client.get("/seller/collect/preview/abc123")
         assert b"98.00" in resp.data
         assert b"USD" in resp.data
+
+    def test_preview_injects_fx_and_krw_calculator(self, client):
+        """원화 환산 계산기(환율 주입 + 환산 버튼)가 페이지에 포함됨."""
+        with patch("src.seller_console.collect_history_store.get", return_value=_MOCK_ITEM):
+            resp = client.get("/seller/collect/preview/abc123")
+        body = resp.data
+        assert "원화로 환산".encode() in body
+        assert b"const _FX" in body
+        assert b"updateKrwPreview" in body
+        # 환율 맵에 KRW 기준(1.0) 포함
+        assert b'"KRW"' in body or b"'KRW'" in body
+
+    def test_preview_has_larger_description_editor(self, client):
+        """상세 설명 에디터가 확대됨(rows 14 + 글자수 카운터)."""
+        with patch("src.seller_console.collect_history_store.get", return_value=_MOCK_ITEM):
+            resp = client.get("/seller/collect/preview/abc123")
+        body = resp.data
+        assert b'rows="14"' in body
+        assert b"descCharCount" in body


### PR DESCRIPTION
## 개요
오너 지시 "세세하게 디테일 손보자 / 퍼센티 벤치마킹"의 일부 — 수집 상품 **편집 페이지** 개선 2건.

### ① 가격 원화 환율 계산기 (가격 0/외화 문제 보완)
수집 가격이 외화(USD/JPY 등)로 들어오거나 0으로 보일 때 셀러가 원화 감을 못 잡던 문제. 편집 페이지에 **실시간 환율 계산기**를 배치:
- 서버가 `get_fx_rates()`(실시간/환경변수/기본값)를 편집 페이지에 주입.
- 가격/통화 입력 시 **"≈ 원화 약 N원"** 실시간 표시.
- **"↻ 원화로 환산"** 버튼 → 가격×환율을 계산해 가격칸을 원화로 채우고 통화를 KRW로 전환.
- 적용 환율과 출처(실시간/기본값) 명시. KRW·환율 미지원 통화는 정직하게 안내(거짓 환산 금지).

### ② 상세 설명 에디터 확대 (퍼센티 벤치마킹)
상세설명 칸이 너무 작던 문제(rows=4) → **rows=14 전체 폭 확대 섹션**으로 분리 + **글자수 카운터**. 마켓 상세페이지 노출용임을 안내 문구로 명시.

## 변경
- `seller_console/views.py` `collect_preview_by_id`: `fx_rates`/`fx_is_mock`/`fx_updated` 컨텍스트 주입(실패해도 편집 동작).
- `templates/collect_preview.html`: 환율 계산기 UI + JS(`updateKrwPreview`/`convertToKrw`), 상세설명 확대 + 카운터(`updateDescCount`).

## 테스트
- `tests/test_collect_preview_view.py` 신규: 환율 주입·환산 버튼·확대 에디터 렌더 검증.
- 전체 `python -m pytest tests/ -q` → **9930 passed, 2 skipped** (회귀 0).

## 비고 (남은 후속)
- 실제 가격 추출 실패(yoshidakaban=봇 차단 403)는 외부 사이트 차단 이슈라 별도 검토 필요. 이 PR은 외화/0 상황에서 셀러가 원화로 보정·확정할 수단을 제공.
- 대시보드 KPI 실데이터화, 수집 페이지 '퍼센티 수집' 원클릭 버튼은 후속 PR로 진행 예정.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_