### PR TITLE
feat(collect): 편집 페이지 키워드/태그 + 대표(썸네일) 이미지 선택 (Phase 213)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,10 @@
    `/api/v1/collect/extension`이 `html` 수신 시 `_merge_scraped_into_payload`로 **빈 값·가격0만 보강**
    (사용자 값 우선, 대용량 html은 이력에 미저장). 확장 manifest 1.1.0→1.2.0.
    → 사용자가 브라우저로 볼 수 있는 어떤 사이트(봇차단 포함)든 인페이지 🛒'수집'으로 수집 가능.
-2. ⏳ 편집 페이지 풀 편집(키워드/썸네일) — 진행 예정.
+2. ✅ **편집 페이지 풀 편집 — 키워드/태그 + 썸네일 선택** (Phase 213): `collect_preview.html`에
+   '키워드/태그'(쉼표구분) 입력 추가 → `buildProductData`/저장에 `keywords`+`tags` 반영(`extra` 머지).
+   이미지 행마다 '⭐대표' 버튼 → 클릭 시 해당 이미지를 맨 위(대표/썸네일)로 이동(`refreshImageBadges`).
+   `buildProductData.thumbnail`=대표이미지. (제목/가격/통화/상세/이미지/옵션은 이미 편집 가능)
 3. ⏳ Google 로그인(설정 진단) — 진행 예정.
 
 ## 작업 방식

--- a/src/seller_console/templates/collect_preview.html
+++ b/src/seller_console/templates/collect_preview.html
@@ -76,7 +76,7 @@
       <!-- 이미지 목록 -->
       <div class="mb-3">
         <div class="d-flex justify-content-between align-items-center mb-2">
-          <label class="form-label small fw-semibold mb-0">이미지 URL (첫 번째 = 대표)</label>
+          <label class="form-label small fw-semibold mb-0">이미지 URL <span class="text-muted">(⭐ = 대표/썸네일, 맨 위가 대표)</span></label>
           <button type="button" class="btn btn-outline-secondary btn-sm py-0" onclick="addImageRow()">+ 이미지 추가</button>
         </div>
         <div id="imageRows" class="vstack gap-2"></div>
@@ -89,6 +89,14 @@
           <button type="button" class="btn btn-outline-secondary btn-sm py-0" onclick="addOptionRow()">+ 옵션 추가</button>
         </div>
         <div id="optionRows" class="vstack gap-2"></div>
+      </div>
+
+      <!-- 키워드 / 태그 -->
+      <div class="mb-2">
+        <label class="form-label small fw-semibold" for="editKeywords">키워드 / 태그
+          <span class="text-muted fw-normal">(쉼표로 구분 — 검색 노출·업로드 태그)</span></label>
+        <input type="text" class="form-control" id="editKeywords"
+               placeholder="예: 백팩, 데일리, 방수, 남녀공용">
       </div>
     </div>
 
@@ -264,11 +272,36 @@ function addImageRow(url) {
   const row = document.createElement('div');
   row.className = 'input-group input-group-sm img-row';
   row.innerHTML = `
+    <button class="btn btn-outline-warning btn-make-primary" type="button" title="대표 이미지로 지정">⭐</button>
     <input type="url" class="form-control img-url" placeholder="https://..." value="${escapeHtml(url || '')}">
-    <button class="btn btn-outline-danger" type="button" title="삭제">✕</button>`;
-  row.querySelector('button').addEventListener('click', () => { row.remove(); refreshPrimaryImage(); });
+    <button class="btn btn-outline-danger btn-del" type="button" title="삭제">✕</button>`;
+  row.querySelector('.btn-make-primary').addEventListener('click', () => {
+    wrap.insertBefore(row, wrap.firstChild);  // 맨 위로 = 대표
+    refreshPrimaryImage();
+    refreshImageBadges();
+  });
+  row.querySelector('.btn-del').addEventListener('click', () => {
+    row.remove(); refreshPrimaryImage(); refreshImageBadges();
+  });
   row.querySelector('input').addEventListener('input', refreshPrimaryImage);
   wrap.appendChild(row);
+  refreshImageBadges();
+}
+
+// 첫 번째(맨 위) 이미지가 대표/썸네일 — 버튼 상태 갱신
+function refreshImageBadges() {
+  const rows = document.querySelectorAll('#imageRows .img-row');
+  rows.forEach((row, i) => {
+    const btn = row.querySelector('.btn-make-primary');
+    if (!btn) return;
+    if (i === 0) {
+      btn.classList.add('btn-warning'); btn.classList.remove('btn-outline-warning');
+      btn.textContent = '⭐대표'; btn.disabled = true; btn.title = '현재 대표/썸네일';
+    } else {
+      btn.classList.add('btn-outline-warning'); btn.classList.remove('btn-warning');
+      btn.textContent = '⭐'; btn.disabled = false; btn.title = '대표 이미지로 지정';
+    }
+  });
 }
 
 function addOptionRow(name, values) {
@@ -365,10 +398,16 @@ function initEditor() {
   document.getElementById('editDescription').value =
     _firstNonEmpty(_EXTRA.description_ko, _EXTRA.description);
 
+  // 키워드/태그 (배열이면 쉼표 결합)
+  const kw = _EXTRA.keywords !== undefined ? _EXTRA.keywords : _EXTRA.tags;
+  document.getElementById('editKeywords').value =
+    Array.isArray(kw) ? kw.join(', ') : (kw || '');
+
   _initImages().forEach(addImageRow);
   if (document.querySelectorAll('#imageRows .img-row').length === 0) addImageRow('');
   _initOptions().forEach(o => addOptionRow(o.name, o.values));
   refreshPrimaryImage();
+  refreshImageBadges();
   updateKrwPreview();
   updateDescCount();
 }
@@ -386,12 +425,16 @@ function buildProductData() {
   const price = document.getElementById('editPrice').value.trim();
   const currency = document.getElementById('editCurrency').value;
   const description = document.getElementById('editDescription').value;
+  const keywords = (document.getElementById('editKeywords').value || '')
+    .split(',').map(k => k.trim()).filter(Boolean);
 
   return {
     title, title_ko: title, title_en: _EXTRA.title_en || title,
     price, price_original: price, currency,
     description, description_ko: description,
     images, options,
+    keywords, tags: keywords,
+    thumbnail: images[0] || '',   // 맨 위(대표) 이미지 = 썸네일
     url: _ITEM.url || _EXTRA.url || '',
     source: _ITEM.source || _EXTRA.source || '',
     brand: _EXTRA.brand || '', category: _EXTRA.category || '',

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -3911,6 +3911,17 @@ def collect_preview_save(item_id: str):
         extra["price_original"] = price
     if currency:
         extra["currency"] = currency
+
+    # 키워드/태그 정규화 (배열 또는 쉼표 문자열 허용)
+    keywords = data.get("keywords")
+    if keywords is None:
+        keywords = data.get("tags")
+    if isinstance(keywords, str):
+        keywords = [k.strip() for k in keywords.split(",") if k.strip()]
+    if isinstance(keywords, list):
+        keywords = [str(k).strip() for k in keywords if str(k).strip()]
+        extra["keywords"] = keywords
+        extra["tags"] = keywords
     extra["edited"] = True
 
     ok = collect_history_store.update(

--- a/tests/test_collect_edit_phase201.py
+++ b/tests/test_collect_edit_phase201.py
@@ -92,6 +92,27 @@ def test_save_merges_extra_and_updates_item(client):
     assert captured["image_url"] == "https://shop.example.com/1.jpg"  # 첫 이미지 = 대표
 
 
+def test_save_persists_keywords(client):
+    """키워드/태그 저장 → extra에 keywords/tags 머지 (Phase 213)."""
+    item = {"id": "kw1", "url": "https://e.com/p", "title": "t", "extra_json": "{}", "seller_id": ""}
+    captured = {}
+    with patch("src.seller_console.collect_history_store.get", return_value=item), \
+         patch("src.seller_console.collect_history_store.update",
+               side_effect=lambda i, **k: captured.update(k) or True):
+        resp = client.post(
+            "/seller/collect/preview/kw1/save",
+            data=json.dumps({
+                "title": "키워드 상품",
+                "keywords": ["백팩", "데일리", "방수"],
+            }),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    extra = json.loads(captured["extra_json"])
+    assert extra["keywords"] == ["백팩", "데일리", "방수"]
+    assert extra["tags"] == ["백팩", "데일리", "방수"]
+
+
 def test_save_options_accepts_comma_string(client):
     item = {"id": "x1", "url": "https://e.com/p", "title": "t", "extra_json": "{}", "seller_id": ""}
     captured = {}

--- a/tests/test_collect_preview_view.py
+++ b/tests/test_collect_preview_view.py
@@ -87,3 +87,13 @@ class TestCollectPreviewView:
         body = resp.data
         assert b'rows="14"' in body
         assert b"descCharCount" in body
+
+    def test_preview_has_keywords_and_thumbnail_controls(self, client):
+        """키워드/태그 입력 + 대표(썸네일) 지정 컨트롤이 포함됨 (Phase 213)."""
+        with patch("src.seller_console.collect_history_store.get", return_value=_MOCK_ITEM):
+            resp = client.get("/seller/collect/preview/abc123")
+        body = resp.data
+        assert b'id="editKeywords"' in body
+        assert "키워드 / 태그".encode() in body
+        assert b"btn-make-primary" in body       # 대표 이미지 지정 버튼
+        assert b"refreshImageBadges" in body


### PR DESCRIPTION
## 개요
오너 지시(나열순 ②): "상세페이지에서 가격과 이미지 옵션등을 설정할 수 있게 해줘야지. 키워드, 제목, 썸네일 등등."

편집 페이지(`/seller/collect/preview/<id>`)는 이미 제목·가격·통화·상세설명·이미지·옵션을 편집할 수 있었고, 여기에 **키워드/태그 + 썸네일(대표 이미지) 선택**을 추가.

## 변경
- **키워드/태그 입력**: 쉼표 구분 입력 필드 추가 → `buildProductData`에 `keywords`/`tags` 포함, 저장(`/save`) 시 `extra`에 머지 + 업로드 페이로드에 전달. 로드 시 기존 `keywords`/`tags` 프리필.
- **썸네일(대표 이미지) 선택**: 각 이미지 행에 **⭐ 버튼** 추가 → 클릭하면 해당 이미지를 맨 위(대표=썸네일)로 이동. 첫 행은 '⭐대표' 강조 표시(`refreshImageBadges`). `buildProductData.thumbnail` = 맨 위 이미지.

## 테스트
- 신규: 키워드 입력/대표 지정 컨트롤 렌더, 키워드 저장 시 `extra.keywords`/`tags` 머지.
- 전체 `python -m pytest tests/ -q` → **9940 passed, 2 skipped** (회귀 0).

## 남은 후속 (나열순)
- ③ Google 로그인 — 코드 정상으로 확인됨(설정 진단). 다음 단계로 안내/진단 보강 예정.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_