### PR TITLE
feat(collect): 봇 차단 사이트 수집 — 확장 HTML 서버 파싱 (Phase 212)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,16 @@
   코드 정상(=`/auth/google/start` 라우트·provider 정상) → 구글 콘솔 redirect_uri/client 설정 문제로 추정
   (로그인 페이지 '🔧 OAuth 콜백 URI 확인' 펼치기로 자가진단). 순차 진행 예정.
 
+### 나열순 후속 — 차례대로 진행 (오너 지시 2026-06-16)
+1. ✅ **봇 차단 사이트도 수집** (Phase 212): 서버 직접 fetch는 403 차단됨 → 크롬확장이 **브라우저 페이지
+   HTML(`document.documentElement.outerHTML`, 600KB 상한)을 함께 전송** → 서버가 `UniversalScraper.parse_html()`
+   (신설, 네트워크 fetch 없이 JSON-LD/OG/Microdata/Heuristic 파싱)로 가격/통화/이미지/제목/옵션 보강.
+   `/api/v1/collect/extension`이 `html` 수신 시 `_merge_scraped_into_payload`로 **빈 값·가격0만 보강**
+   (사용자 값 우선, 대용량 html은 이력에 미저장). 확장 manifest 1.1.0→1.2.0.
+   → 사용자가 브라우저로 볼 수 있는 어떤 사이트(봇차단 포함)든 인페이지 🛒'수집'으로 수집 가능.
+2. ⏳ 편집 페이지 풀 편집(키워드/썸네일) — 진행 예정.
+3. ⏳ Google 로그인(설정 진단) — 진행 예정.
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -60,6 +60,15 @@ function extractProductMeta() {
     }
   }
 
+  // 봇 차단(403) 사이트도 수집되도록 페이지 HTML을 함께 전송 → 서버가 파싱(가격/이미지/옵션 보강).
+  // 대용량 방지를 위해 상한(600KB)으로 자른다.
+  let pageHtml = "";
+  try {
+    pageHtml = (document.documentElement ? document.documentElement.outerHTML : "").slice(0, 600000);
+  } catch (e) {
+    pageHtml = "";
+  }
+
   return {
     url: location.href,
     title: getMeta("og:title") || document.title || "",
@@ -70,6 +79,7 @@ function extractProductMeta() {
     description: getMeta("og:description") || getMeta("description") || "",
     brand: getMeta("og:brand") || "",
     jsonld: jsonldScripts,
+    html: pageHtml,
     collected_at: new Date().toISOString()
   };
 }

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "코가네 퍼센티 수집기",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "쇼핑 페이지를 한 클릭에 코가네 퍼센티로 수집 (인페이지 수집 버튼 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/src/api/extension_api.py
+++ b/src/api/extension_api.py
@@ -130,12 +130,52 @@ def _translate_payload(payload: dict) -> dict:
 # 라우트
 # ---------------------------------------------------------------------------
 
+def _merge_scraped_into_payload(payload: dict, scraped) -> dict:
+    """확장이 보낸 페이지 HTML을 서버 파싱한 결과로 payload의 빈 필드를 보강.
+
+    봇 차단 사이트도 브라우저 DOM 기반으로 수집되도록, 클라이언트가 못 채운 값을
+    범용 스크래퍼 추출값으로 채운다. 기존에 값이 있으면 사용자 값 우선(가격 0/빈 값만 보강).
+    """
+    out = dict(payload)
+
+    def _is_empty(v):
+        return v is None or str(v).strip() in ("", "0", "0.0")
+
+    if _is_empty(out.get("title")) and scraped.title:
+        out["title"] = scraped.title
+    if _is_empty(out.get("description")) and scraped.description:
+        out["description"] = scraped.description
+    if _is_empty(out.get("brand")) and getattr(scraped, "brand", None):
+        out["brand"] = scraped.brand
+
+    # 가격: payload 가격이 비었거나 0이면 스크래퍼 추출값으로 보강 (가격 0 문제 해결)
+    if _is_empty(out.get("price")) and scraped.price is not None:
+        out["price"] = str(scraped.price)
+        if scraped.currency:
+            out["currency"] = scraped.currency
+
+    # 이미지: payload에 없으면 스크래퍼 이미지 사용
+    p_imgs = out.get("images")
+    if not (isinstance(p_imgs, list) and any(str(i or "").strip() for i in p_imgs)):
+        if scraped.images:
+            out["images"] = list(scraped.images)
+            if _is_empty(out.get("image")) and scraped.images:
+                out["image"] = scraped.images[0]
+
+    # 옵션: payload에 없으면 스크래퍼 옵션 사용
+    if not out.get("options") and getattr(scraped, "options", None):
+        out["options"] = scraped.options
+
+    return out
+
+
 @extension_bp.post("/extension")
 def collect_from_extension():
     """크롬 확장 / 북마클릿에서 상품 메타 수신 + 카탈로그 저장.
 
     Request body:
-        {url, title, image, price, currency, description, jsonld, ...}
+        {url, title, image, price, currency, description, jsonld, html, ...}
+        html(선택): 브라우저 페이지 HTML — 봇 차단(403) 사이트도 서버 파싱으로 수집.
     Response:
         {ok: true, preview_url: "/seller/collect/preview/<id>"}
     """
@@ -147,6 +187,17 @@ def collect_from_extension():
     url = (payload.get("url") or "").strip()
     if not url:
         return jsonify({"ok": False, "error": "url 필드가 필요합니다."}), 400
+
+    # 봇 차단 사이트 대응: 확장이 보낸 페이지 HTML을 서버에서 파싱해 필드 보강 (네트워크 fetch 없음)
+    page_html = payload.get("html")
+    if page_html and isinstance(page_html, str):
+        try:
+            from src.collectors.universal_scraper import UniversalScraper
+            scraped = UniversalScraper().parse_html(page_html, url)
+            payload = _merge_scraped_into_payload(payload, scraped)
+        except Exception as exc:
+            logger.warning("확장 HTML 서버 파싱 실패(클라이언트 값 유지): %s", exc)
+    payload.pop("html", None)  # 대용량 HTML은 이력에 저장하지 않음
 
     title = payload.get("title") or ""
     source = "extension"

--- a/src/collectors/universal_scraper.py
+++ b/src/collectors/universal_scraper.py
@@ -187,6 +187,15 @@ class UniversalScraper:
 
     def fetch(self, url: str) -> ScrapedProduct:
         """URL에서 상품 정보 수집. ADAPTER_DRY_RUN=1이면 빈 결과 반환."""
+        html = _fetch_html(url)
+        return self.parse_html(html, url)
+
+    def parse_html(self, html: Optional[str], url: str) -> ScrapedProduct:
+        """제공된 HTML에서 상품 정보 파싱 (네트워크 fetch 없음).
+
+        크롬확장이 사용자 브라우저의 페이지 HTML을 보내면, 서버가 직접 fetch할 수 없는
+        봇 차단(403) 사이트도 동일한 JSON-LD/OG/Microdata/Heuristic 파이프라인으로 수집한다.
+        """
         domain = _extract_domain(url)
         empty = ScrapedProduct(
             source_url=url,
@@ -197,7 +206,6 @@ class UniversalScraper:
             confidence=0.0,
         )
 
-        html = _fetch_html(url)
         if not html:
             return empty
 

--- a/tests/test_extension_api.py
+++ b/tests/test_extension_api.py
@@ -64,6 +64,49 @@ class TestExtensionCollectAPI:
         assert "preview_url" in data
         assert data["product_id"] == "abc123"
 
+    def test_collect_html_server_parse_enriches_price(self, client):
+        """봇 차단 사이트: 확장이 보낸 HTML을 서버가 파싱해 가격 0 → 실가격 보강 (Phase 212)."""
+        jsonld_html = (
+            '<html><head><script type="application/ld+json">'
+            '{"@type":"Product","name":"Porter Backpack",'
+            '"image":["https://img.y.com/bag.jpg"],'
+            '"offers":{"price":"33000","priceCurrency":"JPY"}}'
+            '</script></head></html>'
+        )
+        captured = {}
+
+        def _fake_append(**kwargs):
+            captured.update(kwargs)
+            return "hist1"
+
+        with patch("src.api.extension_api._require_token") as mock_auth:
+            mock_auth.return_value = {"user_id": "u1", "scopes": ["collect.write"]}
+            with patch("src.api.extension_api._upsert_catalog", return_value="cat1"), \
+                 patch("src.api.extension_api._notify_telegram"), \
+                 patch("src.seller_console.collect_history_store.append", _fake_append):
+                resp = client.post(
+                    "/api/v1/collect/extension",
+                    data=json.dumps({
+                        "url": "https://www.yoshidakaban.com/ko/product/102492.html",
+                        "title": "",
+                        "price": "0",
+                        "currency": "USD",
+                        "translate": False,
+                        "html": jsonld_html,
+                    }),
+                    content_type="application/json",
+                    headers={"Authorization": "Bearer tok_test"},
+                )
+        assert resp.status_code == 200
+        # 서버 파싱으로 가격/통화/제목/이미지가 보강됨
+        assert str(captured.get("price")) == "33000"
+        assert captured.get("currency") == "JPY"
+        extra = captured.get("extra") or {}
+        assert extra.get("price_original") == "33000"
+        assert "https://img.y.com/bag.jpg" in (extra.get("images") or [])
+        # 대용량 html은 이력 extra에 저장하지 않음
+        assert "html" not in extra
+
     def test_collect_no_url_400(self, client):
         with patch("src.api.extension_api._require_token") as mock_auth:
             mock_auth.return_value = {"user_id": "test_user", "scopes": ["collect.write"]}

--- a/tests/test_universal_scraper.py
+++ b/tests/test_universal_scraper.py
@@ -309,3 +309,38 @@ class TestUniversalScraperFetch:
             result = scraper.fetch("https://example.com/p")
         assert result.title == "Test Item"
         assert result.extraction_method == "json-ld"
+
+
+class TestParseHtml:
+    """parse_html — 봇 차단 사이트 대응(제공 HTML 파싱, 네트워크 fetch 없음)."""
+
+    JSONLD_HTML = """
+    <html><head>
+    <script type="application/ld+json">
+    {"@type":"Product","name":"Porter Backpack","description":"bag",
+     "image":["https://img.yoshida.com/bag.jpg"],
+     "offers":{"price":"33000","priceCurrency":"JPY","availability":"https://schema.org/InStock"}}
+    </script>
+    </head></html>
+    """
+
+    def test_parse_html_extracts_without_network(self):
+        scraper = UniversalScraper()
+        result = scraper.parse_html(self.JSONLD_HTML, "https://www.yoshidakaban.com/ko/product/102492.html")
+        assert result.title == "Porter Backpack"
+        assert result.price == Decimal("33000")
+        assert result.currency == "JPY"
+        assert result.images == ["https://img.yoshida.com/bag.jpg"]
+
+    def test_parse_html_empty_returns_empty(self):
+        scraper = UniversalScraper()
+        result = scraper.parse_html("", "https://example.com/p")
+        assert result.title == ""
+        assert result.price is None
+
+    def test_fetch_delegates_to_parse_html(self):
+        scraper = UniversalScraper()
+        with patch("src.collectors.universal_scraper._fetch_html", return_value=self.JSONLD_HTML):
+            result = scraper.fetch("https://blocked-site.example/p")
+        assert result.title == "Porter Backpack"
+        assert result.currency == "JPY"


### PR DESCRIPTION
## 개요
오너 지시(나열순 ①): "봇 차단 사이트도 수집할 수 있게 해줘. 소비자가 원하는 모든 사이트를 수집할 수 있게."

## 원인 (팩트)
서버가 직접 URL을 fetch하면 yoshidakaban 등 일부 사이트는 **봇 차단(HTTP 403)** → 가격/이미지 추출 실패(가격 0). 하지만 **크롬확장은 사용자 브라우저 안에서 실행**되므로 그 사이트의 DOM/HTML을 그대로 읽을 수 있음.

## 변경
- **`UniversalScraper.parse_html(html, url)` 신설**: 네트워크 fetch 없이 제공된 HTML을 동일 파이프라인(JSON-LD → OG → Microdata → Heuristic)으로 파싱. 기존 `fetch()`는 `parse_html()`에 위임(동작 동일).
- **크롬확장 → 페이지 HTML 전송**: `content_script.js`가 `document.documentElement.outerHTML`(600KB 상한)을 collect 페이로드에 동봉. manifest `1.1.0→1.2.0`.
- **`/api/v1/collect/extension`**: `html` 수신 시 서버에서 `parse_html`로 파싱 → `_merge_scraped_into_payload`로 **빈 값·가격 0만 보강**(사용자 값 우선). 대용량 `html`은 수집 이력에 저장하지 않음.

→ 사용자가 브라우저로 볼 수 있는 **어떤 사이트(봇차단 포함)든** 상품 페이지에서 🛒'수집' 버튼으로 가격/이미지/옵션까지 수집 가능.

## 정직성
- HTML 파싱 실패 시 클라이언트 값 유지(거짓 데이터 없음). 사용자가 이미 채운 값은 덮어쓰지 않고 빈 칸만 보강.

## 테스트
- 신규: `parse_html`(가격/통화/이미지 추출, 빈 HTML 안전, `fetch` 위임), 확장 엔드포인트(가격 0 → 서버 파싱으로 33000 JPY 보강, html은 이력 미저장).
- 전체 `python -m pytest tests/ -q` → **9938 passed, 2 skipped** (회귀 0).

## 오너 액션
- 크롬확장 재설치/업데이트(1.2.0)로 페이지 HTML 전송 활성화. (서버는 이미 `html` 수신·파싱 지원)

## 남은 후속 (나열순)
- ② 편집 페이지 풀 편집(키워드/썸네일) · ③ Google 로그인(설정 진단) — 다음 PR.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_