### PR TITLE
feat(dashboard): KPI 하드코딩 목업 제거 + 오늘 수집 건수 실데이터 (Phase 209)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,21 @@
    - **외부 승인에 막힌 항목(코드 아님, 오너측)**: Amazon SP-API / eBay / Shopee = 셀러 등록·OAuth 승인·
      키 발급 필요(`markets/adapters/{amazon,ebay,shopee}.py`는 스캐폴드 stub 유지). 승인 완료 후 실연동 착수.
 
+## 🔧 UI/디테일 보완 (오너 지시 2026-06-16, 라이브 화면 스크린샷 기반 — 퍼센티 벤치마킹)
+오너가 실제 화면(kohganepercentiii.com)을 보고 지적한 디테일들을 순차 처리:
+1. ✅ **쿠팡 업로드 NoneType 크래시** (PR #224): 쿠팡 응답 `data`가 sellerProductId 숫자(또는
+   거부 시 null)인데 `result.get('data',{}).get(...)`가 None/int에서 크래시. dict/int/str/None 안전
+   처리 + data=null·비성공코드는 가짜 성공 대신 정직한 실패. `get_categories`도 동일 수정.
+2. ✅ **편집 페이지 원화 환율 계산기 + 상세설명 확대** (PR #225): 수집가가 외화/0일 때 셀러가 원화
+   감 못 잡던 문제 → `collect_preview_by_id`에 `get_fx_rates()` 주입, '≈원화 약 N원' 실시간 표시 +
+   '↻원화로 환산' 버튼(가격×환율→KRW). KRW·미지원통화는 정직 안내. 상세설명 rows 4→14 전체폭+글자수.
+3. ✅ **대시보드 KPI 목업 제거 + 실데이터** (Phase 209): `data_aggregator.py`의 하드코딩 목업
+   (오늘수집 5/주문 12/등록대기 3/[Mock] 알림) 제거. 오늘 수집 건수는 `collect_history_store.summary().today`
+   실 집계, 주문수는 OrderSync:kpi(이미 실), 나머지는 실 모듈 없으면 정직하게 0/빈목록(가짜 값 금지).
+   ※ 마켓 등록/동기화 표·재고부족은 이미 Sheets catalog 실연동(미설정 시 0) — 그대로 유지.
+- **남은 후속(이 지시)**: 수집 페이지 '퍼센티 수집' 원클릭 버튼(④/⑤), 실 가격 추출 개선
+  (yoshidakaban 등 일부 사이트 봇차단 403 — 별도 검토). 진행 예정.
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/src/seller_console/data_aggregator.py
+++ b/src/seller_console/data_aggregator.py
@@ -35,31 +35,46 @@ def _safe_import(module_path: str, attr: str = None) -> Optional[Any]:
 def get_today_kpi() -> Dict[str, Any]:
     """오늘 KPI 카드 데이터 반환 (주문수, GMV, 마진, 신규 수집).
 
-    Phase 33/97 (pricing), Phase 114 (seller_report) 모듈 재사용.
+    실데이터 우선: 오늘 수집 건수는 collect_history_store(실 저장소)에서 집계.
+    GMV/마진/주문수는 seller_report 모듈이 있으면 사용, 없으면 0(가짜 값 금지).
+    Phase 209: 하드코딩 목업 제거 — 데이터 없으면 정직하게 0.
     """
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    mock_data = {
+    data: Dict[str, Any] = {
         "date": today,
-        "order_count": 12,
-        "gmv_krw": 1_850_000,
-        "margin_krw": 340_000,
-        "margin_pct": 18.4,
-        "new_products_collected": 5,
+        "order_count": 0,
+        "gmv_krw": 0,
+        "margin_krw": 0,
+        "margin_pct": 0.0,
+        "new_products_collected": 0,
         "is_mock": True,
     }
+    has_real = False
+
+    # 오늘 수집 건수 — 실 저장소(collect_history_store)에서 집계
+    try:
+        from .collect_history_store import summary as collect_summary
+        s = collect_summary(days=2)
+        if isinstance(s, dict):
+            data["new_products_collected"] = int(s.get("today", 0) or 0)
+            has_real = True
+    except Exception as exc:
+        logger.debug("collect_history 오늘 수집 집계 실패: %s", exc)
 
     try:
-        # Phase 114: seller_report 모듈에서 오늘 요약 조회 시도
+        # Phase 114: seller_report 모듈에서 오늘 요약 조회 시도 (GMV/마진/주문수)
         seller_report_mod = _safe_import("src.seller_report")
         if seller_report_mod and hasattr(seller_report_mod, "get_daily_summary"):
             summary = seller_report_mod.get_daily_summary(today)
             if summary:
-                mock_data.update(summary)
-                mock_data["is_mock"] = False
+                data.update(summary)
+                has_real = True
     except Exception as exc:
-        logger.debug("seller_report 데이터 조회 실패 (mock 사용): %s", exc)
+        logger.debug("seller_report 데이터 조회 실패: %s", exc)
 
-    return mock_data
+    if has_real:
+        data["is_mock"] = False
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -71,12 +86,13 @@ def get_collect_queue_status() -> Dict[str, Any]:
 
     Phase 17 (collectors) 모듈 재사용.
     """
-    mock_data = {
-        "pending": 3,
-        "translating": 1,
-        "reviewing": 2,
-        "uploaded": 8,
-        "total": 14,
+    # Phase 209: 하드코딩 목업(3/1/2/8) 제거 — 실 큐 모듈 없으면 정직하게 0.
+    data = {
+        "pending": 0,
+        "translating": 0,
+        "reviewing": 0,
+        "uploaded": 0,
+        "total": 0,
         "is_mock": True,
     }
 
@@ -85,12 +101,12 @@ def get_collect_queue_status() -> Dict[str, Any]:
         if collectors_mod and hasattr(collectors_mod, "get_queue_status"):
             status = collectors_mod.get_queue_status()
             if status:
-                mock_data.update(status)
-                mock_data["is_mock"] = False
+                data.update(status)
+                data["is_mock"] = False
     except Exception as exc:
-        logger.debug("collectors 큐 상태 조회 실패 (mock 사용): %s", exc)
+        logger.debug("collectors 큐 상태 조회 실패: %s", exc)
 
-    return mock_data
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -154,31 +170,10 @@ def get_sourcing_alerts() -> Dict[str, Any]:
 
     Phase 108 (source_monitor) 모듈 재사용.
     """
-    mock_data = {
-        "alerts": [
-            {
-                "type": "price_change",
-                "label": "가격 변동",
-                "product": "[Mock] Porter Tank — 가격 +12%",
-                "source": "porter",
-                "severity": "warning",
-            },
-            {
-                "type": "out_of_stock",
-                "label": "품절",
-                "product": "[Mock] Alo Yoga Legging XS — 재고 없음",
-                "source": "alo",
-                "severity": "error",
-            },
-            {
-                "type": "new_product",
-                "label": "신상품",
-                "product": "[Mock] Lululemon 2026 FW 신상 10종 감지",
-                "source": "lululemon",
-                "severity": "info",
-            },
-        ],
-        "count": 3,
+    # Phase 209: 가짜 [Mock] 알림 제거 — 실 source_monitor 알림 없으면 빈 목록(정직).
+    data: Dict[str, Any] = {
+        "alerts": [],
+        "count": 0,
         "is_mock": True,
     }
 
@@ -187,13 +182,13 @@ def get_sourcing_alerts() -> Dict[str, Any]:
         if source_monitor_mod and hasattr(source_monitor_mod, "get_recent_alerts"):
             alerts = source_monitor_mod.get_recent_alerts(limit=5)
             if alerts:
-                mock_data["alerts"] = alerts
-                mock_data["count"] = len(alerts)
-                mock_data["is_mock"] = False
+                data["alerts"] = alerts
+                data["count"] = len(alerts)
+                data["is_mock"] = False
     except Exception as exc:
-        logger.debug("source_monitor 알림 조회 실패 (mock 사용): %s", exc)
+        logger.debug("source_monitor 알림 조회 실패: %s", exc)
 
-    return mock_data
+    return data
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_seller_console.py
+++ b/tests/test_seller_console.py
@@ -851,3 +851,30 @@ class TestDataAggregator:
         result = get_sourcing_alerts()
         assert "alerts" in result
         assert isinstance(result["alerts"], list)
+
+    def test_today_kpi_uses_real_collect_count(self):
+        """오늘 수집 건수는 collect_history_store 실 집계를 사용 (Phase 209)."""
+        from unittest.mock import patch
+        from src.seller_console.data_aggregator import get_today_kpi
+        with patch("src.seller_console.collect_history_store.summary",
+                   return_value={"today": 7, "total": 20, "domains": 2, "by_source": {}}):
+            result = get_today_kpi()
+        assert result["new_products_collected"] == 7
+        assert result["is_mock"] is False
+
+    def test_no_fabricated_mock_constants(self):
+        """하드코딩 목업(5/12/3/[Mock]) 제거 — 데이터 없으면 정직하게 0/빈 목록."""
+        from unittest.mock import patch
+        from src.seller_console.data_aggregator import (
+            get_today_kpi, get_collect_queue_status, get_sourcing_alerts,
+        )
+        # 수집 저장소가 비어있으면 오늘 수집 0 (가짜 5 아님)
+        with patch("src.seller_console.collect_history_store.summary",
+                   return_value={"today": 0, "total": 0, "domains": 0, "by_source": {}}):
+            kpi = get_today_kpi()
+        assert kpi["order_count"] == 0  # 가짜 12 아님
+        assert kpi["new_products_collected"] == 0
+        q = get_collect_queue_status()
+        assert q["pending"] == 0  # 가짜 3 아님
+        alerts = get_sourcing_alerts()
+        assert alerts["alerts"] == []  # 가짜 [Mock] 아님


### PR DESCRIPTION
## 개요
오너 지적: 대시보드의 **오늘 수집 건수·주문 수·등록 대기·최근 활동**이 아직 목업(5/3/12, `[Mock]` 알림). "실작동되게끔 해야지."

## 원인 (팩트)
`src/seller_console/data_aggregator.py`가 실 데이터 소스 모듈이 없으면 **하드코딩된 가짜 값**을 반환:
- `get_today_kpi`: `order_count=12`, `new_products_collected=5`
- `get_collect_queue_status`: `pending=3, translating=1, ...`
- `get_sourcing_alerts`: `[Mock] Porter Tank …` 등 가짜 알림 3건

## 변경 (가짜 데이터 제거 + 실데이터 연결)
- **오늘 수집 건수 → 실 집계**: `collect_history_store.summary().today`(Sheets/인메모리 실 저장소)에서 산출 → `is_mock=False`.
- **주문 수**: 대시보드 주문 카드는 이미 `OrderSyncService.kpi_summary()`(Sheets 실데이터) 사용. KPI의 가짜 `order_count=12` 폴백 제거 → 실데이터 또는 0.
- **등록 대기/소싱 알림**: 실 큐·알림 모듈이 없으므로 **가짜 상수 제거 → 0/빈 목록**(정직). 실 모듈 생기면 자동 연결되는 graceful 구조 유지.
- **마켓 등록/동기화 표·재고 부족**: 이미 Sheets `catalog` 실연동(미설정 시 0, 스크린샷처럼) — 변경 없음.

## 정직성
- 데이터 소스가 없을 때 **가짜 숫자 대신 0/빈 목록**을 보여줌(거짓 KPI 금지). `DASHBOARD_SHOW_MOCK=0`(기본)에서 mock 숨김 동작과 일관.

## 테스트
- 신규: 오늘 수집 건수 실 집계 사용, 가짜 상수(5/12/3/[Mock]) 미노출 검증.
- 전체 `python -m pytest tests/ -q` → **9932 passed, 2 skipped** (회귀 0).

## 오너 액션 (durable)
- 주문 수·마켓 표가 실제 숫자로 차려면 `GOOGLE_SHEET_ID`(orders/catalog 워크시트) 설정 필요. 미설정 시 0(정직).

## 남은 후속 (같은 지시)
- 수집 페이지 '퍼센티 수집' 원클릭 버튼, 실 가격 추출 개선(일부 사이트 봇차단 403) — 다음 PR.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_