### PR TITLE
fix(collect)+feat(sourcing): 북마클릿 CORS 수집복구 · 소싱처 변화 모니터 · 토큰설명 · 파비콘 · 삭제 (Phase 216)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,24 @@
 - **버튼 실동작 확인**: 추천 CTA·소싱처·재수집·키워드/디스커버리 링크 타깃 라우트(`/collect`,`/me/tokens`,
   `/bookmarklet`,`/discovery`,`/keywords`,`/sourcing/{watches,candidates}`) 전부 존재 확인. 안내 카피 섬세화.
 
+## 🔧 수집 안 됨(CORS)·소싱처 변화 모니터링·인간친화 카피 (오너 지시 2026-06-17, 라이브 스크린샷)
+오너 지적: ①북마클릿 `Failed to fetch`로 수집 안 됨 ②"회수"같은 딱딱한 단어 ③토큰 설명 부재
+④북마클릿 버튼 큼 ⑤수집상품 소싱처 변화(품절/가격/사이즈/재고) 실시간 연동 희망.
+1. ✅ **북마클릿 수집 `Failed to fetch`** (Phase 216): CORS가 `/health/*`에만 설정돼 임의 쇼핑몰에서
+   `/api/v1/collect/extension`으로 보내는 크로스오리진 POST의 preflight가 막혀 수집 실패. → `order_webhook.py`
+   CORS에 `/api/v1/collect/*`(origins `*`, POST/OPTIONS, Content-Type/Authorization) 추가. Bearer 인증이라
+   `*` 안전. 북마클릿이 페이지 HTML도 함께 전송(600KB 상한)해 봇 차단 사이트도 서버 파싱으로 수집.
+2. ✅ **인간친화 카피** (Phase 216): 토큰 "회수"→**"삭제"**(badge/버튼/확인창/토스트). 고가네퍼센티는 인간친화 우선.
+3. ✅ **토큰 설명** (Phase 216): `personal_tokens.html`에 '토큰이 무엇이고 무슨 일을 하나'(①쓰는법 ②동작=Bearer
+   ③안전=해시저장·삭제로 무효화) 카드 + 스코프 뜻 안내.
+4. ✅ **북마클릿 버튼 → 고가네퍼센티 파비콘** (Phase 216): 🛒 이모지 대신 `favicon.svg`(글로브) 이미지 48×48
+   아이콘 버튼으로. 북마크바에 파비콘으로 표시.
+5. ✅ **수집상품 소싱처 변화 모니터링** (Phase 216): 신규 `/seller/sourcing/monitor`(+nav '소싱처 변화').
+   내 수집 이력 상품의 소싱처를 `UniversalScraper`로 재확인 → 수집 당시 가격/옵션과 비교해 **가격 ▲▼·품절·
+   옵션/사이즈 소진** 판정. 추출 불가(봇차단/네트워크)는 거짓 알림 대신 **'확인 불가'**(정직). 결과는
+   `collect_history_store.update`로 extra_json에 저장(다음 방문 시 마지막 상태 표시). `POST /sourcing/monitor/check`
+   단건/전체. ※ 현재는 온디맨드(버튼) 확인 — 정기 자동확인은 추후 스케줄러로 확장 예정.
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/src/order_webhook.py
+++ b/src/order_webhook.py
@@ -1033,7 +1033,17 @@ except Exception as _ai_api_bp_exc:
 # CORS 설정 — 허용 오리진은 환경변수로 제어
 # 프로덕션에서는 CORS_ORIGINS에 허용할 도메인을 명시적으로 설정할 것
 _cors_origins = os.getenv('CORS_ORIGINS', '*')
-CORS(app, resources={r'/health/*': {'origins': _cors_origins}})
+CORS(app, resources={
+    r'/health/*': {'origins': _cors_origins},
+    # 북마클릿/크롬확장 수집 — 임의 쇼핑몰 페이지에서 크로스오리진 POST가 들어온다.
+    # Bearer 토큰 인증(쿠키 미사용)이라 origins '*' 안전. 미설정 시 브라우저가
+    # preflight를 막아 'Failed to fetch'로 수집이 실패하므로 명시적으로 허용한다.
+    r'/api/v1/collect/*': {
+        'origins': '*',
+        'methods': ['GET', 'POST', 'OPTIONS'],
+        'allow_headers': ['Content-Type', 'Authorization'],
+    },
+})
 
 # Rate Limiter 초기화
 limiter = create_limiter(app)

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -52,6 +52,7 @@
       <li class="console-nav-group-title">리서치/소싱</li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/keywords') %}active{% endif %}" href="/seller/keywords"><i class="bi bi-graph-up"></i><span>키워드 트렌드</span></a></li>
       <li><a class="console-nav-link {% if _path == '/seller/sourcing' or _path.startswith('/seller/sourcing/my-sources') or _path.startswith('/seller/sourcing/collect') or _path.startswith('/seller/sourcing/recommend') %}active{% endif %}" href="/seller/sourcing"><i class="bi bi-stars"></i><span>AI 소싱 허브</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/sourcing/monitor') %}active{% endif %}" href="/seller/sourcing/monitor"><i class="bi bi-broadcast"></i><span>소싱처 변화</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/sourcing/watches') %}active{% endif %}" href="/seller/sourcing/watches"><i class="bi bi-binoculars"></i><span>소싱 watches</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/sourcing/candidates') %}active{% endif %}" href="/seller/sourcing/candidates"><i class="bi bi-inboxes"></i><span>후보 큐</span></a></li>
 

--- a/src/seller_console/templates/bookmarklet.html
+++ b/src/seller_console/templates/bookmarklet.html
@@ -39,15 +39,18 @@
       <div class="card">
         <div class="card-header"><strong>📌 북마클릿 (드래그해서 북마크바에 추가)</strong></div>
         <div class="card-body text-center py-4">
-          <!-- 북마크바에 '아이콘'으로만 보이도록 링크 텍스트는 짧은 이모지(🛒) 하나.
-               긴 이름 대신 파비콘처럼 작게 표시됨. 페이지에서도 작은 버튼으로 노출. -->
+          <!-- 북마크바에 고가네 퍼센티 파비콘(글로브)이 아이콘으로 보이도록 구성.
+               드래그 링크 안에 favicon 이미지를 넣어 작은 아이콘 버튼으로 노출. -->
           <a id="bookmarkletLink" href="javascript:void(0)"
-             class="btn btn-success btn-sm d-inline-flex align-items-center justify-content-center"
-             style="cursor:grab;width:44px;height:44px;font-size:20px;border-radius:10px;padding:0;"
-             title="이 아이콘을 북마크바로 드래그하세요 — 바에는 🛒 아이콘만 표시됩니다"
-             aria-label="코가네 퍼센티 수집 북마클릿">🛒</a>
-          <p class="mt-3 text-muted small mb-0">위 <strong>🛒 아이콘</strong>을 북마크바로 드래그하세요.</p>
-          <p class="text-muted small">북마크바에는 긴 이름 대신 <strong>🛒 아이콘만</strong> 표시됩니다(자리를 적게 차지해요).</p>
+             class="d-inline-flex align-items-center justify-content-center text-decoration-none"
+             style="cursor:grab;width:48px;height:48px;border-radius:12px;padding:4px;border:1px solid #dee2e6;background:#fff;"
+             title="이 아이콘을 북마크바로 드래그하세요 — 고가네 퍼센티 아이콘으로 표시됩니다"
+             aria-label="고가네 퍼센티 수집 북마클릿">
+            <img src="{{ url_for('seller_console.static', filename='favicon.svg') }}"
+                 alt="고가네퍼센티" style="width:100%;height:100%;border-radius:8px;" draggable="false">
+          </a>
+          <p class="mt-3 text-muted small mb-0">위 <strong>고가네 퍼센티 아이콘</strong>을 북마크바로 드래그하세요.</p>
+          <p class="text-muted small">북마크바에는 긴 이름 대신 <strong>고가네 퍼센티 파비콘</strong>으로 표시됩니다(자리를 적게 차지해요).</p>
         </div>
       </div>
     </div>
@@ -89,7 +92,8 @@ function buildBookmarkletCode(token) {
     price:(document.querySelector('meta[property="product:price:amount"]')||{}).content,
     currency:(document.querySelector('meta[property="product:price:currency"]')||{content:'USD'}).content,
     description:(document.querySelector('meta[name="description"]')||{}).content,
-    jsonld:[...document.querySelectorAll('script[type="application/ld+json"]')].map(function(s){try{return JSON.parse(s.innerText);}catch(e){return null;}}).filter(Boolean)
+    jsonld:[...document.querySelectorAll('script[type="application/ld+json"]')].map(function(s){try{return JSON.parse(s.innerText);}catch(e){return null;}}).filter(Boolean),
+    html:(document.documentElement.outerHTML||'').slice(0,600000)
   };
   fetch('${SERVER_URL}/api/v1/collect/extension',{
     method:'POST',

--- a/src/seller_console/templates/personal_tokens.html
+++ b/src/seller_console/templates/personal_tokens.html
@@ -2,14 +2,52 @@
 {% block title %}Personal Access Token 관리{% endblock %}
 {% block content %}
 <div class="container-fluid py-4">
-  <div class="d-flex justify-content-between align-items-center mb-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
     <div>
       <h1 class="h3 mb-0">🔑 Personal Access Token 관리</h1>
-      <small class="text-muted">크롬 확장 / 북마클릿 인증에 사용합니다.</small>
+      <small class="text-muted">크롬 확장 / 북마클릿이 “내 계정”으로 수집하도록 인증하는 열쇠입니다.</small>
     </div>
     <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#generateModal">
       ＋ 새 토큰 발급
     </button>
+  </div>
+
+  <!-- 토큰이 무엇인지 / 어떻게 동작하는지 설명 -->
+  <div class="card border-primary-subtle bg-primary-subtle mb-4">
+    <div class="card-body">
+      <h2 class="h6 mb-2">🔑 토큰이 무엇이고, 무슨 일을 하나요?</h2>
+      <p class="small mb-2">
+        Personal Access Token(개인 액세스 토큰)은 <strong>비밀번호 대신 쓰는 긴 열쇠 문자열</strong>입니다.
+        크롬 확장이나 북마클릿(🛒)으로 상품을 수집할 때, 이 토큰이 “이 수집은 <strong>당신 계정</strong>의 것”이라고
+        서버에 알려줍니다. 토큰이 없으면 수집 요청이 거부돼요.
+      </p>
+      <div class="row g-2 small">
+        <div class="col-md-4">
+          <div class="border rounded-3 p-2 h-100 bg-white">
+            <div class="fw-semibold">① 어떻게 쓰나</div>
+            토큰을 발급해 크롬 확장 옵션이나 북마클릿에 한 번 붙여넣으면 끝. 이후 자동으로 사용됩니다.
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="border rounded-3 p-2 h-100 bg-white">
+            <div class="fw-semibold">② 어떻게 동작하나</div>
+            수집 시 <code>Authorization: Bearer &lt;토큰&gt;</code> 형태로 전송돼 본인 확인 후
+            수집 이력에 저장됩니다. <strong>스코프</strong>로 권한 범위를 제한해요(예: 수집만).
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="border rounded-3 p-2 h-100 bg-white">
+            <div class="fw-semibold">③ 안전한가</div>
+            토큰은 발급 시 <strong>한 번만</strong> 보이고 서버엔 해시로만 저장됩니다. 새어나간 것 같으면
+            언제든 <strong>삭제</strong>하면 즉시 무효화돼요. 만료일도 정할 수 있습니다.
+          </div>
+        </div>
+      </div>
+      <div class="small text-muted mt-2">
+        스코프 뜻 — <code>collect.write</code>: 상품 수집 저장 · <code>catalog.read</code>: 카탈로그 조회 ·
+        <code>markets.write</code>: 마켓 업로드.
+      </div>
+    </div>
   </div>
 
   {% if tokens %}
@@ -41,7 +79,7 @@
             <td>{{ tok.expires_at[:10] if tok.expires_at else '-' }}</td>
             <td>
               {% if tok.revoked %}
-              <span class="badge bg-danger">회수됨</span>
+              <span class="badge bg-secondary">삭제됨</span>
               {% else %}
               <span class="badge bg-success">활성</span>
               {% endif %}
@@ -49,7 +87,7 @@
             <td>
               {% if not tok.revoked %}
               <button class="btn btn-sm btn-outline-danger revoke-btn"
-                      data-hash="{{ tok.token_hash }}">회수</button>
+                      data-hash="{{ tok.token_hash }}">삭제</button>
               {% endif %}
             </td>
           </tr>
@@ -167,7 +205,7 @@ function copyToken() {
 
 document.querySelectorAll('.revoke-btn').forEach(btn => {
   btn.addEventListener('click', async () => {
-    if (!(await pcConfirm('이 토큰을 회수하시겠습니까? 회수 후 복구할 수 없습니다.', {title: '토큰 회수', confirmLabel: '회수'}))) return;
+    if (!(await pcConfirm('이 토큰을 삭제하시겠습니까? 삭제하면 즉시 무효화되며 복구할 수 없습니다.', {title: '토큰 삭제', confirmLabel: '삭제'}))) return;
     const hash = btn.dataset.hash;
     try {
       const resp = await fetch('/seller/me/tokens/revoke', {
@@ -179,7 +217,7 @@ document.querySelectorAll('.revoke-btn').forEach(btn => {
       if (data.ok) {
         location.reload();
       } else {
-        pcToast('회수 실패: ' + (data.error || '알 수 없는 오류'), 'error');
+        pcToast('삭제 실패: ' + (data.error || '알 수 없는 오류'), 'error');
       }
     } catch(e) {
       pcToast('오류: ' + e.message, 'error');

--- a/src/seller_console/templates/sourcing.html
+++ b/src/seller_console/templates/sourcing.html
@@ -7,7 +7,10 @@
       <h1 class="h4 mb-1">AI 소싱 허브</h1>
       <p class="text-muted mb-0">키워드 트렌드 + Discovery + 후보 큐를 합쳐 소싱 우선순위를 제안합니다.</p>
     </div>
-    <a href="/seller/keywords{% if keyword %}?q={{ keyword|urlencode }}&period={{ period }}{% endif %}" class="btn btn-outline-primary btn-sm">키워드 트렌드 보기</a>
+    <div class="d-flex gap-2">
+      <a href="/seller/sourcing/monitor" class="btn btn-outline-success btn-sm"><i class="bi bi-broadcast"></i> 소싱처 변화</a>
+      <a href="/seller/keywords{% if keyword %}?q={{ keyword|urlencode }}&period={{ period }}{% endif %}" class="btn btn-outline-primary btn-sm">키워드 트렌드 보기</a>
+    </div>
   </div>
 
   {% if notice %}

--- a/src/seller_console/templates/sourcing_monitor.html
+++ b/src/seller_console/templates/sourcing_monitor.html
@@ -1,0 +1,134 @@
+{% extends "_base.html" %}
+{% block title %}소싱처 변화 모니터링{% endblock %}
+{% block content %}
+<div class="container-fluid py-3">
+  <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-2">
+    <div>
+      <h1 class="h4 mb-1">📡 소싱처 변화 모니터링</h1>
+      <p class="text-muted mb-0">내가 수집한 상품의 <strong>소싱처(원본 페이지)</strong>를 다시 확인해
+        <strong>가격·품절·옵션/사이즈</strong> 변화를 알려줍니다.</p>
+    </div>
+    <div class="d-flex gap-2">
+      <button id="checkAllBtn" class="btn btn-primary btn-sm" {% if not rows %}disabled{% endif %}>
+        <i class="bi bi-arrow-repeat"></i> 전체 변화 확인
+      </button>
+      <a href="/seller/collect/history" class="btn btn-outline-secondary btn-sm">수집 이력</a>
+    </div>
+  </div>
+
+  <div class="alert alert-light border small d-flex gap-2 align-items-start mb-3">
+    <i class="bi bi-info-circle text-primary"></i>
+    <div class="mb-0">
+      <strong>어떻게 동작하나요?</strong> ‘변화 확인’을 누르면 그 순간 소싱처 페이지를 실제로 다시 읽어
+      <strong>수집 당시 가격과 비교</strong>합니다. 추출이 막힌 사이트(로그인·봇 차단)는 거짓 알림 대신
+      <em>‘확인 불가’</em>로 정직하게 표시합니다. (정기 자동 확인은 추후 스케줄러로 확장 예정)
+    </div>
+  </div>
+
+  {% if not rows %}
+  <div class="console-empty-state p-4">
+    <div class="console-empty-icon"><i class="bi bi-broadcast"></i></div>
+    <div class="fw-semibold mb-1">아직 수집한 상품이 없습니다.</div>
+    <div class="small mb-2">상품을 수집하면 이곳에서 소싱처 변화를 추적할 수 있어요.</div>
+    <a href="/seller/sourcing" class="btn btn-sm btn-primary">상품 수집하러 가기</a>
+  </div>
+  {% else %}
+  <div class="card console-card">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th>상품</th>
+            <th>소싱처</th>
+            <th>수집가</th>
+            <th>마지막 확인</th>
+            <th>변화</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for r in rows %}
+          <tr data-id="{{ r.id }}">
+            <td style="max-width:280px;">
+              <div class="d-flex gap-2 align-items-center">
+                {% if r.image %}<img src="{{ r.image }}" alt="" style="width:40px;height:40px;object-fit:cover;border-radius:6px;flex-shrink:0;" onerror="this.style.display='none'">{% endif %}
+                <a class="text-truncate d-inline-block" style="max-width:220px;" href="/seller/collect/preview/{{ r.id }}" title="{{ r.title }}">{{ r.title }}</a>
+              </div>
+            </td>
+            <td class="small text-muted">
+              {% if r.url %}<a href="{{ r.url }}" target="_blank" rel="noopener noreferrer">{{ r.domain or r.url }}</a>{% else %}-{% endif %}
+            </td>
+            <td class="small">{{ r.price }} {{ r.currency }}</td>
+            <td class="small text-muted mon-checked">{{ (r.monitor.checked_at or '')[:16]|replace('T',' ') or '미확인' }}</td>
+            <td class="mon-change">
+              {% set ch = r.monitor.change %}
+              {% if ch == 'out_of_stock' %}<span class="badge text-bg-danger">{{ r.monitor.summary }}</span>
+              {% elif ch == 'price' %}<span class="badge text-bg-warning text-dark">{{ r.monitor.summary }}</span>
+              {% elif ch == 'options' or ch == 'changed' %}<span class="badge text-bg-info">{{ r.monitor.summary }}</span>
+              {% elif ch == 'none' %}<span class="badge text-bg-success">변화 없음</span>
+              {% elif r.monitor.summary %}<span class="badge text-bg-secondary">{{ r.monitor.summary }}</span>
+              {% else %}<span class="text-muted small">미확인</span>{% endif %}
+            </td>
+            <td>
+              <button class="btn btn-sm btn-outline-primary mon-check-btn" data-id="{{ r.id }}">변화 확인</button>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+function renderChange(td, mon) {
+  const ch = mon.change;
+  const s = mon.summary || '확인 불가';
+  let cls = 'text-bg-secondary', txt = s;
+  if (ch === 'out_of_stock') cls = 'text-bg-danger';
+  else if (ch === 'price') cls = 'text-bg-warning text-dark';
+  else if (ch === 'options' || ch === 'changed') cls = 'text-bg-info';
+  else if (ch === 'none') { cls = 'text-bg-success'; txt = '변화 없음'; }
+  td.innerHTML = `<span class="badge ${cls}">${txt}</span>`;
+}
+
+async function checkItem(id, row) {
+  const btn = row.querySelector('.mon-check-btn');
+  const changeTd = row.querySelector('.mon-change');
+  const checkedTd = row.querySelector('.mon-checked');
+  if (btn) { btn.disabled = true; btn.textContent = '확인 중…'; }
+  try {
+    const resp = await fetch('/seller/sourcing/monitor/check', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({item_id: id})
+    });
+    const data = await resp.json();
+    const mon = (data.results && data.results[0]) || {};
+    renderChange(changeTd, mon);
+    if (checkedTd && mon.checked_at) checkedTd.textContent = mon.checked_at.slice(0,16).replace('T',' ');
+  } catch (e) {
+    changeTd.innerHTML = `<span class="badge text-bg-secondary">확인 실패</span>`;
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '변화 확인'; }
+  }
+}
+
+document.querySelectorAll('.mon-check-btn').forEach(btn => {
+  btn.addEventListener('click', () => checkItem(btn.dataset.id, btn.closest('tr')));
+});
+
+document.getElementById('checkAllBtn')?.addEventListener('click', async (e) => {
+  const btn = e.currentTarget;
+  btn.disabled = true; btn.textContent = '전체 확인 중…';
+  const rows = [...document.querySelectorAll('tr[data-id]')];
+  for (const row of rows) {
+    await checkItem(row.dataset.id, row);
+  }
+  btn.disabled = false; btn.innerHTML = '<i class="bi bi-arrow-repeat"></i> 전체 변화 확인';
+  if (window.pcToast) pcToast('전체 소싱처 변화 확인 완료', 'success');
+});
+</script>
+{% endblock %}

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -4731,6 +4731,175 @@ def sourcing_registry_recollect(domain: str):
         return jsonify({"ok": False, "error": "재수집 중 오류가 발생했습니다."}), 500
 
 
+def _parse_history_extra(item: dict) -> dict:
+    """수집 이력 항목의 extra_json을 dict로 파싱(실패 시 빈 dict)."""
+    raw = item.get("extra_json") or item.get("extra") or ""
+    if isinstance(raw, dict):
+        return raw
+    try:
+        import json as _json
+        parsed = _json.loads(raw) if raw else {}
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+
+def _check_source_change(item: dict) -> dict:
+    """수집 상품 1건의 소싱처를 재확인해 가격/재고/옵션 변화를 판정한다.
+
+    실 스크래핑(UniversalScraper)으로 현재 상태를 가져와 수집 당시 값과 비교.
+    추출 불가(봇 차단/네트워크)면 가짜 변화 대신 '확인 불가'로 정직하게 처리한다.
+    """
+    url = (item.get("url") or "").strip()
+    extra = _parse_history_extra(item)
+
+    def _to_float(v):
+        try:
+            return float(str(v).replace(",", "").strip())
+        except (TypeError, ValueError):
+            return None
+
+    base_price = _to_float(item.get("price")) or _to_float(extra.get("price_original")) or _to_float(extra.get("price"))
+    base_options = extra.get("options") or {}
+
+    result = {
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "current_price": None,
+        "currency": item.get("currency") or extra.get("currency") or "",
+        "in_stock": None,
+        "change": "unknown",
+        "summary": "확인 불가",
+        "method": "",
+    }
+    if not url.startswith(("http://", "https://")):
+        result["summary"] = "URL 없음 — 확인 불가"
+        return result
+
+    try:
+        from src.collectors.universal_scraper import UniversalScraper
+        sp = UniversalScraper().fetch(url)
+    except Exception as exc:
+        logger.warning("소싱처 변화 확인 실패(%s): %s", url[:80], exc)
+        sp = None
+
+    if sp is None or (getattr(sp, "price", None) is None and getattr(sp, "in_stock", None) is None):
+        # 추출 불가 — 거짓 변화 금지(정직)
+        result["summary"] = "확인 불가 (봇 차단/네트워크/비표준 페이지)"
+        return result
+
+    cur_price = _to_float(getattr(sp, "price", None))
+    in_stock = getattr(sp, "in_stock", None)
+    cur_options = getattr(sp, "options", None) or {}
+    result["current_price"] = cur_price
+    result["in_stock"] = in_stock
+    result["method"] = getattr(sp, "extraction_method", "") or ""
+    if getattr(sp, "currency", None):
+        result["currency"] = sp.currency
+
+    changes = []
+    if in_stock is False:
+        changes.append("품절")
+        result["change"] = "out_of_stock"
+    if base_price is not None and cur_price is not None and abs(cur_price - base_price) >= 0.01:
+        arrow = "▲" if cur_price > base_price else "▼"
+        pct = ((cur_price - base_price) / base_price * 100) if base_price else 0
+        changes.append(f"가격 {arrow} {base_price:g}→{cur_price:g} ({pct:+.0f}%)")
+        if result["change"] != "out_of_stock":
+            result["change"] = "price"
+    # 옵션/사이즈 변경 감지(값 집합 비교)
+    def _opt_values(opts):
+        vals = set()
+        if isinstance(opts, dict):
+            for v in opts.values():
+                if isinstance(v, (list, tuple)):
+                    vals.update(str(x).strip() for x in v if str(x).strip())
+        return vals
+    base_set, cur_set = _opt_values(base_options), _opt_values(cur_options)
+    if base_set and cur_set and base_set != cur_set:
+        removed = base_set - cur_set
+        if removed:
+            changes.append("옵션/사이즈 일부 소진/변경")
+            if result["change"] == "unknown":
+                result["change"] = "options"
+
+    if changes:
+        result["summary"] = " · ".join(changes)
+        if result["change"] == "unknown":
+            result["change"] = "changed"
+    else:
+        result["change"] = "none"
+        result["summary"] = "변화 없음"
+    return result
+
+
+def _persist_monitor_result(item_id: str, seller_id: str, item: dict, mon: dict) -> None:
+    """변화 확인 결과를 수집 이력 extra_json에 저장(다음 방문 시 마지막 상태 표시)."""
+    try:
+        from . import collect_history_store
+        import json as _json
+        extra = _parse_history_extra(item)
+        extra["monitor"] = mon
+        collect_history_store.update(item_id, seller_id=seller_id, extra_json=_json.dumps(extra, ensure_ascii=False))
+    except Exception as exc:
+        logger.warning("모니터 결과 저장 실패(%s): %s", item_id, exc)
+
+
+@bp.get("/sourcing/monitor")
+def sourcing_monitor():
+    """수집한 상품의 소싱처 변화(품절/가격/옵션) 모니터링 페이지."""
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.url))
+    from . import collect_history_store
+    items = collect_history_store.list_items(days=90, seller_id=_seller_id())
+    rows = []
+    for it in items:
+        extra = _parse_history_extra(it)
+        mon = extra.get("monitor") or {}
+        rows.append({
+            "id": it.get("id"),
+            "title": it.get("title") or extra.get("title_ko") or extra.get("title") or "(제목 없음)",
+            "url": it.get("url") or "",
+            "domain": it.get("domain") or "",
+            "image": it.get("image_url") or (extra.get("images") or [""])[0] if extra.get("images") else it.get("image_url") or "",
+            "price": it.get("price") or extra.get("price_original") or "",
+            "currency": it.get("currency") or extra.get("currency") or "",
+            "monitor": mon,
+        })
+    return render_template("sourcing_monitor.html", rows=rows, total=len(rows))
+
+
+@bp.post("/sourcing/monitor/check")
+def sourcing_monitor_check():
+    """수집 상품의 소싱처 변화 확인 (단건 또는 다건).
+
+    Request: {"item_id": "..."} 또는 {"item_ids": [...]}
+    Response: {"ok": true, "results": [{id, summary, change, current_price, in_stock, checked_at}]}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    data = request.get_json(force=True, silent=True) or {}
+    ids = data.get("item_ids")
+    if not ids:
+        single = data.get("item_id")
+        ids = [single] if single else []
+    ids = [str(i) for i in ids if i][:30]
+    if not ids:
+        return jsonify({"ok": False, "error": "확인할 항목이 없습니다."}), 400
+
+    from . import collect_history_store
+    sid = _seller_id()
+    results = []
+    for item_id in ids:
+        item = collect_history_store.get(item_id, seller_id=sid)
+        if not item:
+            results.append({"id": item_id, "ok": False, "summary": "항목을 찾을 수 없습니다."})
+            continue
+        mon = _check_source_change(item)
+        _persist_monitor_result(item_id, sid, item, mon)
+        results.append({"id": item_id, "ok": True, **mon})
+    return jsonify({"ok": True, "results": results})
+
+
 def _sourcing_require_admin():
     """소싱 페이지 관리자 권한 확인."""
     from src.auth.admin_resolver import is_admin_session

--- a/tests/test_extension_cors.py
+++ b/tests/test_extension_cors.py
@@ -1,0 +1,45 @@
+"""tests/test_extension_cors.py — 북마클릿/확장 크로스오리진 수집 CORS 허용 검증.
+
+CORS가 없으면 브라우저가 preflight를 막아 'Failed to fetch'로 수집이 실패한다.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_extension_preflight_allows_cross_origin(client):
+    """OPTIONS preflight에 Access-Control-Allow-Origin이 있어야 한다."""
+    resp = client.options(
+        "/api/v1/collect/extension",
+        headers={
+            "Origin": "https://www.yoshidakaban.com",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Content-Type, Authorization",
+        },
+    )
+    assert resp.status_code in (200, 204)
+    assert resp.headers.get("Access-Control-Allow-Origin") in ("*", "https://www.yoshidakaban.com")
+
+
+def test_extension_post_has_cors_header(client):
+    """실제 POST 응답에도 CORS 헤더가 붙어야 한다(401이어도 헤더는 존재)."""
+    resp = client.post(
+        "/api/v1/collect/extension",
+        headers={"Origin": "https://shop.example", "Content-Type": "application/json"},
+        json={"url": "https://shop.example/p/1"},
+    )
+    # 토큰 없으면 401이지만 CORS 헤더는 있어야 브라우저가 응답을 읽을 수 있다
+    assert resp.headers.get("Access-Control-Allow-Origin") in ("*", "https://shop.example")

--- a/tests/test_sourcing_monitor.py
+++ b/tests/test_sourcing_monitor.py
@@ -1,0 +1,95 @@
+"""tests/test_sourcing_monitor.py — 수집상품 소싱처 변화 모니터링 (가격/품절/옵션)."""
+from __future__ import annotations
+
+import os
+import sys
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _sp(price=None, in_stock=None, options=None, currency="USD", method="jsonld"):
+    return SimpleNamespace(price=price, in_stock=in_stock, options=options or {},
+                           currency=currency, extraction_method=method)
+
+
+def _item(price="100", url="https://brand.example/p/1", options=None):
+    extra = {"price_original": price, "options": options or {}}
+    return {"id": "it1", "url": url, "price": price, "currency": "USD",
+            "title": "샘플", "extra_json": json.dumps(extra)}
+
+
+def test_change_price_up_detected():
+    from src.seller_console import views
+    with patch("src.collectors.universal_scraper.UniversalScraper") as M:
+        M.return_value.fetch.return_value = _sp(price=130, in_stock=True)
+        mon = views._check_source_change(_item(price="100"))
+    assert mon["change"] == "price"
+    assert "가격" in mon["summary"] and "▲" in mon["summary"]
+
+
+def test_change_out_of_stock_detected():
+    from src.seller_console import views
+    with patch("src.collectors.universal_scraper.UniversalScraper") as M:
+        M.return_value.fetch.return_value = _sp(price=100, in_stock=False)
+        mon = views._check_source_change(_item(price="100"))
+    assert mon["change"] == "out_of_stock"
+    assert "품절" in mon["summary"]
+
+
+def test_change_none_when_same():
+    from src.seller_console import views
+    with patch("src.collectors.universal_scraper.UniversalScraper") as M:
+        M.return_value.fetch.return_value = _sp(price=100, in_stock=True)
+        mon = views._check_source_change(_item(price="100"))
+    assert mon["change"] == "none"
+    assert mon["summary"] == "변화 없음"
+
+
+def test_unfetchable_is_honest_not_fake():
+    from src.seller_console import views
+    with patch("src.collectors.universal_scraper.UniversalScraper") as M:
+        M.return_value.fetch.return_value = _sp(price=None, in_stock=None)
+        mon = views._check_source_change(_item(price="100"))
+    assert mon["change"] == "unknown"
+    assert "확인 불가" in mon["summary"]
+
+
+def test_option_size_change_detected():
+    from src.seller_console import views
+    with patch("src.collectors.universal_scraper.UniversalScraper") as M:
+        M.return_value.fetch.return_value = _sp(price=100, in_stock=True, options={"size": ["S", "M"]})
+        mon = views._check_source_change(_item(price="100", options={"size": ["S", "M", "L"]}))
+    assert mon["change"] in ("options", "changed")
+    assert "옵션" in mon["summary"] or "사이즈" in mon["summary"]
+
+
+def test_monitor_check_endpoint(client):
+    from src.seller_console import views
+    item = _item(price="100")
+    with patch("src.seller_console.collect_history_store.get", return_value=item), \
+         patch("src.seller_console.collect_history_store.update", return_value=True), \
+         patch.object(views, "_check_source_change", return_value={"change": "price", "summary": "가격 ▲", "checked_at": "2026-06-17T00:00:00"}):
+        resp = client.post("/seller/sourcing/monitor/check", json={"item_id": "it1"})
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["results"][0]["change"] == "price"
+
+
+def test_monitor_page_renders(client):
+    with patch("src.seller_console.collect_history_store.list_items", return_value=[_item(price="100")]):
+        resp = client.get("/seller/sourcing/monitor")
+    assert resp.status_code == 200
+    assert "소싱처 변화 모니터링" in resp.get_data(as_text=True)


### PR DESCRIPTION
오너 라이브 스크린샷(토큰 페이지 · 북마클릿 `Failed to fetch` · 북마크바 · 파비콘) 5종을 반영했습니다.

## 1. 북마클릿 수집이 안 되던 핵심 버그 — `Failed to fetch` (CORS)
- **원인**: CORS가 `/health/*`에만 설정돼 있어, 쇼핑몰 페이지에서 `/api/v1/collect/extension`으로 보내는 **크로스오리진 POST의 preflight(OPTIONS)가 차단** → 브라우저가 `Failed to fetch`로 막음.
- **수정**: `order_webhook.py` CORS에 `/api/v1/collect/*` (origins `*`, POST/OPTIONS, `Content-Type`/`Authorization`) 추가. Bearer 토큰 인증(쿠키 미사용)이라 `*` 안전.
- 북마클릿이 **페이지 HTML도 함께 전송**(600KB 상한)하도록 보강 → 봇 차단 사이트(yoshidakaban 등)도 서버 파싱으로 수집.

## 2. 인간친화 카피 — "회수" → "삭제"
- 토큰 상태/버튼/확인창/토스트의 "회수"를 모두 **"삭제"**로. (고가네퍼센티는 인간친화 우선)

## 3. 토큰 설명 추가
- `personal_tokens.html`에 **"토큰이 무엇이고 무슨 일을 하나"** 카드: ①쓰는 법 ②동작(=`Authorization: Bearer`) ③안전(해시 저장·삭제로 즉시 무효화) + 스코프 뜻 안내.

## 4. 북마클릿 버튼 → 고가네퍼센티 파비콘
- 🛒 이모지 대신 **`favicon.svg`(글로브) 이미지** 48×48 아이콘 버튼으로 → 북마크바에 고가네퍼센티 파비콘으로 표시.

## 5. 수집상품 소싱처 변화 모니터링 (실시간 연동 요청)
- 신규 **`/seller/sourcing/monitor`** (+사이드바 '소싱처 변화', AI 소싱 허브 링크).
- 내 수집 이력 상품의 소싱처를 `UniversalScraper`로 **재확인** → 수집 당시 가격/옵션과 비교해 **가격 ▲▼ · 품절 · 옵션/사이즈 소진**을 판정.
- 추출 불가(봇 차단/네트워크)는 거짓 알림 대신 **'확인 불가'**로 정직 처리. 결과는 `extra_json`에 저장해 다음 방문 시 마지막 상태 표시.
- `POST /sourcing/monitor/check` 단건/전체. ※ 현재 **온디맨드(버튼) 확인** — 정기 자동확인은 추후 스케줄러로 확장 예정(이건 명확히 안내).

## 테스트
- 전체 `python -m pytest tests/ -q`: **9960 passed, 2 skipped**.
- 신규: 소싱 모니터 변화판정 7종 + 모니터 CORS preflight 2종.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_