### PR TITLE
fix(collect): 편집 썸네일 · 오류창 정리 · 파비콘 · 이미지필터 · 로그인튕김 방지 (Phase 220)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,21 @@
    baked, `receive`가 `translate` 존중(off면 원문 유지·번역함수 미호출).
 5. ✅ **일괄수집 100→1000** (Phase 219): `/collect/bulk`(30→1000), `/api/v1/collect/bulk`(100→1000), UI 문구 갱신.
 
+## 🔧 사람친화 수정: 편집 썸네일·오류창·파비콘·이미지필터·로그인 (오너 지시 2026-06-17, 편집/업로드 스샷)
+1. ✅ **편집 페이지 이미지 썸네일** (Phase 220): `collect_preview.html` 이미지 URL 행마다 46px **썸네일**(클릭 시 원본)
+   표시 — URL만 보이던 걸 사람이 이미지로 바로 확인(대표 선택 쉬움). `addImageRow` 썸네일+동기화.
+2. ✅ **마켓 등록 오류창 정리** (Phase 220): WC 406 등 긴 오류 URL(consumer_secret 포함)이 모달 밖으로 튀어나오던 문제
+   → `#uploadResults` word-break/overflow-wrap + `modal-dialog-scrollable`로 박스 안에서 줄바꿈.
+3. ✅ **북마클릿 파비콘 표시** (Phase 220): 북마크바에 글로브 파비콘만 작게(텍스트 라벨 제거). (hover 시 js URL 노출은
+   북마클릿 본질상 불가피 — 외부 스크립트 로딩은 CSP에 막혀 인라인 유지.)
+4. ✅ **북마클릿 이미지 필터** (Phase 220): `document.images`에서 logo/sprite/icon/avatar/banner/placeholder/300px미만
+   제외(`G()`) → 배너·로고 대신 상품 이미지 위주 수집.
+5. ✅ **북마클릿 로그인 튕김 방지** (Phase 220): `/seller/collect/receiver` 페이지 렌더의 인증 게이트 제거(저장 POST만 인증)
+   → 새 창이 로그인 폼으로 점프하지 않고, 미로그인 시 receiver 안에서 친절한 '로그인' 안내(401 처리).
+- **남은 후속(이 지시)**: ① **리스팅/검색 페이지에서 여러 상품 한 번에·취사선택 수집** — 북마클릿/페이지 한계로
+  **크롬 확장**(상품카드별 버튼 주입)이 정석. 다음 단계로 확장에 구현 예정. ② Temu 등 SPA의 가격/옵션/리뷰는
+  표준 메타(JSON-LD/OG)가 빈약해 추출이 제한적 — 사이트별 파서 보강 필요(별도 작업).
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/src/seller_console/templates/bookmarklet.html
+++ b/src/seller_console/templates/bookmarklet.html
@@ -40,14 +40,17 @@
         <div class="card-header"><strong>📌 북마클릿 (드래그해서 북마크바에 추가)</strong></div>
         <div class="card-body text-center py-4">
           <!-- 토큰 불필요: 새 탭(로그인 세션)으로 데이터를 보내 수집(CSP/CORS 우회).
-               북마크 이름은 짧은 단어 '고가네수집'으로 표시되도록 링크 텍스트를 지정. -->
+               북마크바에는 고가네 퍼센티 파비콘(글로브)만 작게 표시된다. -->
           <a id="bookmarkletLink"
-             class="d-inline-flex align-items-center gap-2 text-decoration-none px-3 py-2"
-             style="cursor:grab;border-radius:10px;border:1px solid #dee2e6;background:#fff;color:#0a1f5c;font-weight:700;"
-             title="이 버튼을 북마크바로 드래그하세요 — '고가네수집'으로 추가됩니다"
-             aria-label="고가네수집 북마클릿">고가네수집</a>
-          <p class="mt-3 text-muted small mb-0">위 <strong>고가네수집</strong> 버튼을 북마크바로 드래그하세요.</p>
-          <p class="text-muted small mb-0">북마크바에는 짧게 <strong>‘고가네수집’</strong> 한 단어로 표시됩니다.</p>
+             class="d-inline-flex align-items-center justify-content-center text-decoration-none"
+             style="cursor:grab;width:48px;height:48px;border-radius:12px;padding:4px;border:1px solid #dee2e6;background:#fff;"
+             title="이 아이콘을 북마크바로 드래그하세요 — 고가네 퍼센티 아이콘으로 표시됩니다"
+             aria-label="고가네수집 북마클릿">
+            <img src="{{ url_for('seller_console.static', filename='favicon.svg') }}"
+                 alt="고가네수집" style="width:100%;height:100%;border-radius:8px;" draggable="false">
+          </a>
+          <p class="mt-3 text-muted small mb-0">위 <strong>고가네 퍼센티 아이콘</strong>을 북마크바로 드래그하세요.</p>
+          <p class="text-muted small mb-0">북마크바에는 <strong>파비콘(아이콘)</strong>만 작게 표시됩니다.</p>
         </div>
       </div>
     </div>
@@ -87,8 +90,9 @@ function buildBookmarkletCode(translate) {
   return "javascript:(function(){" +
     "var S='" + SERVER_URL + "';" +
     "function M(p){var e=document.querySelector('meta[property=\"'+p+'\"],meta[name=\"'+p+'\"]');return e?(e.content||''):''}" +
-    "var imgs=[];if(M('og:image'))imgs.push(M('og:image'));" +
-    "try{[].forEach.call(document.images||[],function(im){if(im&&im.src&&(im.naturalWidth||0)>=200)imgs.push(im.src)})}catch(e){}" +
+    "function G(s){if(!s||s.indexOf('data:')===0)return false;if(/(logo|sprite|icon|avatar|placeholder|loading|blank|pixel|banner|thumb_)/i.test(s))return false;return true;}" +
+    "var imgs=[];var og=M('og:image');if(G(og))imgs.push(og);" +
+    "try{[].forEach.call(document.images||[],function(im){if(im&&im.src&&G(im.src)&&(im.naturalWidth||0)>=300&&(im.naturalHeight||0)>=300)imgs.push(im.src)})}catch(e){}" +
     "var data={url:location.href," +
     "title:(M('og:title')||document.title||'').slice(0,300)," +
     "price:M('product:price:amount')||''," +

--- a/src/seller_console/templates/collect_preview.html
+++ b/src/seller_console/templates/collect_preview.html
@@ -130,7 +130,14 @@
 
 <!-- ── 마켓 등록 모달 (Phase 190) ───────────────────────────────── -->
 <div class="modal fade" id="uploadModal" tabindex="-1" aria-labelledby="uploadModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
+  <style>
+    /* 긴 오류 URL/메시지가 창 밖으로 튀어나오지 않도록 박스 안에서 줄바꿈 */
+    #uploadResults .list-group-item { overflow:hidden; }
+    #uploadResults .umsg, #uploadResults .list-group-item .small, #uploadResults .list-group-item div {
+      word-break:break-all; overflow-wrap:anywhere; white-space:normal;
+    }
+  </style>
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title fw-bold" id="uploadModalLabel">📤 마켓 등록</h5>
@@ -270,11 +277,22 @@ function _initOptions() {
 function addImageRow(url) {
   const wrap = document.getElementById('imageRows');
   const row = document.createElement('div');
-  row.className = 'input-group input-group-sm img-row';
+  row.className = 'd-flex align-items-center gap-1 img-row';
   row.innerHTML = `
-    <button class="btn btn-outline-warning btn-make-primary" type="button" title="대표 이미지로 지정">⭐</button>
-    <input type="url" class="form-control img-url" placeholder="https://..." value="${escapeHtml(url || '')}">
-    <button class="btn btn-outline-danger btn-del" type="button" title="삭제">✕</button>`;
+    <button class="btn btn-outline-warning btn-sm btn-make-primary flex-shrink-0" type="button" title="대표 이미지로 지정">⭐</button>
+    <img class="img-thumb flex-shrink-0 rounded border" alt="" style="width:46px;height:46px;object-fit:cover;background:#f1f3f5;cursor:zoom-in"
+         title="클릭하면 원본 보기" onerror="this.style.visibility='hidden'">
+    <input type="url" class="form-control form-control-sm img-url" placeholder="https://..." value="${escapeHtml(url || '')}">
+    <button class="btn btn-outline-danger btn-sm btn-del flex-shrink-0" type="button" title="삭제">✕</button>`;
+  const input = row.querySelector('.img-url');
+  const thumb = row.querySelector('.img-thumb');
+  function syncThumb() {
+    const v = (input.value || '').trim();
+    if (v) { thumb.src = v; thumb.style.visibility = 'visible'; }
+    else { thumb.removeAttribute('src'); thumb.style.visibility = 'hidden'; }
+  }
+  syncThumb();
+  thumb.addEventListener('click', () => { const v = (input.value || '').trim(); if (v) window.open(v, '_blank'); });
   row.querySelector('.btn-make-primary').addEventListener('click', () => {
     wrap.insertBefore(row, wrap.firstChild);  // 맨 위로 = 대표
     refreshPrimaryImage();
@@ -283,7 +301,7 @@ function addImageRow(url) {
   row.querySelector('.btn-del').addEventListener('click', () => {
     row.remove(); refreshPrimaryImage(); refreshImageBadges();
   });
-  row.querySelector('input').addEventListener('input', refreshPrimaryImage);
+  input.addEventListener('input', () => { syncThumb(); refreshPrimaryImage(); });
   wrap.appendChild(row);
   refreshImageBadges();
 }

--- a/src/seller_console/templates/collect_receiver.html
+++ b/src/seller_console/templates/collect_receiver.html
@@ -50,6 +50,19 @@ function showError(msg) {
   );
 }
 
+function showLogin() {
+  // 로그인 페이지로 튕기지 않고, 이 창 안에서 친절히 로그인 안내
+  render(
+    '<div class="display-6 mb-2">🔒</div>' +
+    '<h1 class="h5 mb-2">고가네 퍼센티 로그인이 필요해요</h1>' +
+    '<p class="text-muted small mb-3">로그인 후 다시 상품 페이지에서 북마클릿을 누르면 바로 수집됩니다.</p>' +
+    '<div class="d-flex gap-2 justify-content-center flex-wrap">' +
+      '<a class="btn btn-primary btn-sm" href="/auth/login?next=/seller/collect/history">로그인하기</a>' +
+      '<button class="btn btn-outline-secondary btn-sm" onclick="window.close()">창 닫기</button>' +
+    '</div>'
+  );
+}
+
 async function save(data) {
   if (saved) return;
   try {
@@ -58,6 +71,7 @@ async function save(data) {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(data)
     });
+    if (resp.status === 401) { showLogin(); return; }
     const d = await resp.json();
     if (d.ok) showSuccess(d); else showError(d.error);
   } catch (e) {

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1296,13 +1296,14 @@ def _extract_reviews(html: str, limit: int = 20) -> list[dict]:
 def collect_receiver():
     """북마클릿 postMessage 수신 페이지 (Phase 219).
 
-    북마클릿이 새 탭으로 이 페이지를 열고(로그인 세션 → 인증), 페이지 HTML·이미지·메타를
+    북마클릿이 새 탭으로 이 페이지를 열고(로그인 세션), 페이지 HTML·이미지·메타를
     postMessage로 전달한다. 이 페이지가 같은 출처로 `/seller/collect/receive`에 저장 요청 →
     '수집됨'만 표시하고 편집 페이지로 이동하지 않는다(내 계정 수집 이력에서 확인).
+
+    ※ 로그인 페이지로 튕기지 않도록 페이지 렌더는 인증 게이트를 두지 않는다(저장 POST에서만
+    인증 확인). 미로그인 시 페이지 안에서 친절히 '로그인' 버튼을 보여준다.
     """
-    if not _check_auth():
-        return redirect(url_for("auth.login", next=request.full_path))
-    return render_template("collect_receiver.html")
+    return render_template("collect_receiver.html", authed=_check_auth())
 
 
 @bp.post("/collect/receive")

--- a/tests/test_collect_receiver.py
+++ b/tests/test_collect_receiver.py
@@ -105,3 +105,31 @@ def test_bulk_limit_raised_to_1000(client):
     with patch("src.seller_console.views._collect_real_draft", return_value=None):
         r = client.post("/seller/collect/bulk", json={"urls": urls})
     assert r.get_json()["total"] == 1000
+
+
+def test_receiver_does_not_redirect_to_login_when_unauth(monkeypatch):
+    """미로그인이어도 receiver는 로그인 페이지로 튕기지 않고 페이지 안에서 안내."""
+    monkeypatch.setenv("SELLER_CONSOLE_AUTH", "1")
+    import importlib
+    from src.seller_console import views as v
+    importlib.reload(v)  # _AUTH_ENABLED 재평가
+    try:
+        from src.order_webhook import app
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            r = c.get("/seller/collect/receiver")
+        assert r.status_code == 200          # redirect(302) 아님
+        assert "showLogin" in r.get_data(as_text=True)
+    finally:
+        monkeypatch.delenv("SELLER_CONSOLE_AUTH", raising=False)
+        importlib.reload(v)
+
+
+def test_edit_page_has_image_thumbnails(client):
+    """편집 페이지 이미지 행에 썸네일(사람이 보이게)."""
+    with patch("src.seller_console.collect_history_store.get",
+               return_value={"id": "x", "title": "t", "url": "https://u", "image_url": "https://i/1.jpg",
+                             "price": "10", "currency": "USD", "extra_json": "{}"}):
+        r = client.get("/seller/collect/preview/x")
+    html = r.get_data(as_text=True)
+    assert "img-thumb" in html


### PR DESCRIPTION
오너 지적(편집 화면·업로드 오류창 스샷, "사람친화적이어야 한다"): 이미지가 URL로만 보임 / 오류창이 튀어나옴 / 북마클릿 파비콘 / 로그인 페이지로 튕김 / 이미지 제대로 수집 안 됨.

## 1. 편집 페이지 이미지 = 썸네일로 보이게 (사람친화)
- 이미지 URL 행마다 **46px 썸네일**을 함께 표시(클릭하면 원본 새 탭). URL 텍스트만 보이던 걸 **사람이 이미지로 바로 확인**하고 대표를 쉽게 고르게.

## 2. 마켓 등록 오류창이 박스를 벗어나던 문제
- WC 406처럼 긴 오류 URL(consumer_secret 포함)이 모달 밖으로 튀어나오던 것 → `word-break/overflow-wrap` + `modal-dialog-scrollable`로 **박스 안에서 줄바꿈**.

## 3. 북마클릿 = 파비콘만 표시
- 북마크바에 텍스트 라벨 대신 **고가네 퍼센티 글로브 파비콘**만 작게. (단, 마우스 hover 시 `javascript:` URL이 보이는 건 북마클릿의 본질적 동작 — 외부 스크립트 로딩은 쇼핑몰 CSP에 막혀 인라인을 유지해야 합니다.)

## 4. 이미지 필터 개선 (배너/로고 제외)
- 북마클릿이 `document.images`에서 logo/sprite/icon/avatar/**banner**/placeholder/**300px 미만**을 제외 → 배너·로고 대신 **상품 이미지 위주**로 수집.

## 5. 북마클릿 클릭 시 로그인 페이지로 튕기지 않게
- `/seller/collect/receiver` 페이지 렌더의 인증 게이트 제거(저장 POST에서만 인증) → 새 창이 **로그인 폼으로 점프하지 않고**, 미로그인 시 receiver 안에서 친절한 ‘로그인’ 안내(401 graceful).

## 남은 후속 (정직하게 말씀드립니다)
- **리스팅/검색 페이지에서 여러 상품 한 번에·취사선택 수집**: 상품 카드마다 버튼을 띄우는 건 북마클릿 한계라 **크롬 확장**이 정석입니다 — 다음 단계로 확장에 구현하겠습니다.
- **Temu 등 SPA의 가격/옵션/리뷰**: 표준 메타(JSON-LD/OG)가 빈약해 추출이 제한적입니다. 사이트별 파서 보강이 필요해 별도 작업으로 잡았습니다.

## 테스트
- 전체 `python -m pytest tests/ -q`: **9980 passed, 2 skipped**. 북마클릿 생성 JS `node --check` 통과.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_