### PR TITLE
feat(collect/sourcing): 확장 수집버튼 브랜딩 직관화 + 소싱처 변화 자동확인 (Phase 217)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,15 @@
    `collect_history_store.update`로 extra_json에 저장(다음 방문 시 마지막 상태 표시). `POST /sourcing/monitor/check`
    단건/전체. ※ 현재는 온디맨드(버튼) 확인 — 정기 자동확인은 추후 스케줄러로 확장 예정.
 
+## 🔧 인페이지 수집버튼 직관화 + 소싱처 자동확인 (오너 지시 2026-06-17, Temu 스샷 — 퍼센티 벤치마킹 "똑같지 않게·바로")
+1. ✅ **확장 인페이지 수집 버튼 브랜딩/직관화** (Phase 217): `content_script.js` FAB를 🛒→**고가네 글로브
+   아이콘(네이비+주황/초록 궤도, 파비콘 모티프) + "고가네 수집/번역까지 한 번에"** 라벨, 네이비+주황테
+   pill로 강화(경쟁사 파란 막대형과 구분). 첫 등장 시 살짝 강조 애니메이션. manifest 1.2.0→1.3.0.
+2. ✅ **소싱처 변화 자동확인** (Phase 217): ①페이지 자동확인 — `/seller/sourcing/monitor` 열 때 '자동 확인'
+   토글(기본 ON, localStorage)로 미확인 상품 자동 점검(상한 20). ②서버 정기확인 — `run_auto_source_monitor()`
+   (최근 N일 수집상품 일괄 재확인, only_stale_hours 이내 스킵) + `POST /cron/sourcing-monitor`(X-Cron-Secret,
+   Render Cron). 변화건은 alerts로 요약. 정직성 유지(확인 불가는 변화 아님).
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -145,9 +145,19 @@ function setFabState(btn, state) {
   } else {
     btn.dataset.busy = "";
     btn.style.opacity = "1";
-    btn.querySelector(".kgp-fab-label").textContent = "수집";
+    btn.querySelector(".kgp-fab-label").textContent = "고가네 수집";
   }
 }
+
+// 고가네 퍼센티 브랜드 아이콘(글로브 + 주황/초록 궤도) — 파비콘과 동일 모티프.
+// 경쟁사(파란 막대형) 버튼과 구분되는 우리만의 식별 아이콘.
+const KGP_GLOBE_SVG =
+  '<svg width="20" height="20" viewBox="0 0 512 512" aria-hidden="true" style="display:block">' +
+  '<circle cx="256" cy="256" r="150" fill="#1e4fd1"/>' +
+  '<circle cx="256" cy="256" r="150" fill="none" stroke="#bcd6ff" stroke-width="10" opacity="0.5"/>' +
+  '<ellipse cx="256" cy="256" rx="210" ry="78" fill="none" stroke="#ff8a1e" stroke-width="22" transform="rotate(35 256 256)"/>' +
+  '<ellipse cx="256" cy="256" rx="210" ry="78" fill="none" stroke="#37d05a" stroke-width="22" transform="rotate(-35 256 256)"/>' +
+  '</svg>';
 
 function handleFabClick(btn) {
   if (btn.dataset.busy) return;
@@ -183,22 +193,39 @@ function injectCollectButton() {
   btn.id = KGP_BTN_ID;
   btn.type = "button";
   btn.innerHTML =
-    '<span style="font-size:18px;line-height:1">🛒</span>' +
-    '<span class="kgp-fab-label" style="font-weight:600">수집</span>';
-  btn.title = "코가네 퍼센티로 수집 (번역 포함)";
+    '<span style="display:flex;align-items:center;justify-content:center;width:28px;height:28px;' +
+    'background:#0a0a2a;border-radius:50%;flex-shrink:0">' + KGP_GLOBE_SVG + '</span>' +
+    '<span style="display:flex;flex-direction:column;align-items:flex-start;line-height:1.1">' +
+    '<span class="kgp-fab-label" style="font-weight:700;font-size:14px">고가네 수집</span>' +
+    '<span style="font-size:10px;opacity:.85">번역까지 한 번에</span>' +
+    '</span>';
+  btn.title = "고가네 퍼센티로 수집 (한국어 번역 포함)";
+  // 브랜드 색(네이비 + 주황 포인트) — 경쟁사 파란 막대형 버튼과 구분되는 우리만의 식별.
   btn.style.cssText = [
     "position:fixed", "right:20px", "bottom:20px", "z-index:2147483646",
-    "display:flex", "align-items:center", "gap:8px",
-    "padding:10px 16px", "border:none", "border-radius:999px",
-    "background:linear-gradient(135deg,#6f42c1,#8b5cf6)", "color:#fff",
+    "display:flex", "align-items:center", "gap:10px",
+    "padding:9px 16px 9px 10px", "border:1.5px solid #ff8a1e", "border-radius:999px",
+    "background:linear-gradient(135deg,#0a1f5c,#13308f)", "color:#fff",
     "font:14px/1 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
-    "cursor:pointer", "box-shadow:0 6px 18px rgba(111,66,193,.45)",
-    "transition:transform .12s,opacity .12s"
+    "cursor:pointer", "box-shadow:0 6px 20px rgba(10,31,92,.45)",
+    "transition:transform .12s,opacity .12s,box-shadow .12s"
   ].join(";");
-  btn.addEventListener("mouseenter", () => { btn.style.transform = "translateY(-2px)"; });
-  btn.addEventListener("mouseleave", () => { btn.style.transform = "none"; });
+  btn.addEventListener("mouseenter", () => {
+    btn.style.transform = "translateY(-2px)";
+    btn.style.boxShadow = "0 10px 26px rgba(255,138,30,.45)";
+  });
+  btn.addEventListener("mouseleave", () => {
+    btn.style.transform = "none";
+    btn.style.boxShadow = "0 6px 20px rgba(10,31,92,.45)";
+  });
   btn.addEventListener("click", () => handleFabClick(btn));
   document.body.appendChild(btn);
+
+  // 처음 등장 시 한 번 살짝 강조(인지성↑, 과하지 않게 1.2초)
+  btn.animate(
+    [{ transform: "scale(1)" }, { transform: "scale(1.06)" }, { transform: "scale(1)" }],
+    { duration: 600, iterations: 2, easing: "ease-in-out" }
+  );
 }
 
 // SPA 대응: 최초 + URL 변경 시 재시도

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "코가네 퍼센티 수집기",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "쇼핑 페이지를 한 클릭에 코가네 퍼센티로 수집 (인페이지 수집 버튼 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/src/pricing/cron.py
+++ b/src/pricing/cron.py
@@ -53,6 +53,41 @@ def reprice():
     return jsonify({"ok": True, "results": results})
 
 
+@cron_bp.post("/sourcing-monitor")
+def sourcing_monitor_cron():
+    """수집 상품 소싱처 변화 자동 확인 (Render Cron / 외부 스케줄러 훅).
+
+    헤더 ``X-Cron-Secret`` 이 ``CRON_SECRET`` 환경변수와 일치해야 실행.
+    (키 미설정 시 허용 — Render 크론에서 헤더 없이 호출 가능)
+
+    Query Params:
+        days, max_items, stale_hours — 확인 범위/주기 조정(선택).
+    """
+    cron_secret = os.getenv("CRON_SECRET")
+    if cron_secret:
+        if request.headers.get("X-Cron-Secret", "") != cron_secret:
+            return jsonify({"ok": False, "error": "Unauthorized"}), 401
+
+    def _int(name, default):
+        try:
+            return int(request.args.get(name, default))
+        except (TypeError, ValueError):
+            return default
+
+    try:
+        from src.seller_console.views import run_auto_source_monitor
+        summary = run_auto_source_monitor(
+            days=_int("days", 14),
+            max_items=_int("max_items", 200),
+            only_stale_hours=float(request.args.get("stale_hours", 6) or 6),
+        )
+    except Exception as exc:
+        logger.error("소싱처 자동확인 오류: %s", exc)
+        return jsonify({"ok": False, "error": "소싱처 자동확인 중 오류가 발생했습니다."}), 500
+
+    return jsonify({"ok": True, **summary})
+
+
 def _send_summary_notification(results: dict):
     """재가격 결과 요약을 텔레그램 + 이메일로 발송."""
     evaluated = results.get("evaluated", 0)

--- a/src/seller_console/templates/sourcing_monitor.html
+++ b/src/seller_console/templates/sourcing_monitor.html
@@ -8,7 +8,11 @@
       <p class="text-muted mb-0">내가 수집한 상품의 <strong>소싱처(원본 페이지)</strong>를 다시 확인해
         <strong>가격·품절·옵션/사이즈</strong> 변화를 알려줍니다.</p>
     </div>
-    <div class="d-flex gap-2">
+    <div class="d-flex gap-2 align-items-center">
+      <div class="form-check form-switch me-1" title="페이지를 열 때 아직 확인 안 한 상품을 자동으로 확인합니다">
+        <input class="form-check-input" type="checkbox" id="autoCheckToggle" checked>
+        <label class="form-check-label small" for="autoCheckToggle">자동 확인</label>
+      </div>
       <button id="checkAllBtn" class="btn btn-primary btn-sm" {% if not rows %}disabled{% endif %}>
         <i class="bi bi-arrow-repeat"></i> 전체 변화 확인
       </button>
@@ -19,9 +23,10 @@
   <div class="alert alert-light border small d-flex gap-2 align-items-start mb-3">
     <i class="bi bi-info-circle text-primary"></i>
     <div class="mb-0">
-      <strong>어떻게 동작하나요?</strong> ‘변화 확인’을 누르면 그 순간 소싱처 페이지를 실제로 다시 읽어
-      <strong>수집 당시 가격과 비교</strong>합니다. 추출이 막힌 사이트(로그인·봇 차단)는 거짓 알림 대신
-      <em>‘확인 불가’</em>로 정직하게 표시합니다. (정기 자동 확인은 추후 스케줄러로 확장 예정)
+      <strong>어떻게 동작하나요?</strong> 소싱처 페이지를 실제로 다시 읽어 <strong>수집 당시 가격·옵션과 비교</strong>합니다.
+      <strong>자동 확인</strong>이 켜져 있으면 이 페이지를 열 때 아직 확인 안 한 상품을 자동으로 확인합니다.
+      추출이 막힌 사이트(로그인·봇 차단)는 거짓 알림 대신 <em>‘확인 불가’</em>로 정직하게 표시합니다.
+      <span class="text-muted">서버 정기 자동확인은 <code>POST /cron/sourcing-monitor</code>(Render Cron)로 동작합니다.</span>
     </div>
   </div>
 
@@ -48,7 +53,7 @@
         </thead>
         <tbody>
           {% for r in rows %}
-          <tr data-id="{{ r.id }}">
+          <tr data-id="{{ r.id }}" data-checked="{{ '1' if r.monitor.checked_at else '0' }}">
             <td style="max-width:280px;">
               <div class="d-flex gap-2 align-items-center">
                 {% if r.image %}<img src="{{ r.image }}" alt="" style="width:40px;height:40px;object-fit:cover;border-radius:6px;flex-shrink:0;" onerror="this.style.display='none'">{% endif %}
@@ -130,5 +135,25 @@ document.getElementById('checkAllBtn')?.addEventListener('click', async (e) => {
   btn.disabled = false; btn.innerHTML = '<i class="bi bi-arrow-repeat"></i> 전체 변화 확인';
   if (window.pcToast) pcToast('전체 소싱처 변화 확인 완료', 'success');
 });
+
+// 자동 확인 토글 상태 저장
+const autoToggle = document.getElementById('autoCheckToggle');
+if (autoToggle) {
+  const saved = localStorage.getItem('kgp_monitor_auto');
+  if (saved !== null) autoToggle.checked = saved === '1';
+  autoToggle.addEventListener('change', () => {
+    localStorage.setItem('kgp_monitor_auto', autoToggle.checked ? '1' : '0');
+  });
+}
+
+// 페이지 열 때: 자동 확인 ON이면 아직 확인 안 한 상품을 자동으로 확인(과부하 방지 상한 20)
+(async function autoCheckOnLoad() {
+  if (!autoToggle || !autoToggle.checked) return;
+  const pending = [...document.querySelectorAll('tr[data-id][data-checked="0"]')].slice(0, 20);
+  for (const row of pending) {
+    if (!autoToggle.checked) break;  // 도중 끄면 중단
+    await checkItem(row.dataset.id, row);
+  }
+})();
 </script>
 {% endblock %}

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -4844,6 +4844,42 @@ def _persist_monitor_result(item_id: str, seller_id: str, item: dict, mon: dict)
         logger.warning("모니터 결과 저장 실패(%s): %s", item_id, exc)
 
 
+def run_auto_source_monitor(*, days: int = 14, max_items: int = 200, only_stale_hours: float = 6.0,
+                            seller_id: Optional[str] = None) -> dict:
+    """모든(또는 특정 셀러) 최근 수집 상품의 소싱처를 자동 재확인한다.
+
+    Render Cron(`/cron/sourcing-monitor`) 또는 페이지 자동확인에서 호출.
+    최근 확인분(only_stale_hours 이내)은 건너뛰어 과도한 스크래핑을 방지한다.
+    """
+    from . import collect_history_store
+    from datetime import datetime as _dt
+
+    items = collect_history_store.list_items(days=days, seller_id=seller_id)
+    checked = changed = skipped = 0
+    alerts: list[dict] = []
+    for it in items[:max_items]:
+        extra = _parse_history_extra(it)
+        mon = extra.get("monitor") or {}
+        last = mon.get("checked_at")
+        if last and only_stale_hours:
+            try:
+                age_h = (datetime.now(timezone.utc) - _dt.fromisoformat(last)).total_seconds() / 3600.0
+                if age_h < only_stale_hours:
+                    skipped += 1
+                    continue
+            except Exception:
+                pass
+        sid = str(it.get("seller_id") or "") or None
+        res = _check_source_change(it)
+        _persist_monitor_result(it.get("id"), sid, it, res)
+        checked += 1
+        if res.get("change") not in ("none", "unknown", None):
+            changed += 1
+            alerts.append({"id": it.get("id"), "title": it.get("title"), "summary": res.get("summary")})
+    return {"total": len(items), "checked": checked, "changed": changed,
+            "skipped": skipped, "alerts": alerts[:50]}
+
+
 @bp.get("/sourcing/monitor")
 def sourcing_monitor():
     """수집한 상품의 소싱처 변화(품절/가격/옵션) 모니터링 페이지."""

--- a/tests/test_sourcing_monitor.py
+++ b/tests/test_sourcing_monitor.py
@@ -93,3 +93,39 @@ def test_monitor_page_renders(client):
         resp = client.get("/seller/sourcing/monitor")
     assert resp.status_code == 200
     assert "소싱처 변화 모니터링" in resp.get_data(as_text=True)
+
+
+# 자동확인 — 배치 러너 + cron 엔드포인트
+def test_run_auto_monitor_skips_recent_and_counts_changes():
+    from src.seller_console import views
+    from datetime import datetime, timezone, timedelta
+    recent = datetime.now(timezone.utc).isoformat()
+    old = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+    fresh_item = {"id": "fresh", "url": "https://x/1", "price": "100", "currency": "USD",
+                  "extra_json": json.dumps({"monitor": {"checked_at": recent, "change": "none"}})}
+    stale_item = {"id": "stale", "url": "https://x/2", "price": "100", "currency": "USD",
+                  "extra_json": json.dumps({"monitor": {"checked_at": old, "change": "none"}, "price_original": "100"})}
+    with patch("src.seller_console.collect_history_store.list_items", return_value=[fresh_item, stale_item]), \
+         patch("src.seller_console.collect_history_store.update", return_value=True), \
+         patch.object(views, "_check_source_change", return_value={"change": "price", "summary": "가격 ▲", "checked_at": "2026-06-17T00:00:00"}):
+        summary = views.run_auto_source_monitor(only_stale_hours=6)
+    assert summary["skipped"] == 1      # fresh 건너뜀
+    assert summary["checked"] == 1      # stale 확인
+    assert summary["changed"] == 1
+    assert summary["alerts"][0]["id"] == "stale"
+
+
+def test_cron_sourcing_monitor_route(client, monkeypatch):
+    monkeypatch.delenv("CRON_SECRET", raising=False)
+    with patch("src.seller_console.views.run_auto_source_monitor",
+               return_value={"total": 3, "checked": 2, "changed": 1, "skipped": 1, "alerts": []}):
+        resp = client.post("/cron/sourcing-monitor")
+    data = resp.get_json()
+    assert resp.status_code == 200 and data["ok"] is True
+    assert data["checked"] == 2 and data["changed"] == 1
+
+
+def test_cron_sourcing_monitor_requires_secret(client, monkeypatch):
+    monkeypatch.setenv("CRON_SECRET", "s3cret")
+    resp = client.post("/cron/sourcing-monitor")  # 헤더 없음 → 401
+    assert resp.status_code == 401


### PR DESCRIPTION
오너 지시(Temu 화면의 퍼센티 인페이지 수집 버튼 벤치마킹 — "직관적·딱 알아보기 쉽게, 단 똑같지 않게" + "자동확인도 붙여라").

## 1. 인페이지 수집 버튼 직관화 + 고가네 브랜딩 (확장)
- `content_script.js` 인페이지 FAB을 강화: 🛒 이모지 → **고가네 글로브 아이콘**(네이비 배경 + 주황/초록 궤도, 파비콘 모티프) + **"고가네 수집 / 번역까지 한 번에"** 2줄 라벨.
- 색상은 **네이비+주황 테두리 pill** — 경쟁사(퍼센티)의 파란 우측 막대형과 **명확히 구분**(똑같지 않게).
- 첫 등장 시 살짝 강조 애니메이션으로 인지성↑. `manifest` 1.2.0 → **1.3.0**.

## 2. 소싱처 변화 자동확인 (요청: "자동확인도 붙여라")
- **페이지 자동확인**: `/seller/sourcing/monitor`에 **'자동 확인' 토글**(기본 ON, localStorage 저장) 추가 → 페이지를 열면 아직 확인 안 한 상품을 자동으로 점검(과부하 방지 상한 20).
- **서버 정기확인**: `run_auto_source_monitor()` (최근 N일 수집상품 일괄 재확인, 최근 확인분은 `stale_hours` 이내면 스킵) + **`POST /cron/sourcing-monitor`** (기존 `/cron/reprice`와 동일한 `X-Cron-Secret` 인증, Render Cron Job으로 주기 호출). 변화 건은 `alerts`로 요약 반환.
- 정직성 유지: 추출 불가(봇 차단/네트워크)는 변화로 치지 않고 '확인 불가'.

## 테스트
- 전체 `python -m pytest tests/ -q`: **9963 passed, 2 skipped**.
- 신규: 자동확인 배치(최근분 스킵/변화 카운트) + cron 라우트/시크릿 3종. content_script JS `node --check` 통과.

### 오너 액션(선택)
- 서버 정기 자동확인을 켜려면 **Render Cron Job**에서 `POST https://kohganepercentiii.com/cron/sourcing-monitor` 주기 호출(예: 매시). `CRON_SECRET` 설정 시 `X-Cron-Secret` 헤더 필요.
- 확장 버튼 변경은 **확장 새로고침/재설치** 후 반영(manifest 1.3.0).

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_