### PR TITLE
fix(collect): 북마클릿 CSP 우회 실작동(토큰불필요) + 아마존 국가선택 + 수집화면 파비콘 (Phase 218)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,19 @@
    (최근 N일 수집상품 일괄 재확인, only_stale_hours 이내 스킵) + `POST /cron/sourcing-monitor`(X-Cron-Secret,
    Render Cron). 변화건은 alerts로 요약. 정직성 유지(확인 불가는 변화 아님).
 
+## 🔧 북마클릿 실작동(CSP 우회)+아마존 국가선택+수집화면 파비콘 (오너 지시 2026-06-17, /seller/collect 스샷)
+1. ✅ **북마클릿 토큰 발급해도 수집 안 됨 → 실작동** (Phase 218): 원인은 토큰이 아니라 **임의 쇼핑몰의 CSP**가
+   북마클릿 `fetch`(`/api/v1/collect/extension`)를 막은 것(Temu/아마존 등). → 북마클릿을 **fetch 대신 '새 탭
+   네비게이션'** 방식으로 교체: 페이지 메타(u/t/img/p/c)를 쿼리로 담아 `window.open('/seller/collect/quick?…')`.
+   새 탭은 **로그인 세션**으로 열려(토큰 불필요) CSP/CORS 영향 없음 → 실제 수집됨. 신설 `GET /seller/collect/quick`:
+   세션 인증 → `_collect_real_draft` 서버수집(상세·번역), 막히면 **페이지 메타로 폴백 수집**(정직) → 수집 이력
+   저장 → 편집 페이지로 redirect. 둘 다 실패 시 `collect_quick_result.html`로 직접입력/확장 안내. (구 토큰 fetch
+   북마클릿 제거. 크롬 확장은 그대로 — 봇 차단 사이트는 확장 권장.)
+2. ✅ **아마존 국가 드롭다운** (Phase 218): `oneclick_markets`의 아마존을 `countries`(미국/일본/독일/영국/프랑스/
+   캐나다/이탈리아/스페인/호주/인도) 드롭다운으로 — 국가별 사이트 선택 후 열기.
+3. ✅ **수집 화면 파비콘 + 카피 갱신** (Phase 218): `/seller/collect` '인페이지 수집' 안내에 favicon.svg 노출 +
+   '보라색 수집 버튼'→'고가네 퍼센티 아이콘+고가네 수집'으로 갱신, 북마클릿(토큰 불필요) 링크 추가.
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/src/seller_console/templates/bookmarklet.html
+++ b/src/seller_console/templates/bookmarklet.html
@@ -3,35 +3,22 @@
 {% block content %}
 <div class="container-fluid py-4">
   <h1 class="h3 mb-1">📌 북마클릿 설치</h1>
-  <p class="text-muted mb-4">쇼핑 페이지에서 클릭 한 번으로 상품을 수집합니다.</p>
+  <p class="text-muted mb-4">쇼핑 페이지에서 클릭 한 번으로 상품을 수집합니다. <strong>토큰 없이</strong> 바로 작동해요(로그인만 되어 있으면 됩니다).</p>
 
   <div class="row g-4">
     <!-- 설치 안내 -->
     <div class="col-lg-7">
       <div class="card mb-4">
-        <div class="card-header"><strong>🔧 설치 방법</strong></div>
+        <div class="card-header"><strong>🔧 설치 방법 (2단계)</strong></div>
         <div class="card-body">
-          <ol class="mb-3">
-            <li>아래 <strong>북마클릿 버튼</strong>을 마우스로 드래그해 브라우저 북마크바에 놓으세요.</li>
-            <li>상품 페이지에서 북마크를 클릭하면 즉시 수집됩니다.</li>
+          <ol class="mb-2">
+            <li>아래 <strong>고가네 퍼센티 아이콘</strong>을 마우스로 드래그해 브라우저 북마크바에 놓으세요.</li>
+            <li>상품 페이지에서 그 북마크를 클릭하면 <strong>새 탭이 열리며 자동 수집</strong>되고, 바로 편집 화면으로 이동합니다.</li>
           </ol>
-          <div class="alert alert-warning">
-            ⚠️ <strong>Personal Access Token이 필요합니다.</strong>
-            <a href="/seller/me/tokens" class="alert-link">→ 토큰 발급하기</a>
+          <div class="alert alert-success small mb-0">
+            ✅ <strong>토큰이 필요 없습니다.</strong> 새 탭이 고가네 퍼센티(로그인된 내 계정)로 열려 안전하게 수집됩니다.
+            (예전 토큰 방식은 일부 사이트의 보안정책(CSP)에 막혀 작동하지 않았어요 — 이 방식은 그 문제가 없습니다.)
           </div>
-        </div>
-      </div>
-
-      <!-- 토큰 입력 -->
-      <div class="card mb-4">
-        <div class="card-header"><strong>🔑 토큰 설정</strong></div>
-        <div class="card-body">
-          <div class="mb-3">
-            <label class="form-label">Personal Access Token</label>
-            <input type="password" class="form-control font-monospace" id="tokenInput"
-                   placeholder="tok_...">
-          </div>
-          <button class="btn btn-primary" onclick="updateBookmarklet()">북마클릿 업데이트</button>
         </div>
       </div>
 
@@ -39,9 +26,8 @@
       <div class="card">
         <div class="card-header"><strong>📌 북마클릿 (드래그해서 북마크바에 추가)</strong></div>
         <div class="card-body text-center py-4">
-          <!-- 북마크바에 고가네 퍼센티 파비콘(글로브)이 아이콘으로 보이도록 구성.
-               드래그 링크 안에 favicon 이미지를 넣어 작은 아이콘 버튼으로 노출. -->
-          <a id="bookmarkletLink" href="javascript:void(0)"
+          <!-- 토큰 불필요: 새 탭으로 서버를 열어 로그인 세션으로 수집(CSP/CORS 우회). -->
+          <a id="bookmarkletLink"
              class="d-inline-flex align-items-center justify-content-center text-decoration-none"
              style="cursor:grab;width:48px;height:48px;border-radius:12px;padding:4px;border:1px solid #dee2e6;background:#fff;"
              title="이 아이콘을 북마크바로 드래그하세요 — 고가네 퍼센티 아이콘으로 표시됩니다"
@@ -50,17 +36,17 @@
                  alt="고가네퍼센티" style="width:100%;height:100%;border-radius:8px;" draggable="false">
           </a>
           <p class="mt-3 text-muted small mb-0">위 <strong>고가네 퍼센티 아이콘</strong>을 북마크바로 드래그하세요.</p>
-          <p class="text-muted small">북마크바에는 긴 이름 대신 <strong>고가네 퍼센티 파비콘</strong>으로 표시됩니다(자리를 적게 차지해요).</p>
+          <p class="text-muted small">북마크바에는 긴 이름 대신 <strong>고가네 퍼센티 파비콘</strong>으로 표시됩니다.</p>
         </div>
       </div>
     </div>
 
-    <!-- 코드 보기 -->
+    <!-- 코드 보기 / 동작 원리 -->
     <div class="col-lg-5">
       <div class="card">
         <div class="card-header"><strong>📄 북마클릿 코드</strong></div>
         <div class="card-body">
-          <pre class="bg-light p-3 rounded" style="font-size:0.75rem;overflow-x:auto;" id="bookmarkletCode">토큰을 입력하면 코드가 표시됩니다.</pre>
+          <pre class="bg-light p-3 rounded" style="font-size:0.72rem;overflow-x:auto;white-space:pre-wrap;" id="bookmarkletCode">코드 로딩 중…</pre>
           <button class="btn btn-sm btn-outline-secondary mt-2" onclick="copyCode()">코드 복사</button>
         </div>
       </div>
@@ -68,12 +54,12 @@
       <div class="card mt-3">
         <div class="card-header"><strong>ℹ️ 동작 원리</strong></div>
         <div class="card-body small text-muted">
-          <ol>
-            <li>상품 페이지의 메타태그(JSON-LD/OG) 추출</li>
-            <li>서버 <code>/api/v1/collect/extension</code>으로 전송</li>
-            <li>카탈로그 저장 + 텔레그램 알림</li>
-            <li>결과 알림 (alert)</li>
+          <ol class="mb-2">
+            <li>상품 페이지의 메타(제목/이미지/가격)를 읽습니다.</li>
+            <li><strong>새 탭으로 고가네 퍼센티를 열어</strong> 상품 URL과 메타를 전달합니다.</li>
+            <li>서버가 상세·번역까지 수집해 <strong>수집 이력에 저장</strong>하고 편집 화면으로 이동합니다.</li>
           </ol>
+          <div>봇 차단이 강한 사이트는 <a href="/seller/markets/guide">크롬 확장(고가네 수집)</a>을 권장합니다.</div>
         </div>
       </div>
     </div>
@@ -81,42 +67,29 @@
 </div>
 
 <script>
-const SERVER_URL = "{{ server_url }}";
+const SERVER_URL = "{{ request.host_url.rstrip('/') }}";
 
-function buildBookmarkletCode(token) {
-  return `javascript:(function(){
-  var meta={
-    url:location.href,
-    title:document.title,
-    image:(document.querySelector('meta[property="og:image"]')||{}).content,
-    price:(document.querySelector('meta[property="product:price:amount"]')||{}).content,
-    currency:(document.querySelector('meta[property="product:price:currency"]')||{content:'USD'}).content,
-    description:(document.querySelector('meta[name="description"]')||{}).content,
-    jsonld:[...document.querySelectorAll('script[type="application/ld+json"]')].map(function(s){try{return JSON.parse(s.innerText);}catch(e){return null;}}).filter(Boolean),
-    html:(document.documentElement.outerHTML||'').slice(0,600000)
-  };
-  fetch('${SERVER_URL}/api/v1/collect/extension',{
-    method:'POST',
-    headers:{'Content-Type':'application/json','Authorization':'Bearer ${token}'},
-    body:JSON.stringify(meta)
-  }).then(function(r){return r.json();}).then(function(d){
-    alert(d.ok?'✅ 수집 완료: ${SERVER_URL}'+(d.preview_url||''):'❌ 실패: '+(d.error||'알 수 없는 오류'));
-  }).catch(function(e){alert('❌ 오류: '+e.message);});
-})();`;
+// 토큰 불필요 — 새 탭으로 서버(/seller/collect/quick)를 열어 로그인 세션으로 수집.
+// 임의 쇼핑몰의 CSP가 fetch를 막아도 페이지 '이동'은 막히지 않아 실제로 수집된다.
+function buildBookmarkletCode() {
+  return "javascript:(function(){" +
+    "var S='" + SERVER_URL + "';" +
+    "function M(p){var e=document.querySelector('meta[property=\"'+p+'\"],meta[name=\"'+p+'\"]');return e?(e.content||''):''}" +
+    "var q=new URLSearchParams();" +
+    "q.set('u',location.href);" +
+    "q.set('t',(M('og:title')||document.title||'').slice(0,300));" +
+    "q.set('img',M('og:image')||M('og:image:url')||'');" +
+    "q.set('p',M('product:price:amount')||'');" +
+    "q.set('c',M('product:price:currency')||'');" +
+    "window.open(S+'/seller/collect/quick?'+q.toString(),'_blank');" +
+    "})();";
 }
 
-function updateBookmarklet() {
-  const rawToken = document.getElementById('tokenInput').value.trim();
-  if (!rawToken) {
-    pcToast('토큰을 입력해주세요.', 'warning');
-    return;
-  }
-  // 토큰 값을 JSON-encode하여 특수 문자가 JS 코드에 삽입되지 않도록 처리
-  const safeToken = JSON.stringify(rawToken).slice(1, -1);
-  const code = buildBookmarkletCode(safeToken);
-  document.getElementById('bookmarkletLink').href = code;
+(function initBookmarklet() {
+  const code = buildBookmarkletCode();
+  document.getElementById('bookmarkletLink').setAttribute('href', code);
   document.getElementById('bookmarkletCode').textContent = code;
-}
+})();
 
 function copyCode() {
   const code = document.getElementById('bookmarkletCode').textContent;
@@ -124,3 +97,4 @@ function copyCode() {
 }
 </script>
 {% endblock %}
+

--- a/src/seller_console/templates/collect_quick_result.html
+++ b/src/seller_console/templates/collect_quick_result.html
@@ -1,0 +1,40 @@
+{% extends "_base.html" %}
+{% block title %}북마클릿 수집{% endblock %}
+{% block content %}
+<div class="container-fluid py-4" style="max-width:680px">
+  <div class="card console-card">
+    <div class="card-body text-center py-4">
+      {% if ok %}
+      <div class="display-6 mb-2">✅</div>
+      <h1 class="h5 mb-2">수집 완료</h1>
+      <p class="text-muted small mb-3">{{ message }}</p>
+      {% else %}
+      <div class="display-6 mb-2">⚠️</div>
+      <h1 class="h5 mb-2">자동 수집이 어려운 페이지예요</h1>
+      <p class="text-muted small mb-3">{{ message }}</p>
+      {% endif %}
+
+      {% if url %}
+      <div class="small text-muted text-truncate mb-3" title="{{ url }}">{{ url }}</div>
+      {% endif %}
+
+      <div class="d-flex flex-wrap gap-2 justify-content-center">
+        {% if url %}
+        <a class="btn btn-primary btn-sm" href="/seller/collect?url={{ url|urlencode }}">
+          <i class="bi bi-pencil"></i> 직접 입력으로 등록
+        </a>
+        {% endif %}
+        <a class="btn btn-outline-secondary btn-sm" href="/seller/bookmarklet">
+          <i class="bi bi-bookmark"></i> 북마클릿 다시 보기
+        </a>
+        <a class="btn btn-outline-secondary btn-sm" href="/seller/collect/history">수집 이력</a>
+      </div>
+
+      <div class="alert alert-light border small mt-4 mb-0 text-start">
+        💡 <strong>봇 차단이 강한 사이트</strong>(로그인 필요·강한 보호)는 <strong>크롬 확장(고가네 수집)</strong>을
+        쓰면 브라우저 화면 그대로 수집됩니다. <a href="/seller/markets/guide">설치 가이드 →</a>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/seller_console/templates/manual_collect.html
+++ b/src/seller_console/templates/manual_collect.html
@@ -33,14 +33,33 @@
     </div>
     <div class="d-flex flex-wrap gap-2" id="oneclickMarkets">
       {% for m in oneclick_markets %}
+      {% if m.countries %}
+      <div class="dropdown oneclick-market">
+        <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+          {{ m.emoji }} {{ m.name }}
+        </button>
+        <ul class="dropdown-menu">
+          <li><h6 class="dropdown-header">국가 선택</h6></li>
+          {% for ctry in m.countries %}
+          <li><a class="dropdown-item" href="{{ ctry.url }}" target="_blank" rel="noopener noreferrer">{{ ctry.name }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% else %}
       <a href="{{ m.url }}" target="_blank" rel="noopener noreferrer"
          class="btn btn-outline-primary btn-sm oneclick-market">{{ m.emoji }} {{ m.name }}</a>
+      {% endif %}
       {% endfor %}
     </div>
-    <div class="alert alert-light border mt-3 mb-0 small" role="note">
-      <b class="text-primary">퍼센티식 인페이지 수집</b> — 크롬 확장(🛒 수집)을 설치하면 위 마켓의 상품
-      페이지 우하단에 보라색 <b>수집</b> 버튼이 떠서, 클릭 한 번으로 자동 수집·한국어 번역됩니다.
-      <a href="/seller/markets/guide" class="ms-1 text-decoration-none">설치/사용 가이드 →</a>
+    <div class="alert alert-light border mt-3 mb-0 small d-flex gap-2 align-items-start" role="note">
+      <img src="{{ url_for('seller_console.static', filename='favicon.svg') }}" alt="고가네퍼센티"
+           style="width:34px;height:34px;border-radius:8px;flex-shrink:0">
+      <div>
+        <b class="text-primary">고가네 인페이지 수집</b> — 크롬 확장(고가네 수집)을 설치하면 위 마켓의 상품
+        페이지 우하단에 <b>고가네 퍼센티 아이콘 + “고가네 수집”</b> 버튼이 떠서, 클릭 한 번으로 자동 수집·한국어
+        번역됩니다. 설치가 부담되면 <a href="/seller/bookmarklet">북마클릿(토큰 불필요)</a>으로도 수집할 수 있어요.
+        <a href="/seller/markets/guide" class="ms-1 text-decoration-none">설치/사용 가이드 →</a>
+      </div>
     </div>
   </div>
 </div>

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1028,7 +1028,19 @@ def collect():
         {"name": "VVIC", "url": "https://www.vvic.com", "emoji": "👗"},
         {"name": "라쿠텐", "url": "https://www.rakuten.co.jp", "emoji": "🎌"},
         {"name": "ZOZOTOWN", "url": "https://zozo.jp", "emoji": "👕"},
-        {"name": "아마존", "url": "https://www.amazon.com", "emoji": "🅰️"},
+        # 아마존은 국가별 사이트가 달라 드롭다운으로 선택(퍼센티 벤치마킹)
+        {"name": "아마존", "emoji": "🅰️", "countries": [
+            {"name": "미국 (.com)", "url": "https://www.amazon.com"},
+            {"name": "일본 (.co.jp)", "url": "https://www.amazon.co.jp"},
+            {"name": "독일 (.de)", "url": "https://www.amazon.de"},
+            {"name": "영국 (.co.uk)", "url": "https://www.amazon.co.uk"},
+            {"name": "프랑스 (.fr)", "url": "https://www.amazon.fr"},
+            {"name": "캐나다 (.ca)", "url": "https://www.amazon.ca"},
+            {"name": "이탈리아 (.it)", "url": "https://www.amazon.it"},
+            {"name": "스페인 (.es)", "url": "https://www.amazon.es"},
+            {"name": "호주 (.com.au)", "url": "https://www.amazon.com.au"},
+            {"name": "인도 (.in)", "url": "https://www.amazon.in"},
+        ]},
         {"name": "SHEIN", "url": "https://www.shein.com", "emoji": "✨"},
         {"name": "요시다카반", "url": "https://www.yoshidakaban.com/ko/", "emoji": "🎒"},
     ]
@@ -1124,6 +1136,86 @@ def collect_preview():
             response["save_error"] = "수집은 됐지만 이력 저장에 실패했습니다."
 
     return jsonify(response)
+
+
+@bp.get("/collect/quick")
+def collect_quick():
+    """북마클릿 '새 탭 네비게이션' 수집 (Phase 218 — 토큰 없이 로그인 세션으로 작동).
+
+    북마클릿이 `fetch` 대신 새 탭으로 이 URL을 열어 수집한다. 임의 쇼핑몰의 CSP가
+    `fetch`를 막아도(토큰 발급해도 수집 실패하던 원인) 페이지 '이동'은 막히지 않으므로
+    실제로 수집된다. 로그인 세션을 쓰므로 Personal Access Token이 필요 없다.
+
+    Query: u(상품URL, 필수), t(제목), img(이미지), p(가격), c(통화) — 페이지에서 읽은 메타.
+    """
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.full_path))
+
+    url = (request.args.get("u") or "").strip()
+    if not url.startswith(("http://", "https://")):
+        return render_template(
+            "collect_quick_result.html", ok=False,
+            message="올바른 상품 URL이 아닙니다. 상품 상세 페이지에서 북마클릿을 눌러주세요.",
+            url=url,
+        ), 400
+
+    # 1) 서버 수집 시도(접근 가능한 사이트는 상세/번역까지). 막히면 페이지 메타로 폴백.
+    draft = None
+    try:
+        draft = _collect_real_draft(url, translate=True)
+    except Exception as exc:
+        logger.warning("북마클릿 수집 파이프라인 오류(%s): %s", url[:80], exc)
+
+    used_meta = False
+    if not draft:
+        # 봇 차단 등으로 서버 수집 실패 → 북마클릿이 보낸 페이지 메타로 최소 수집(정직)
+        t = (request.args.get("t") or "").strip()
+        img = (request.args.get("img") or "").strip()
+        price = (request.args.get("p") or "").strip()
+        currency = (request.args.get("c") or "").strip() or "USD"
+        if t or img:
+            used_meta = True
+            draft = {
+                "title": t, "title_ko": t, "title_en": t,
+                "price_original": price, "price": price, "currency": currency,
+                "images": [img] if img else [], "image": img,
+                "description": "", "description_ko": "",
+                "source": "bookmarklet_meta",
+            }
+
+    if not draft:
+        # 메타조차 없으면 정직하게 직접입력으로 안내
+        return render_template(
+            "collect_quick_result.html", ok=False,
+            message=("이 페이지에서 상품 정보를 읽지 못했습니다. 상품 상세 페이지인지 확인하거나, "
+                     "봇 차단 사이트는 크롬 확장(고가네 수집)을 사용하세요."),
+            url=url,
+        )
+
+    images = draft.get("images") if isinstance(draft.get("images"), list) else []
+    title = draft.get("title_ko") or draft.get("title") or draft.get("title_en") or "(제목 없음)"
+    try:
+        from . import collect_history_store
+        item_id = collect_history_store.append(
+            source="bookmarklet",
+            url=url,
+            title=title,
+            image=images[0] if images else draft.get("image", ""),
+            price=str(draft.get("price_original") or draft.get("price") or ""),
+            currency=draft.get("currency") or "",
+            extra=draft,
+            seller_id=_seller_id(),
+        )
+    except Exception as exc:
+        logger.warning("북마클릿 수집 이력 저장 실패: %s", exc)
+        return render_template(
+            "collect_quick_result.html", ok=False,
+            message="수집은 됐지만 이력 저장에 실패했습니다. 다시 시도해주세요.", url=url,
+        )
+
+    _register_discovery_candidate_from_collection(url)
+    # 편집 페이지로 바로 이동(확인·수정·등록)
+    return redirect(f"/seller/collect/preview/{item_id}?from=bookmarklet&meta={'1' if used_meta else '0'}")
 
 
 @bp.post("/collect/upload")

--- a/tests/test_collect_quick_bookmarklet.py
+++ b/tests/test_collect_quick_bookmarklet.py
@@ -1,0 +1,72 @@
+"""tests/test_collect_quick_bookmarklet.py — 토큰 없는 새 탭 네비게이션 북마클릿 수집."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _draft(**over):
+    d = {"title_ko": "테스트", "title": "t", "title_en": "t", "images": ["https://i/1.jpg"],
+         "price_original": "10", "price": "10", "currency": "USD", "source": "x"}
+    d.update(over)
+    return d
+
+
+def test_quick_collect_saves_and_redirects_to_edit(client):
+    with patch("src.seller_console.views._collect_real_draft", return_value=_draft()), \
+         patch("src.seller_console.collect_history_store.append", return_value="qid1"):
+        r = client.get("/seller/collect/quick?u=https://shop.example/p/1")
+    assert r.status_code == 302
+    assert "/seller/collect/preview/qid1" in r.headers["Location"]
+
+
+def test_quick_collect_meta_fallback_when_server_blocked(client):
+    """서버 수집 실패해도 북마클릿이 보낸 페이지 메타로 최소 수집(정직)."""
+    with patch("src.seller_console.views._collect_real_draft", return_value=None), \
+         patch("src.seller_console.collect_history_store.append", return_value="qid2") as ap:
+        r = client.get("/seller/collect/quick?u=https://shop.example/p/2&t=가방&img=https://i/x.jpg&p=99&c=USD")
+    assert r.status_code == 302
+    assert "/seller/collect/preview/qid2" in r.headers["Location"]
+    # append가 메타 기반으로 호출됨
+    assert ap.call_count == 1
+    assert ap.call_args.kwargs["title"] == "가방"
+    assert ap.call_args.kwargs["source"] == "bookmarklet"
+
+
+def test_quick_collect_no_data_shows_honest_result(client):
+    with patch("src.seller_console.views._collect_real_draft", return_value=None):
+        r = client.get("/seller/collect/quick?u=https://shop.example/p/3")
+    assert r.status_code == 200
+    assert "자동 수집이 어려운" in r.get_data(as_text=True)
+
+
+def test_quick_collect_rejects_bad_url(client):
+    r = client.get("/seller/collect/quick?u=notaurl")
+    assert r.status_code == 400
+
+
+def test_bookmarklet_page_is_token_free(client):
+    html = client.get("/seller/bookmarklet").get_data(as_text=True)
+    assert "/seller/collect/quick" in html
+    assert "Bearer" not in html          # 토큰 fetch 방식 제거됨
+    assert "토큰이 필요 없습니다" in html
+
+
+def test_collect_page_amazon_dropdown_and_favicon(client):
+    html = client.get("/seller/collect").get_data(as_text=True)
+    assert "dropdown-toggle" in html
+    assert "amazon.co.jp" in html and "amazon.de" in html
+    assert "favicon.svg" in html


### PR DESCRIPTION
오너 지적(`/seller/collect` 화면): ①북마클릿 토큰 발급해도 수집 안 됨 ②아마존은 여러 나라가 있으니 드롭다운 선택 ③여기에도 파비콘.

## 1. 북마클릿이 실제로 수집되게 (핵심)
- **진단**: 토큰 문제가 아니었습니다. 임의 쇼핑몰(Temu/아마존 등)의 **CSP(Content-Security-Policy)** 가 북마클릿의 `fetch` 요청을 차단해서, **토큰을 발급해도 수집이 안 되던 것**입니다.
- **수정**: 북마클릿을 `fetch` 대신 **"새 탭 네비게이션"** 방식으로 교체했습니다. 페이지 메타(제목/이미지/가격)를 쿼리로 담아 `window.open('/seller/collect/quick?…')` 로 새 탭을 엽니다.
  - 새 탭은 **로그인된 내 계정(세션)** 으로 열리므로 **토큰이 필요 없고**, 페이지 이동은 CSP/CORS에 막히지 않아 **실제로 수집됩니다.**
  - 신설 `GET /seller/collect/quick`: 세션 인증 → `_collect_real_draft`로 서버 수집(상세·번역) → 막히면 **북마클릿이 보낸 페이지 메타로 폴백 수집**(정직) → **수집 이력 저장** → 곧장 **편집 화면으로 이동**. 둘 다 불가하면 직접입력/확장 안내 페이지.
  - 구 토큰 fetch 북마클릿은 제거. (봇 차단이 강한 사이트는 크롬 확장 권장 — 안내 유지)

## 2. 아마존 국가 드롭다운
- '원클릭 수집 지원 마켓'의 아마존을 **국가 선택 드롭다운**으로: 미국/일본/독일/영국/프랑스/캐나다/이탈리아/스페인/호주/인도. 선택한 국가 사이트가 열립니다.

## 3. 수집 화면 파비콘 + 카피 갱신
- `/seller/collect` '인페이지 수집' 안내에 **고가네 퍼센티 파비콘** 노출. '보라색 수집 버튼' → **'고가네 퍼센티 아이콘 + 고가네 수집'** 으로 갱신(Phase 217 버튼과 일치) + **북마클릿(토큰 불필요)** 링크 추가.

## 테스트
- 전체 `python -m pytest tests/ -q`: **9969 passed, 2 skipped**.
- 신규: 북마클릿 quick 수집 성공/메타폴백/실패/잘못된URL + 토큰프리/아마존드롭다운 6종.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_