### PR TITLE
fix(ai-listing): 실 업로더 연동 + 마켓 페이지 링크 + 마켓 추가 (Phase 211)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,18 @@
 - **남은 후속(이 지시)**: 실 가격 추출 개선 — yoshidakaban 등 일부 사이트 봇차단(403)으로 외부에서
   가격 마크업 확인 불가. 편집 페이지 환율 계산기로 외화/0 보정은 제공됨(#225). 사이트별 셀렉터는 별도 검토.
 
+## 🔧 UI/디테일 보완 2차 (오너 지시 2026-06-16, 라이브 스크린샷)
+1. ✅ **AI 수집기(`/seller/listing/ai-create`) 실발행 + 마켓 추가 + 마켓 링크** (Phase 211): `ai_listing/
+   multi_publisher.py`가 존재하지 않는 `publish_to_channel` import 실패 → 항상 가짜 `MOCK-COUPANG-…`
+   성공으로 폴백했음. → `_publish_to_market`을 수동 업로드와 동일한 `UploadDispatcher`(실 업로더)로 재배선.
+   `PublishJob.product_url` 추가 → 결과에 '마켓 페이지 열기' 링크. 마켓 목록에 shopify/woocommerce/
+   shopee/amazon 추가(쇼피/아마존은 미연동 시 정직한 실패). 11st→elevenst 코드 매핑. 자격증명 없으면
+   가짜 성공 대신 정직한 실패.
+- **남은 후속(이 지시)**: ① 봇 차단(403) 사이트 수집 — 크롬확장이 브라우저 DOM을 서버로 보내 파싱하는
+  경로 필요(any-site 수집). ② 편집 페이지 풀 편집(키워드/썸네일 선택) 보강. ③ Google 로그인 '안 눌림'은
+  코드 정상(=`/auth/google/start` 라우트·provider 정상) → 구글 콘솔 redirect_uri/client 설정 문제로 추정
+  (로그인 페이지 '🔧 OAuth 콜백 URI 확인' 펼치기로 자가진단). 순차 진행 예정.
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/src/ai_listing/multi_publisher.py
+++ b/src/ai_listing/multi_publisher.py
@@ -33,6 +33,7 @@ class PublishJob:
     job_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     status: str = "queued"  # queued | publishing | success | failed
     external_product_id: Optional[str] = None
+    product_url: Optional[str] = None        # 마켓 실제 상품 페이지 URL
     error_message: Optional[str] = None
     published_at: Optional[str] = None
 
@@ -67,6 +68,7 @@ class PublishResult:
                     "market": j.market,
                     "status": j.status,
                     "external_product_id": j.external_product_id,
+                    "product_url": j.product_url,
                     "error_message": j.error_message,
                     "published_at": j.published_at,
                 }
@@ -75,40 +77,88 @@ class PublishResult:
         }
 
 
-# ── 마켓 어댑터 (mock) ────────────────────────────────────────────────────────
+# ── 실 업로더 연동 (수동 업로드와 동일한 UploadDispatcher 경로) ────────────────
 
-def _mock_publish(job: PublishJob) -> PublishJob:
-    """Mock 마켓 등록 (실제 API 미연결 시)."""
-    import time
-    time.sleep(0.05)  # 네트워크 지연 시뮬레이션
-    job.status = "success"
-    job.external_product_id = f"MOCK-{job.market.upper()}-{job.job_id[:8]}"
-    job.published_at = datetime.now(timezone.utc).isoformat()
-    logger.info("[mock] %s 등록 성공: %s", job.market, job.external_product_id)
-    return job
+# AI 페이지 마켓 코드 → UploadDispatcher 마켓 코드
+_MARKET_CODE_MAP = {
+    "coupang": "coupang",
+    "smartstore": "smartstore",
+    "11st": "elevenst",
+    "elevenst": "elevenst",
+    "woocommerce": "woocommerce",
+    "kohganemultishop": "woocommerce",
+    "shopify": "shopify",
+}
+
+
+def _build_dispatch_product(job: PublishJob) -> Dict[str, Any]:
+    """AI 분석/마켓별 데이터 → UploadDispatcher product_data 형식.
+
+    market_data[market] = {title, description, tags, category_code, suggested_price_krw}
+    analysis = 공통 분석(이미지/원문/브랜드 등).
+    """
+    pd = job.product_data or {}
+    analysis = pd.get("analysis") or {}
+    md = (pd.get("market_data") or {}).get(job.market) or {}
+
+    images = (
+        analysis.get("images")
+        or analysis.get("image_urls")
+        or analysis.get("processed_image_urls")
+        or []
+    )
+    price_krw = md.get("suggested_price_krw") or analysis.get("suggested_price_krw") or 0
+    title = md.get("title") or analysis.get("title_translated") or analysis.get("title") or ""
+    return {
+        "sku": pd.get("listing_id") or job.ai_listing_id or "",
+        "title": title,
+        "title_ko": title,
+        "sell_price_krw": price_krw,
+        "price_krw": price_krw,
+        "currency": "KRW",
+        "category_code": md.get("category_code") or analysis.get("category_code") or "",
+        "description": md.get("description") or analysis.get("description") or "",
+        "description_html": md.get("description") or analysis.get("description") or "",
+        "images": images if isinstance(images, list) else [],
+        "options": analysis.get("options") or {},
+        "keywords": md.get("tags") or analysis.get("keywords") or [],
+        "brand": analysis.get("brand") or "",
+        "url": analysis.get("source_url") or analysis.get("url") or "",
+    }
 
 
 def _publish_to_market(job: PublishJob) -> PublishJob:
-    """단일 마켓 등록 (어댑터 연동 또는 mock)."""
-    job.status = "publishing"
-    try:
-        # Phase 143 auto_publish 어댑터 연동 시도
-        from src.listing.auto_publish import publish_to_channel
+    """단일 마켓 실 등록 — 수동 업로드와 동일한 UploadDispatcher(실 업로더) 사용.
 
-        result = publish_to_channel(
-            channel=job.market,
-            product=job.product_data,
-        )
-        if result and result.get("ok"):
+    자격증명 미설정·API 실패 시 가짜 성공이 아니라 정직하게 실패/큐로 기록한다.
+    지원하지 않는 마켓(쇼피/아마존 등 미연동)은 실패 + 사유.
+    """
+    job.status = "publishing"
+    mapped = _MARKET_CODE_MAP.get(job.market)
+    if not mapped:
+        job.status = "failed"
+        job.error_message = f"{job.market}는 자동발행 미연동입니다(마켓 승인·연동 필요)."
+        return job
+    try:
+        from src.seller_console.upload_dispatcher import UploadDispatcher
+
+        product_data = _build_dispatch_product(job)
+        result = UploadDispatcher().dispatch(product_data, [mapped])
+        r = result.results[0] if result.results else None
+        if r is None:
+            job.status = "failed"
+            job.error_message = "업로드 결과가 비어 있습니다."
+        elif r.success:
             job.status = "success"
-            job.external_product_id = result.get("product_id", f"EXT-{job.job_id[:8]}")
+            job.external_product_id = r.external_product_id or f"EXT-{job.job_id[:8]}"
+            job.product_url = r.external_url
             job.published_at = datetime.now(timezone.utc).isoformat()
+        elif r.queued:
+            job.status = "failed"  # 실제 등록은 아직 안 됨 → 재시도 큐로
+            job.error_message = (r.message or "큐 적재됨") + (f" ({r.hint})" if r.hint else "")
         else:
             job.status = "failed"
-            job.error_message = result.get("error", "등록 실패") if result else "응답 없음"
-    except (ImportError, AttributeError):
-        # Phase 143 어댑터 미연결 → mock
-        job = _mock_publish(job)
+            job.error_message = (r.message or "등록 실패") + (f" ({r.hint})" if r.hint else "")
     except Exception as exc:
         job.status = "failed"
         job.error_message = str(exc)[:200]

--- a/src/ai_listing/routes.py
+++ b/src/ai_listing/routes.py
@@ -555,8 +555,9 @@ function showPublishResults(data) {
   const rows = results.map(r => {
     const icon = r.status === 'success' ? '✅' : '❌';
     const retry = r.status === 'failed' ? `<button class='btn btn-xs btn-outline-danger ms-2 btn-sm' onclick='retryMarket("${r.market}")'>재시도</button>` : '';
+    const link = r.product_url ? ` · <a href="${r.product_url}" target="_blank" rel="noopener noreferrer">마켓 페이지 열기 →</a>` : '';
     return `<li class='list-group-item d-flex justify-content-between align-items-center'>
-      <span>${icon} <strong>${r.market}</strong> ${r.external_product_id ? '— ID: ' + r.external_product_id : ''}</span>
+      <span>${icon} <strong>${r.market}</strong> ${r.external_product_id ? '— ID: ' + r.external_product_id : ''}${link}</span>
       <span>${r.error_message ? '<span class=text-danger small>' + r.error_message + '</span>' : ''} ${retry}</span>
     </li>`;
   }).join('');
@@ -613,7 +614,8 @@ def ai_listing_create():
         current_phase = get_current_phase()
     except Exception:
         current_phase = 153
-    all_markets = ["coupang", "smartstore", "11st", "gmarket"]
+    # 실 업로더 연동 마켓(쿠팡/스마트스토어/11번가/Shopify/코가네멀티샵) + 미연동(쇼피/아마존=승인 필요)
+    all_markets = ["coupang", "smartstore", "11st", "shopify", "woocommerce", "gmarket", "shopee", "amazon"]
     default_weight_kg = float(os.getenv("PRICING_DEFAULT_WEIGHT_KG", "0.5"))
     return render_template_string(
         _AI_CREATE_PAGE,

--- a/tests/test_ai_listing_multi_publisher.py
+++ b/tests/test_ai_listing_multi_publisher.py
@@ -53,7 +53,8 @@ class TestPublishToMarkets:
         job_markets = {j.market for j in result.jobs}
         assert job_markets == set(markets)
 
-    def test_mock_publish_success(self):
+    def test_no_credentials_is_honest_failure_not_mock(self):
+        """자격증명 미설정 시 가짜 MOCK 성공이 아니라 정직한 실패 (Phase 211)."""
         from src.ai_listing.multi_publisher import publish_to_markets
 
         result = publish_to_markets(
@@ -61,8 +62,45 @@ class TestPublishToMarkets:
             product_data=SAMPLE_PRODUCT,
             markets=["coupang"],
         )
-        # mock 모드에서는 성공해야 함
-        assert result.success_count >= 0  # 최소 실패가 없어야 함
+        # 가짜 MOCK 성공 ID를 만들지 않는다
+        for j in result.jobs:
+            assert not (j.external_product_id or "").startswith("MOCK-")
+        assert result.success_count + result.failed_count == len(result.jobs)
+
+    def test_unsupported_market_honest_failure(self):
+        """쇼피/아마존 등 미연동 마켓은 가짜 성공이 아니라 실패 + 사유."""
+        from src.ai_listing.multi_publisher import publish_to_markets
+
+        result = publish_to_markets(
+            ai_listing_id="test-004b",
+            product_data=SAMPLE_PRODUCT,
+            markets=["shopee"],
+        )
+        job = result.jobs[0]
+        assert job.status == "failed"
+        assert "미연동" in (job.error_message or "")
+
+    def test_real_dispatch_success_maps_url(self, monkeypatch):
+        """UploadDispatcher 성공 시 external_product_id + product_url 매핑."""
+        from unittest.mock import MagicMock
+        import src.ai_listing.multi_publisher as mp
+
+        fake_result = MagicMock()
+        fake_result.results = [MagicMock(success=True, queued=False,
+                                         external_product_id="CP-77",
+                                         external_url="https://coupang.com/vp/products/CP-77")]
+        fake_dispatcher = MagicMock()
+        fake_dispatcher.return_value.dispatch.return_value = fake_result
+        monkeypatch.setattr(
+            "src.seller_console.upload_dispatcher.UploadDispatcher", fake_dispatcher
+        )
+        result = mp.publish_to_markets(
+            ai_listing_id="test-004c", product_data=SAMPLE_PRODUCT, markets=["coupang"],
+        )
+        job = result.jobs[0]
+        assert job.status == "success"
+        assert job.external_product_id == "CP-77"
+        assert job.product_url == "https://coupang.com/vp/products/CP-77"
 
     def test_to_dict_structure(self):
         from src.ai_listing.multi_publisher import publish_to_markets
@@ -119,15 +157,3 @@ class TestPublishToMarkets:
         assert "success_24h" in stats
         assert "failed_24h" in stats
         assert "by_market" in stats
-
-
-class TestMockPublish:
-    def test_mock_publish_sets_success(self):
-        from src.ai_listing.multi_publisher import _mock_publish, PublishJob
-
-        job = PublishJob(ai_listing_id="x", market="coupang", product_data={})
-        result = _mock_publish(job)
-        assert result.status == "success"
-        assert result.external_product_id is not None
-        assert "MOCK" in result.external_product_id
-        assert result.published_at is not None


### PR DESCRIPTION
## 개요
오너 지적(스크린샷): AI 상품등록(`/seller/listing/ai-create`)이 **`coupang — ID: MOCK-COUPANG-c9b560bd`** 처럼 가짜로만 뜨고, **마켓 실제 페이지로 갈 수도, 수정할 수도 없음**. 또 **대상 마켓에 멀티샵/쇼피파이/쇼피/아마존이 없음**.

## 원인 (팩트)
- `src/ai_listing/multi_publisher.py:_publish_to_market`가 `from src.listing.auto_publish import publish_to_channel`를 import하는데 **그 함수는 존재하지 않음** → `ImportError` → **항상 `_mock_publish`로 폴백**해서 `MOCK-{MARKET}-{id}` 가짜 성공 반환.
- 마켓 체크박스가 `["coupang","smartstore","11st","gmarket"]` 4개로 하드코딩.

## 변경
- **실 업로더 연동**: `_publish_to_market`을 수동 업로드와 **동일한 `UploadDispatcher`(실 업로더: 쿠팡 Wing/네이버/11번가/Shopify/WooCommerce)**로 재배선. AI 분석·마켓별 데이터 → 디스패처 product_data로 매핑(`11st`→`elevenst` 코드 매핑 포함).
- **마켓 페이지 링크**: `PublishJob.product_url`(=`external_url`) 추가 → 결과 화면에 **"마켓 페이지 열기 →"** 링크 노출. (Shopify는 실제 상품 admin/스토어 URL 반환)
- **마켓 추가**: 체크박스에 `shopify`, `woocommerce`(실연동) + `shopee`, `amazon`(미연동) 추가.
- **정직성**: 자격증명 미설정·미연동 마켓(쇼피/아마존)·API 실패 시 **가짜 MOCK 성공이 아니라 실패 + 사유**. `MOCK-...` ID 생성 제거.

## 테스트
- 신규: 자격증명 미설정 시 가짜 MOCK ID 미생성·정직 실패, 미연동 마켓 실패+사유, 실 dispatch 성공 시 `external_product_id`+`product_url` 매핑.
- 전체 `python -m pytest tests/ -q` → **9934 passed, 2 skipped** (회귀 0).

## 오너 액션
- 각 마켓 실제 등록·링크가 뜨려면 해당 마켓 자격증명 필요(쿠팡/네이버/11번가/Shopify/WC). Shopify는 이미 연결됨 → 실제 상품 URL 노출됨.

## 남은 후속 (같은 지시 — 다음 PR)
- ① **봇 차단(403) 사이트 수집**: 크롬확장이 브라우저 DOM을 서버로 보내 파싱(any-site 수집).
- ② **편집 페이지 풀 편집**(키워드/썸네일 선택) 보강.
- ③ **Google 로그인 '안 눌림'**: 코드(`/auth/google/start`·provider)는 정상 → 구글 콘솔 redirect_uri/client 설정 문제로 추정. 로그인 페이지 '🔧 OAuth 콜백 URI 확인' 펼치기로 자가진단 가능.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_