### PR TITLE
feat(collect): 북마클릿 이미지·상세·리뷰 수집(postMessage) + 번역선택 + 짧은라벨 + 일괄1000 (Phase 219)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,19 @@
 3. ✅ **수집 화면 파비콘 + 카피 갱신** (Phase 218): `/seller/collect` '인페이지 수집' 안내에 favicon.svg 노출 +
    '보라색 수집 버튼'→'고가네 퍼센티 아이콘+고가네 수집'으로 갱신, 북마클릿(토큰 불필요) 링크 추가.
 
+## 🔧 북마클릿 Percenty급 수집(이미지·상세·리뷰)+번역선택+일괄1000 (오너 지시 2026-06-17)
+1. ✅ **북마크 짧은 라벨** (Phase 219): 북마크바에 긴 js 코드 대신 한 단어 **‘고가네수집’**(드래그 링크 텍스트)로 표시.
+2. ✅ **클릭 시 편집페이지 새탭 X → ‘수집됨’만 표시** (Phase 219): 결과를 내 계정 **수집 이력**에서 확인.
+   `/collect/quick` 성공도 redirect 대신 confirmation 페이지(collect_quick_result ok=True).
+3. ✅ **이미지·상세설명·리뷰까지 수집** (Phase 219): 북마클릿을 **postMessage 방식**으로 — 새 탭
+   `/seller/collect/receiver`(로그인 세션 인증)를 열고 페이지 **HTML(800KB)·이미지·메타**를 postMessage 전달
+   → 같은 출처로 `POST /seller/collect/receive` 저장. 서버가 `UniversalScraper.parse_html`로 이미지/상세/옵션
+   추출 + `_extract_reviews`(JSON-LD review 우선 + 보수적 휴리스틱, 없으면 빈 리스트=정직) → 수집 이력 저장.
+   CSP가 fetch를 막는 사이트(Temu/아마존)도 동작(페이지 이동·postMessage는 CSP connect-src와 무관).
+4. ✅ **번역 사용자 선택** (Phase 219): 북마클릿 페이지에 ‘수집할 때 한국어 자동 번역’ 토글(기본 ON) → 북마클릿에
+   baked, `receive`가 `translate` 존중(off면 원문 유지·번역함수 미호출).
+5. ✅ **일괄수집 100→1000** (Phase 219): `/collect/bulk`(30→1000), `/api/v1/collect/bulk`(100→1000), UI 문구 갱신.
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/src/api/extension_api.py
+++ b/src/api/extension_api.py
@@ -284,8 +284,8 @@ def collect_bulk():
     if not urls or not isinstance(urls, list):
         return jsonify({"ok": False, "error": "urls 배열이 필요합니다."}), 400
 
-    # URL 최대 100개 제한
-    urls = [u.strip() for u in urls if isinstance(u, str) and u.strip()][:100]
+    # URL 최대 1000개 제한
+    urls = [u.strip() for u in urls if isinstance(u, str) and u.strip()][:1000]
     if not urls:
         return jsonify({"ok": False, "error": "유효한 URL이 없습니다."}), 400
 

--- a/src/seller_console/templates/bookmarklet.html
+++ b/src/seller_console/templates/bookmarklet.html
@@ -12,8 +12,9 @@
         <div class="card-header"><strong>🔧 설치 방법 (2단계)</strong></div>
         <div class="card-body">
           <ol class="mb-2">
-            <li>아래 <strong>고가네 퍼센티 아이콘</strong>을 마우스로 드래그해 브라우저 북마크바에 놓으세요.</li>
-            <li>상품 페이지에서 그 북마크를 클릭하면 <strong>새 탭이 열리며 자동 수집</strong>되고, 바로 편집 화면으로 이동합니다.</li>
+            <li>아래 <strong>‘고가네수집’</strong> 버튼을 마우스로 드래그해 브라우저 북마크바에 놓으세요.</li>
+            <li>상품 페이지에서 그 북마크를 클릭하면 <strong>이미지·상세설명·리뷰까지 자동 수집</strong>되고
+                <strong>‘수집 완료’</strong>만 표시됩니다. 결과는 <strong>내 계정의 ‘수집 이력’</strong>에서 확인·편집하세요.</li>
           </ol>
           <div class="alert alert-success small mb-0">
             ✅ <strong>토큰이 필요 없습니다.</strong> 새 탭이 고가네 퍼센티(로그인된 내 계정)로 열려 안전하게 수집됩니다.
@@ -22,21 +23,31 @@
         </div>
       </div>
 
+      <!-- 수집 시 번역 선택 -->
+      <div class="card mb-4">
+        <div class="card-header"><strong>🌐 번역 설정</strong></div>
+        <div class="card-body">
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" id="translateToggle" checked>
+            <label class="form-check-label" for="translateToggle">수집할 때 한국어로 자동 번역</label>
+          </div>
+          <div class="form-text">끄면 원문 그대로 수집됩니다(편집 화면에서 나중에 번역할 수도 있어요). 설정을 바꾸면 아래 북마클릿이 자동 갱신됩니다.</div>
+        </div>
+      </div>
+
       <!-- 북마클릿 버튼 -->
       <div class="card">
         <div class="card-header"><strong>📌 북마클릿 (드래그해서 북마크바에 추가)</strong></div>
         <div class="card-body text-center py-4">
-          <!-- 토큰 불필요: 새 탭으로 서버를 열어 로그인 세션으로 수집(CSP/CORS 우회). -->
+          <!-- 토큰 불필요: 새 탭(로그인 세션)으로 데이터를 보내 수집(CSP/CORS 우회).
+               북마크 이름은 짧은 단어 '고가네수집'으로 표시되도록 링크 텍스트를 지정. -->
           <a id="bookmarkletLink"
-             class="d-inline-flex align-items-center justify-content-center text-decoration-none"
-             style="cursor:grab;width:48px;height:48px;border-radius:12px;padding:4px;border:1px solid #dee2e6;background:#fff;"
-             title="이 아이콘을 북마크바로 드래그하세요 — 고가네 퍼센티 아이콘으로 표시됩니다"
-             aria-label="고가네 퍼센티 수집 북마클릿">
-            <img src="{{ url_for('seller_console.static', filename='favicon.svg') }}"
-                 alt="고가네퍼센티" style="width:100%;height:100%;border-radius:8px;" draggable="false">
-          </a>
-          <p class="mt-3 text-muted small mb-0">위 <strong>고가네 퍼센티 아이콘</strong>을 북마크바로 드래그하세요.</p>
-          <p class="text-muted small">북마크바에는 긴 이름 대신 <strong>고가네 퍼센티 파비콘</strong>으로 표시됩니다.</p>
+             class="d-inline-flex align-items-center gap-2 text-decoration-none px-3 py-2"
+             style="cursor:grab;border-radius:10px;border:1px solid #dee2e6;background:#fff;color:#0a1f5c;font-weight:700;"
+             title="이 버튼을 북마크바로 드래그하세요 — '고가네수집'으로 추가됩니다"
+             aria-label="고가네수집 북마클릿">고가네수집</a>
+          <p class="mt-3 text-muted small mb-0">위 <strong>고가네수집</strong> 버튼을 북마크바로 드래그하세요.</p>
+          <p class="text-muted small mb-0">북마크바에는 짧게 <strong>‘고가네수집’</strong> 한 단어로 표시됩니다.</p>
         </div>
       </div>
     </div>
@@ -55,11 +66,11 @@
         <div class="card-header"><strong>ℹ️ 동작 원리</strong></div>
         <div class="card-body small text-muted">
           <ol class="mb-2">
-            <li>상품 페이지의 메타(제목/이미지/가격)를 읽습니다.</li>
-            <li><strong>새 탭으로 고가네 퍼센티를 열어</strong> 상품 URL과 메타를 전달합니다.</li>
-            <li>서버가 상세·번역까지 수집해 <strong>수집 이력에 저장</strong>하고 편집 화면으로 이동합니다.</li>
+            <li>상품 페이지의 <strong>이미지·상세설명·리뷰·HTML</strong>을 읽습니다.</li>
+            <li><strong>새 탭으로 고가네 퍼센티(로그인된 내 계정)를 열어</strong> 그 데이터를 전달합니다.</li>
+            <li>서버가 이미지·상세·리뷰를 정리하고(선택 시 번역) <strong>내 수집 이력에 저장</strong>합니다 — ‘수집 완료’만 표시됩니다.</li>
           </ol>
-          <div>봇 차단이 강한 사이트는 <a href="/seller/markets/guide">크롬 확장(고가네 수집)</a>을 권장합니다.</div>
+          <div>봇 차단이 강한 사이트는 <a href="/seller/markets/guide">크롬 확장(고가네 수집)</a>도 사용할 수 있어요.</div>
         </div>
       </div>
     </div>
@@ -69,27 +80,39 @@
 <script>
 const SERVER_URL = "{{ request.host_url.rstrip('/') }}";
 
-// 토큰 불필요 — 새 탭으로 서버(/seller/collect/quick)를 열어 로그인 세션으로 수집.
-// 임의 쇼핑몰의 CSP가 fetch를 막아도 페이지 '이동'은 막히지 않아 실제로 수집된다.
-function buildBookmarkletCode() {
+// 토큰 불필요 — 새 탭(/seller/collect/receiver, 로그인 세션)을 열고 페이지 데이터(이미지/상세/HTML)를
+// postMessage로 전달해 수집한다. CSP가 fetch를 막는 사이트(Temu/아마존 등)에서도 동작하며,
+// 편집 페이지로 바로 가지 않고 '수집됨'만 표시한다(내 계정 수집 이력에서 확인).
+function buildBookmarkletCode(translate) {
   return "javascript:(function(){" +
     "var S='" + SERVER_URL + "';" +
     "function M(p){var e=document.querySelector('meta[property=\"'+p+'\"],meta[name=\"'+p+'\"]');return e?(e.content||''):''}" +
-    "var q=new URLSearchParams();" +
-    "q.set('u',location.href);" +
-    "q.set('t',(M('og:title')||document.title||'').slice(0,300));" +
-    "q.set('img',M('og:image')||M('og:image:url')||'');" +
-    "q.set('p',M('product:price:amount')||'');" +
-    "q.set('c',M('product:price:currency')||'');" +
-    "window.open(S+'/seller/collect/quick?'+q.toString(),'_blank');" +
+    "var imgs=[];if(M('og:image'))imgs.push(M('og:image'));" +
+    "try{[].forEach.call(document.images||[],function(im){if(im&&im.src&&(im.naturalWidth||0)>=200)imgs.push(im.src)})}catch(e){}" +
+    "var data={url:location.href," +
+    "title:(M('og:title')||document.title||'').slice(0,300)," +
+    "price:M('product:price:amount')||''," +
+    "currency:M('product:price:currency')||''," +
+    "description:M('og:description')||M('description')||''," +
+    "images:imgs.slice(0,30)," +
+    "html:(document.documentElement?document.documentElement.outerHTML:'').slice(0,800000)," +
+    "translate:" + (translate ? "true" : "false") + "};" +
+    "var w=window.open(S+'/seller/collect/receiver','_blank');" +
+    "if(!w){alert('팝업이 차단되었습니다. 이 사이트의 팝업을 허용해주세요.');return;}" +
+    "function H(e){if(e.source===w&&e.data&&e.data.kgp==='ready'){w.postMessage({kgp:'collect',data:data},S);window.removeEventListener('message',H);}}" +
+    "window.addEventListener('message',H);" +
     "})();";
 }
 
-(function initBookmarklet() {
-  const code = buildBookmarkletCode();
+function refreshBookmarklet() {
+  const translate = document.getElementById('translateToggle').checked;
+  const code = buildBookmarkletCode(translate);
   document.getElementById('bookmarkletLink').setAttribute('href', code);
   document.getElementById('bookmarkletCode').textContent = code;
-})();
+}
+
+document.getElementById('translateToggle').addEventListener('change', refreshBookmarklet);
+refreshBookmarklet();
 
 function copyCode() {
   const code = document.getElementById('bookmarkletCode').textContent;

--- a/src/seller_console/templates/collect_receiver.html
+++ b/src/seller_console/templates/collect_receiver.html
@@ -1,0 +1,86 @@
+{% extends "_base.html" %}
+{% block title %}수집 중…{% endblock %}
+{% block content %}
+<div class="container-fluid py-5" style="max-width:560px">
+  <div class="card console-card">
+    <div class="card-body text-center py-5" id="recvBox">
+      <div class="spinner-border text-primary mb-3" role="status"></div>
+      <h1 class="h5 mb-1">상품을 수집하고 있어요…</h1>
+      <p class="text-muted small mb-0">잠시만 기다려주세요. 이미지·상세설명·리뷰를 가져오는 중입니다.</p>
+    </div>
+  </div>
+</div>
+
+<script>
+const SERVER_ORIGIN = window.location.origin;
+const box = document.getElementById('recvBox');
+let saved = false;
+
+function render(html) { box.innerHTML = html; }
+
+function showSuccess(d) {
+  saved = true;
+  const meta = [];
+  if (d.image_count) meta.push('이미지 ' + d.image_count + '장');
+  if (d.review_count) meta.push('리뷰 ' + d.review_count + '개');
+  meta.push(d.translated ? '한국어 번역 포함' : '원문');
+  render(
+    '<div class="display-6 mb-2">✅</div>' +
+    '<h1 class="h5 mb-1">수집 완료!</h1>' +
+    '<div class="fw-semibold text-truncate mb-1">' + (d.title || '') + '</div>' +
+    '<div class="small text-muted mb-3">' + meta.join(' · ') + '</div>' +
+    '<div class="small text-muted mb-3">내 계정의 <strong>수집 이력</strong>에서 확인·편집할 수 있어요.</div>' +
+    '<div class="d-flex gap-2 justify-content-center flex-wrap">' +
+      '<a class="btn btn-primary btn-sm" href="/seller/collect/history">수집 이력에서 보기</a>' +
+      '<a class="btn btn-outline-secondary btn-sm" href="' + (d.edit_url || '#') + '">바로 편집</a>' +
+      '<button class="btn btn-outline-secondary btn-sm" onclick="window.close()">창 닫기</button>' +
+    '</div>'
+  );
+}
+
+function showError(msg) {
+  render(
+    '<div class="display-6 mb-2">⚠️</div>' +
+    '<h1 class="h5 mb-2">자동 수집이 어려운 페이지예요</h1>' +
+    '<p class="text-muted small mb-3">' + (msg || '상품 정보를 읽지 못했습니다.') + '</p>' +
+    '<div class="d-flex gap-2 justify-content-center flex-wrap">' +
+      '<a class="btn btn-outline-secondary btn-sm" href="/seller/collect">직접 입력으로 등록</a>' +
+      '<button class="btn btn-outline-secondary btn-sm" onclick="window.close()">창 닫기</button>' +
+    '</div>'
+  );
+}
+
+async function save(data) {
+  if (saved) return;
+  try {
+    const resp = await fetch('/seller/collect/receive', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(data)
+    });
+    const d = await resp.json();
+    if (d.ok) showSuccess(d); else showError(d.error);
+  } catch (e) {
+    showError('저장 중 오류가 발생했습니다: ' + e.message);
+  }
+}
+
+// 북마클릿(opener)에서 보낸 데이터 수신
+window.addEventListener('message', (e) => {
+  const m = e.data;
+  if (m && m.kgp === 'collect' && m.data) save(m.data);
+});
+
+// opener에게 '준비됨' 신호 → 데이터 전송 트리거
+if (window.opener) {
+  try { window.opener.postMessage({kgp: 'ready'}, '*'); } catch (err) {}
+}
+
+// 8초 내 데이터 안 오면 안내(팝업 직접 열림 등)
+setTimeout(() => {
+  if (!saved && box.querySelector('.spinner-border')) {
+    showError('상품 페이지에서 북마클릿(고가네수집)을 눌러 실행해주세요.');
+  }
+}, 8000);
+</script>
+{% endblock %}

--- a/src/seller_console/templates/manual_collect.html
+++ b/src/seller_console/templates/manual_collect.html
@@ -81,7 +81,7 @@
   <div class="card-body">
     <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
       <label for="bulkUrls" class="form-label fw-semibold mb-0">📥 여러 URL 한 번에 수집</label>
-      <span class="small text-muted">한 줄에 하나씩 · 최대 30개</span>
+      <span class="small text-muted">한 줄에 하나씩 · 최대 1000개</span>
     </div>
     <textarea id="bulkUrls" class="form-control" rows="4"
       placeholder="https://www.amazon.com/dp/...&#10;https://item.taobao.com/...&#10;https://detail.1688.com/..."></textarea>

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1214,8 +1214,198 @@ def collect_quick():
         )
 
     _register_discovery_candidate_from_collection(url)
-    # 편집 페이지로 바로 이동(확인·수정·등록)
-    return redirect(f"/seller/collect/preview/{item_id}?from=bookmarklet&meta={'1' if used_meta else '0'}")
+    # 편집 페이지로 바로 보내지 않고 '수집됨'만 표시 — 내 계정의 수집 이력에서 확인.
+    return render_template(
+        "collect_quick_result.html", ok=True,
+        message="수집 이력에 저장했어요. 내 계정의 ‘수집 이력’에서 확인·편집할 수 있습니다.",
+        url=url, item_id=item_id,
+    )
+
+
+def _extract_reviews(html: str, limit: int = 20) -> list[dict]:
+    """페이지 HTML에서 리뷰를 best-effort 추출(JSON-LD 우선 + 보수적 휴리스틱).
+
+    추출 못 하면 빈 리스트(정직 — 가짜 리뷰 생성 금지).
+    """
+    reviews: list[dict] = []
+    if not html:
+        return reviews
+    try:
+        from bs4 import BeautifulSoup
+        import json as _json
+        soup = BeautifulSoup(html, "html.parser")
+
+        # 1) JSON-LD review (가장 신뢰도 높음)
+        for s in soup.find_all("script", type="application/ld+json"):
+            try:
+                data = _json.loads(s.string or s.get_text() or "")
+            except Exception:
+                continue
+            for obj in (data if isinstance(data, list) else [data]):
+                if not isinstance(obj, dict):
+                    continue
+                revs = obj.get("review") or obj.get("reviews")
+                if isinstance(revs, dict):
+                    revs = [revs]
+                if not isinstance(revs, list):
+                    continue
+                for r in revs:
+                    if not isinstance(r, dict):
+                        continue
+                    body = str(r.get("reviewBody") or r.get("description") or "").strip()
+                    if not body:
+                        continue
+                    rating = None
+                    rr = r.get("reviewRating")
+                    if isinstance(rr, dict):
+                        rating = rr.get("ratingValue")
+                    author = r.get("author")
+                    if isinstance(author, dict):
+                        author = author.get("name")
+                    reviews.append({"body": body[:500], "rating": rating,
+                                    "author": str(author or "")[:60]})
+
+        # 2) 보수적 휴리스틱(JSON-LD가 적을 때만): class에 review가 포함된 짧은 텍스트 블록
+        if len(reviews) < 3:
+            for el in soup.find_all(attrs={"class": True}):
+                cls = " ".join(el.get("class") or []).lower()
+                if "review" not in cls or "reviews" == cls:
+                    continue
+                txt = el.get_text(" ", strip=True)
+                if 15 <= len(txt) <= 400:
+                    reviews.append({"body": txt[:400], "rating": None, "author": ""})
+                if len(reviews) >= limit:
+                    break
+    except Exception as exc:
+        logger.debug("리뷰 추출 실패: %s", exc)
+
+    # 중복 제거
+    seen, out = set(), []
+    for r in reviews:
+        b = r.get("body", "")
+        if not b or b in seen:
+            continue
+        seen.add(b)
+        out.append(r)
+        if len(out) >= limit:
+            break
+    return out
+
+
+@bp.get("/collect/receiver")
+def collect_receiver():
+    """북마클릿 postMessage 수신 페이지 (Phase 219).
+
+    북마클릿이 새 탭으로 이 페이지를 열고(로그인 세션 → 인증), 페이지 HTML·이미지·메타를
+    postMessage로 전달한다. 이 페이지가 같은 출처로 `/seller/collect/receive`에 저장 요청 →
+    '수집됨'만 표시하고 편집 페이지로 이동하지 않는다(내 계정 수집 이력에서 확인).
+    """
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.full_path))
+    return render_template("collect_receiver.html")
+
+
+@bp.post("/collect/receive")
+def collect_receive():
+    """북마클릿이 보낸 페이지 데이터(HTML 포함)를 받아 이미지·상세·리뷰까지 수집·저장.
+
+    Request JSON: {url, title, price, currency, description, images[], html, translate}
+    Response: {ok, id, history_url}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    data = request.get_json(force=True, silent=True) or {}
+    url = (data.get("url") or "").strip()
+    if not url.startswith(("http://", "https://")):
+        return jsonify({"ok": False, "error": "올바른 상품 URL이 아닙니다."}), 400
+
+    translate = data.get("translate", True) is not False
+    html = data.get("html") if isinstance(data.get("html"), str) else ""
+    client_images = [str(i).strip() for i in (data.get("images") or []) if str(i or "").strip()]
+
+    # 1) 페이지 HTML 서버 파싱(이미지/상세/옵션) — 봇 차단 사이트도 브라우저 DOM 기반으로 수집
+    draft = None
+    if html:
+        try:
+            from src.collectors.universal_scraper import UniversalScraper
+            scraped = UniversalScraper().parse_html(html, url)
+            draft = _scraped_to_draft(scraped)
+        except Exception as exc:
+            logger.warning("receiver HTML 파싱 실패: %s", exc)
+
+    if draft is None:
+        draft = {
+            "url": url, "source": "bookmarklet_meta", "title": "", "title_en": "",
+            "title_ko": "", "description": "", "images": [], "price": None,
+            "price_original": 0.0, "currency": "USD", "options": [],
+        }
+
+    # 2) 클라이언트가 보낸 메타/이미지로 빈 값 보강(사용자가 본 화면 우선)
+    if not (draft.get("title") or "").strip() and data.get("title"):
+        draft["title"] = draft["title_en"] = draft["title_ko"] = str(data["title"])[:300]
+    if not (draft.get("description") or "").strip() and data.get("description"):
+        draft["description"] = str(data["description"])
+    if data.get("price") and not draft.get("price"):
+        draft["price"] = str(data["price"])
+        try:
+            draft["price_original"] = float(str(data["price"]).replace(",", ""))
+        except (TypeError, ValueError):
+            pass
+    if data.get("currency"):
+        draft["currency"] = str(data["currency"]) or draft.get("currency") or "USD"
+    # 이미지 병합(서버 파싱 + 클라이언트 DOM 이미지), 중복 제거·상한 30
+    merged_imgs, seen = [], set()
+    for src in list(draft.get("images") or []) + client_images:
+        s = str(src or "").strip()
+        if s and s not in seen and s.startswith(("http://", "https://")):
+            seen.add(s)
+            merged_imgs.append(s)
+    draft["images"] = merged_imgs[:30]
+
+    # 3) 리뷰 추출(best-effort)
+    reviews = _extract_reviews(html) if html else []
+    if reviews:
+        draft["reviews"] = reviews
+
+    # 의미있는 수집인지 확인
+    if not (draft.get("title") or draft.get("images")):
+        return jsonify({"ok": False, "error": "상품 정보를 읽지 못했습니다. 상품 상세 페이지인지 확인하세요."}), 200
+
+    draft.setdefault("title_ko", draft.get("title") or "")
+    if translate:
+        try:
+            draft = _translate_draft(draft)
+        except Exception as exc:
+            logger.warning("receiver 번역 실패(원문 유지): %s", exc)
+
+    images = draft.get("images") or []
+    title = draft.get("title_ko") or draft.get("title") or "(제목 없음)"
+    try:
+        from . import collect_history_store
+        item_id = collect_history_store.append(
+            source="bookmarklet",
+            url=url,
+            title=title,
+            image=images[0] if images else "",
+            price=str(draft.get("price_original") or draft.get("price") or ""),
+            currency=draft.get("currency") or "",
+            extra=draft,
+            seller_id=_seller_id(),
+        )
+    except Exception as exc:
+        logger.warning("receiver 수집 이력 저장 실패: %s", exc)
+        return jsonify({"ok": False, "error": "수집은 됐지만 이력 저장에 실패했습니다."}), 200
+
+    _register_discovery_candidate_from_collection(url)
+    return jsonify({
+        "ok": True, "id": item_id,
+        "title": title,
+        "image_count": len(images),
+        "review_count": len(reviews),
+        "translated": translate,
+        "history_url": "/seller/collect/history",
+        "edit_url": f"/seller/collect/preview/{item_id}",
+    })
 
 
 @bp.post("/collect/upload")
@@ -1439,7 +1629,7 @@ def collect_bulk():
         urls = []
     # 중복 제거(순서 유지) + 상한
     seen = set()
-    urls = [u for u in urls if not (u in seen or seen.add(u))][:30]
+    urls = [u for u in urls if not (u in seen or seen.add(u))][:1000]
     if not urls:
         return jsonify({"ok": False, "error": "수집할 URL을 한 줄에 하나씩 입력하세요."}), 400
 

--- a/tests/test_bulk_collect.py
+++ b/tests/test_bulk_collect.py
@@ -28,11 +28,11 @@ def client(app):
 
 
 class TestBulkCollect:
-    def test_bulk_max_100_urls(self, client):
-        """URL 100개 초과 시 100개로 잘림."""
+    def test_bulk_max_1000_urls(self, client):
+        """URL 1000개 초과 시 1000개로 잘림(퍼센티 100 → 우리 1000)."""
         with patch("src.api.extension_api._require_token") as mock_auth:
             mock_auth.return_value = {"user_id": "u", "scopes": ["collect.write"]}
-            urls = [f"https://example.com/product/{i}" for i in range(150)]
+            urls = [f"https://example.com/product/{i}" for i in range(1100)]
             resp = client.post(
                 "/api/v1/collect/bulk",
                 data=json.dumps({"urls": urls}),
@@ -40,7 +40,7 @@ class TestBulkCollect:
                 headers={"Authorization": "Bearer tok_test"},
             )
         data = resp.get_json()
-        assert data["total"] == 100
+        assert data["total"] == 1000
 
     def test_bulk_job_polling(self, client):
         """잡 ID로 진행률 폴링."""

--- a/tests/test_collect_quick_bookmarklet.py
+++ b/tests/test_collect_quick_bookmarklet.py
@@ -25,12 +25,13 @@ def _draft(**over):
     return d
 
 
-def test_quick_collect_saves_and_redirects_to_edit(client):
+def test_quick_collect_saves_and_shows_confirmation(client):
+    """편집페이지로 redirect하지 않고 '수집됨' 확인만 표시(내 계정에서 확인)."""
     with patch("src.seller_console.views._collect_real_draft", return_value=_draft()), \
          patch("src.seller_console.collect_history_store.append", return_value="qid1"):
         r = client.get("/seller/collect/quick?u=https://shop.example/p/1")
-    assert r.status_code == 302
-    assert "/seller/collect/preview/qid1" in r.headers["Location"]
+    assert r.status_code == 200
+    assert "수집 완료" in r.get_data(as_text=True)
 
 
 def test_quick_collect_meta_fallback_when_server_blocked(client):
@@ -38,8 +39,8 @@ def test_quick_collect_meta_fallback_when_server_blocked(client):
     with patch("src.seller_console.views._collect_real_draft", return_value=None), \
          patch("src.seller_console.collect_history_store.append", return_value="qid2") as ap:
         r = client.get("/seller/collect/quick?u=https://shop.example/p/2&t=가방&img=https://i/x.jpg&p=99&c=USD")
-    assert r.status_code == 302
-    assert "/seller/collect/preview/qid2" in r.headers["Location"]
+    assert r.status_code == 200
+    assert "수집 완료" in r.get_data(as_text=True)
     # append가 메타 기반으로 호출됨
     assert ap.call_count == 1
     assert ap.call_args.kwargs["title"] == "가방"
@@ -60,9 +61,10 @@ def test_quick_collect_rejects_bad_url(client):
 
 def test_bookmarklet_page_is_token_free(client):
     html = client.get("/seller/bookmarklet").get_data(as_text=True)
-    assert "/seller/collect/quick" in html
-    assert "Bearer" not in html          # 토큰 fetch 방식 제거됨
+    assert "/seller/collect/receiver" in html   # postMessage 수신 페이지로 전송
+    assert "Bearer" not in html                 # 토큰 fetch 방식 제거됨
     assert "토큰이 필요 없습니다" in html
+    assert "고가네수집" in html                  # 짧은 단어 라벨
 
 
 def test_collect_page_amazon_dropdown_and_favicon(client):

--- a/tests/test_collect_receiver.py
+++ b/tests/test_collect_receiver.py
@@ -1,0 +1,107 @@
+"""tests/test_collect_receiver.py — 북마클릿 postMessage 수집(이미지/상세/리뷰 + 번역선택)."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+_HTML = """<html><head>
+<meta property="og:title" content="가죽 가방">
+<meta property="og:image" content="https://img/og.jpg">
+<script type="application/ld+json">{"@type":"Product","review":[{"@type":"Review","reviewBody":"정말 좋아요 튼튼합니다","reviewRating":{"ratingValue":5},"author":{"name":"홍길동"}}]}</script>
+</head><body></body></html>"""
+
+
+def test_receiver_page_renders(client):
+    r = client.get("/seller/collect/receiver")
+    assert r.status_code == 200
+    assert "kgp" in r.get_data(as_text=True)  # postMessage handshake JS
+
+
+def test_receive_collects_images_and_reviews(client):
+    with patch("src.seller_console.views._translate_draft", side_effect=lambda d: d), \
+         patch("src.seller_console.collect_history_store.append", return_value="rid1") as ap:
+        r = client.post("/seller/collect/receive", json={
+            "url": "https://shop.example/p/1", "title": "가죽 가방",
+            "images": ["https://img/a.jpg", "https://img/og.jpg"],  # og.jpg 중복 → dedupe
+            "html": _HTML, "translate": True,
+        })
+    d = r.get_json()
+    assert d["ok"] is True and d["id"] == "rid1"
+    assert d["image_count"] >= 2            # og + client, 중복 제거
+    assert d["review_count"] == 1           # JSON-LD 리뷰 1개
+    # 저장된 extra에 reviews 포함
+    extra = ap.call_args.kwargs["extra"]
+    assert extra["reviews"][0]["rating"] == 5
+    assert ap.call_args.kwargs["source"] == "bookmarklet"
+
+
+def test_receive_translate_false_keeps_original(client):
+    """번역 off 선택 시 번역 함수 호출 안 함(원문 유지)."""
+    with patch("src.seller_console.views._translate_draft") as tr, \
+         patch("src.seller_console.collect_history_store.append", return_value="rid2"):
+        r = client.post("/seller/collect/receive", json={
+            "url": "https://shop.example/p/2", "title": "셔츠", "html": "", "translate": False,
+        })
+    assert r.get_json()["ok"] is True
+    assert r.get_json()["translated"] is False
+    tr.assert_not_called()
+
+
+def test_receive_rejects_bad_url(client):
+    r = client.post("/seller/collect/receive", json={"url": "nope"})
+    assert r.status_code == 400
+
+
+def test_receive_honest_when_no_data(client):
+    """제목·이미지 둘 다 없으면 정직하게 실패(가짜 저장 금지)."""
+    with patch("src.seller_console.collect_history_store.append") as ap:
+        r = client.post("/seller/collect/receive", json={
+            "url": "https://shop.example/p/3", "html": "", "title": "", "images": [],
+        })
+    assert r.get_json()["ok"] is False
+    ap.assert_not_called()
+
+
+def test_extract_reviews_jsonld():
+    from src.seller_console.views import _extract_reviews
+    revs = _extract_reviews(_HTML)
+    assert len(revs) == 1
+    assert "좋아요" in revs[0]["body"]
+
+
+def test_extract_reviews_empty_on_no_reviews():
+    from src.seller_console.views import _extract_reviews
+    assert _extract_reviews("<html><body>no reviews here</body></html>") == []
+
+
+def test_quick_now_shows_confirmation_not_redirect(client):
+    """북마클릿 quick은 편집페이지로 redirect하지 않고 '수집됨' 확인만 표시."""
+    draft = {"title_ko": "t", "title": "t", "images": ["https://i/1.jpg"],
+             "price_original": "10", "currency": "USD", "source": "x"}
+    with patch("src.seller_console.views._collect_real_draft", return_value=draft), \
+         patch("src.seller_console.collect_history_store.append", return_value="qid"):
+        r = client.get("/seller/collect/quick?u=https://shop.example/p/9", follow_redirects=False)
+    assert r.status_code == 200          # redirect(302) 아님
+    assert "수집 완료" in r.get_data(as_text=True)
+
+
+def test_bulk_limit_raised_to_1000(client):
+    """일괄 수집 상한이 1000으로 상향."""
+    urls = "\n".join(f"https://x.com/p/{i}" for i in range(1100))
+    with patch("src.seller_console.views._collect_real_draft", return_value=None):
+        r = client.post("/seller/collect/bulk", json={"urls": urls})
+    assert r.get_json()["total"] == 1000


### PR DESCRIPTION
오너 지시(Temu/Shopify 화면): 북마크 라벨 짧게 · 클릭 시 편집페이지 말고 '수집됨'만 표시(계정에서 확인) · 이미지·상세설명·리뷰까지 수집 · 번역 사용자 선택 · 일괄수집 100→1000.

## 1. 북마크 라벨 = 한 단어 '고가네수집'
- 북마크바에 긴 `javascript:` 코드가 뜨던 문제 → 드래그 링크 텍스트를 **‘고가네수집’** 한 단어로. 북마크 이름이 짧게 표시됩니다.

## 2. 클릭 시 편집페이지 새탭 X → '수집됨'만 표시
- 결과는 **내 계정의 ‘수집 이력’** 에서 확인·편집(Percenty와 동일 UX). `/collect/quick`도 redirect 대신 확인 페이지.

## 3. 이미지·상세설명·리뷰까지 수집 (핵심)
- 북마클릿을 **postMessage 방식**으로 전환: 새 탭 `/seller/collect/receiver`(로그인 세션 인증)를 열고, 페이지 **HTML(최대 800KB)·이미지·메타**를 `postMessage`로 전달 → 같은 출처에서 `POST /seller/collect/receive`로 저장.
- 서버가 `UniversalScraper.parse_html`로 **이미지/상세/옵션** 추출 + `_extract_reviews`로 **리뷰**(JSON-LD review 우선 + 보수적 휴리스틱; 없으면 빈 리스트=정직, 가짜 리뷰 생성 안 함).
- **CSP가 `fetch`를 막는 사이트(Temu/아마존)도 동작** — 페이지 이동·postMessage는 CSP `connect-src`와 무관.

## 4. 번역 사용자 선택
- 북마클릿 페이지에 **‘수집할 때 한국어 자동 번역’ 토글**(기본 ON) → 북마클릿에 baked. `receive`가 `translate`를 존중(끄면 원문 유지·번역함수 미호출).

## 5. 일괄수집 100 → 1000
- `/collect/bulk`(30→1000), `/api/v1/collect/bulk`(100→1000), UI 문구 갱신. (퍼센티 100 대비 우리 1000)

## 테스트
- 전체 `python -m pytest tests/ -q`: **9978 passed, 2 skipped**.
- 신규/갱신: receiver 수집(이미지/리뷰), 번역 off, 잘못된 URL, 무데이터 정직실패, 리뷰추출, quick 확인전환, 일괄1000 등. 북마클릿 생성 JS `node --check` 통과.

### 오너 액션
- 북마클릿을 **다시 설치**(‘고가네수집’ 버튼을 북마크바로 다시 드래그)해야 새 동작이 적용됩니다. 클릭 시 **팝업 허용**이 필요할 수 있어요(새 탭 사용).

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_