### PR TITLE
feat(collect): 상품 이미지 전체 수집 — lazy/srcset/갤러리 (로고·배너 제외) (Phase 222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,18 @@
   ※ 목록 수집은 카드 정보(제목·이미지·가격·링크) 수준 — 상세·옵션·리뷰는 상세페이지 ‘고가네 수집’ 권장(README 방법4).
 - 인앱 `/seller/collect` 안내·확장 README에 ‘검색/목록 페이지 여러 상품 한 번에 수집’ 추가.
 
+## 🔧 상품 이미지 전체 수집 (오너 지시 2026-06-17 "모든 이미지 수집해야돼")
+- ✅ **이미지 전체 수집** (Phase 222): `universal_scraper`가 이미지를 `src`만·5개로만 받던 걸 →
+  신설 `_collect_dom_images()`로 `src`+lazy(`data-src`/`data-original`/`data-lazy`)+`srcset`/`<source>` 최대해상도까지
+  수집, 로고/아이콘/배너/플레이스홀더 패턴 제외, 상대경로 절대화·중복제거. JSON-LD/OG 경로도 갤러리 이미지를
+  머지(캡 10→40). 확장 `content_script.extractProductMeta`도 og 하나가 아니라 페이지의 모든 상품 이미지(≥250px,
+  로고/배너 제외) 수집. manifest 1.4.0→1.4.1.
+- **남은 후속(오너 화면, 코드 아닌 사안/대형 기능)**: ① 구글/네이버 로그인 = OAuth 키 미설정(카카오만 설정됨) —
+  로그인 페이지가 이미 ‘설정 경로/redirect_uri/client_id’ 진단 표시. 오너가 `GOOGLE_CLIENT_ID/SECRET`,
+  `NAVER_CLIENT_ID/SECRET` 설정 + 콘솔 redirect_uri 등록해야 활성화. ② 북마클릿 아이콘/hover URL = 브라우저가
+  `javascript:` 북마클릿에 강제하는 동작이라 커스터마이즈 불가 → 크롬 확장(브랜드 아이콘·hover 정상) 권장.
+  ③ 마켓별 카테고리 선택 + 자동 카테고리 분류 = 대형 기능(퍼센티 벤치마킹) — 별도 PR로 진행 예정.
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -26,10 +26,27 @@ function extractProductMeta() {
     })
     .filter(Boolean);
 
-  // 이미지 후보: og:image 우선, 없으면 본문 큰 이미지
+  // 이미지: og:image 우선 + 페이지의 모든 상품 이미지(로고/배너/아이콘/작은 이미지 제외)
   const ogImage = getMeta("og:image") || getMeta("og:image:url") || "";
+  const _isProductImg = (s) =>
+    s && s.indexOf("data:") !== 0 &&
+    !/(logo|sprite|icon|favicon|avatar|placeholder|loading|blank|pixel|banner|badge|rating|star_|flag_|emoji)/i.test(s);
   const images = [];
-  if (ogImage) images.push(ogImage);
+  const _seenImg = new Set();
+  const _pushImg = (s) => { if (_isProductImg(s) && !_seenImg.has(s)) { _seenImg.add(s); images.push(s); } };
+  if (ogImage) _pushImg(ogImage);
+  try {
+    document.querySelectorAll("img").forEach((im) => {
+      let src = im.currentSrc || im.src || im.getAttribute("data-src") || im.getAttribute("data-original") || "";
+      if (!src && im.getAttribute("srcset")) {
+        const parts = im.getAttribute("srcset").split(",");
+        src = (parts[parts.length - 1] || "").trim().split(" ")[0];
+      }
+      const w = im.naturalWidth || im.width || 0;
+      const h = im.naturalHeight || im.height || 0;
+      if (src && w >= 250 && h >= 250) _pushImg(src);
+    });
+  } catch (e) { /* noop */ }
 
   // 가격 휴리스틱 (og:price 없을 때)
   let heuristicPrice = "";

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "코가네 퍼센티 수집기",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "쇼핑 페이지를 한 클릭에 코가네 퍼센티로 수집 (인페이지 수집 + 리스팅 다중 선택 수집 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/src/collectors/universal_scraper.py
+++ b/src/collectors/universal_scraper.py
@@ -180,6 +180,74 @@ def _extract_domain(url: str) -> str:
         return ""
 
 
+# 상품 이미지가 아닌 것으로 보이는 URL 패턴(로고/아이콘/배너/플레이스홀더 등)
+_NON_PRODUCT_IMG_RE = re.compile(
+    r"(logo|sprite|icon|favicon|avatar|placeholder|loading|blank|pixel|spinner|"
+    r"banner|badge|button|arrow|star_|rating|flag_|emoji)",
+    re.IGNORECASE,
+)
+
+
+def _collect_dom_images(soup, base_url: str) -> list:
+    """페이지 DOM에서 상품 이미지를 최대한 수집한다.
+
+    - src + lazy-load 속성(data-src/data-original/data-lazy/data-srcset) + srcset(최대 해상도)
+    - data: URI, 로고/아이콘/배너/플레이스홀더 패턴 제외
+    - 상대경로 절대화, 순서 유지 중복 제거
+    """
+    out: list = []
+    seen = set()
+
+    def _abs(s: str) -> str:
+        s = (s or "").strip()
+        if not s or s.startswith("data:"):
+            return ""
+        if s.startswith("//"):
+            s = "https:" + s
+        elif s.startswith("/"):
+            s = urljoin(base_url, s)
+        return s if s.startswith("http") else ""
+
+    def _from_srcset(val: str) -> str:
+        # "url1 320w, url2 800w" → 가장 큰 후보(마지막) URL
+        best = ""
+        for part in (val or "").split(","):
+            cand = part.strip().split(" ")[0].strip()
+            if cand:
+                best = cand
+        return best
+
+    for img in soup.find_all("img"):
+        cand = ""
+        for attr in ("src", "data-src", "data-original", "data-lazy",
+                     "data-lazy-src", "data-image", "data-zoom-image"):
+            v = img.get(attr)
+            if v:
+                cand = v
+                break
+        if not cand:
+            ss = img.get("srcset") or img.get("data-srcset")
+            if ss:
+                cand = _from_srcset(ss)
+        url = _abs(cand)
+        if not url or url in seen:
+            continue
+        if _NON_PRODUCT_IMG_RE.search(url):
+            continue
+        seen.add(url)
+        out.append(url)
+
+    # <source srcset> (picture 요소) 도 수집
+    for src in soup.find_all("source"):
+        ss = src.get("srcset") or src.get("data-srcset")
+        url = _abs(_from_srcset(ss)) if ss else ""
+        if url and url not in seen and not _NON_PRODUCT_IMG_RE.search(url):
+            seen.add(url)
+            out.append(url)
+
+    return out
+
+
 class UniversalScraper:
     """범용 수집기 — 도메인 불문 상품 메타 추출."""
 
@@ -305,7 +373,7 @@ class UniversalScraper:
                         domain=domain,
                         title=title,
                         description=desc,
-                        images=images[:10],
+                        images=list(dict.fromkeys(list(images) + _collect_dom_images(soup, url)))[:40],
                         price=price_val,
                         currency=currency,
                         brand=brand or None,
@@ -390,7 +458,7 @@ class UniversalScraper:
             domain=domain,
             title=title,
             description=data.get("description", ""),
-            images=list(dict.fromkeys(images))[:10],
+            images=list(dict.fromkeys(images + _collect_dom_images(soup, url)))[:40],
             price=price_val,
             currency=currency,
             brand=data.get("brand"),
@@ -476,19 +544,9 @@ class UniversalScraper:
         if meta_desc:
             desc = meta_desc.get("content", "")
 
-        # 이미지 — og:image 없으면 페이지 최대 이미지
-        images: list = []
-        for img in soup.find_all("img", src=True):
-            src = img.get("src", "")
-            if not src or src.startswith("data:"):
-                continue
-            if src.startswith("//"):
-                src = "https:" + src
-            elif src.startswith("/"):
-                src = urljoin(url, src)
-            if src.startswith("http"):
-                images.append(src)
-        images = list(dict.fromkeys(images))[:5]
+        # 이미지 — og:image 없으면 페이지의 상품 이미지를 최대한 수집
+        # (src + lazy-load 속성 + srcset 최대해상도, 로고/배너/아이콘 제외)
+        images = _collect_dom_images(soup, url)[:40]
 
         # 가격 휴리스틱
         price_val: Optional[Decimal] = None

--- a/tests/test_scraper_images.py
+++ b/tests/test_scraper_images.py
@@ -1,0 +1,44 @@
+"""tests/test_scraper_images.py — 상품 이미지 전체 수집(로고/배너 제외, lazy/srcset)."""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_HTML = """<html><head>
+<meta property="og:title" content="가죽 가방">
+<meta property="og:image" content="https://cdn.example.com/main.jpg">
+</head><body>
+<img src="https://cdn.example.com/logo.png">
+<img src="https://cdn.example.com/p1_800x800.jpg" width="800" height="800">
+<img data-src="https://cdn.example.com/p2.jpg">
+<img srcset="https://cdn.example.com/p3_320.jpg 320w, https://cdn.example.com/p3_1200.jpg 1200w">
+<img src="https://cdn.example.com/icon-cart.svg">
+<img src="https://cdn.example.com/banner_top.jpg">
+</body></html>"""
+
+
+def test_parse_html_collects_all_product_images_excluding_logo_banner():
+    from src.collectors.universal_scraper import UniversalScraper
+    sp = UniversalScraper().parse_html(_HTML, "https://example.com/p/1")
+    imgs = sp.images
+    # og 대표 + 갤러리 이미지들이 모두 포함
+    assert "https://cdn.example.com/main.jpg" in imgs
+    assert "https://cdn.example.com/p1_800x800.jpg" in imgs
+    assert "https://cdn.example.com/p2.jpg" in imgs          # data-src(lazy)
+    assert "https://cdn.example.com/p3_1200.jpg" in imgs     # srcset 최대해상도
+    # 로고/아이콘/배너는 제외
+    assert "https://cdn.example.com/logo.png" not in imgs
+    assert "https://cdn.example.com/icon-cart.svg" not in imgs
+    assert "https://cdn.example.com/banner_top.jpg" not in imgs
+    assert len(imgs) >= 4
+
+
+def test_collect_dom_images_dedupes_and_resolves_relative():
+    from src.collectors.universal_scraper import _collect_dom_images
+    from bs4 import BeautifulSoup
+    html = '<div><img src="/a.jpg"><img src="/a.jpg"><img src="//cdn.x/b.jpg"></div>'
+    soup = BeautifulSoup(html, "html.parser")
+    imgs = _collect_dom_images(soup, "https://shop.example/p")
+    assert imgs == ["https://shop.example/a.jpg", "https://cdn.x/b.jpg"]


### PR DESCRIPTION
오너 지적 중 **"수집된 이미지가 저거밖에 안 돼 — 모든 (제품) 이미지를 수집해야 돼"** 를 이번 PR에서 해결했습니다.

## 상품 이미지 전체 수집
- `universal_scraper`가 이미지를 `<img src>`만, 5개로만 받던 걸 → 신설 `_collect_dom_images()`로 교체:
  - `src` + **lazy-load**(`data-src`/`data-original`/`data-lazy`/`data-image`) + **`srcset`/`<source>` 최대 해상도**까지 수집
  - **로고/아이콘/배너/플레이스홀더/별점** 등 비상품 이미지 제외
  - 상대경로 절대화 + 중복 제거, 캡 10 → **40**
  - JSON-LD/OG 경로에도 갤러리 이미지 머지(대표 이미지 + 전체 갤러리)
- 크롬 확장 `content_script.extractProductMeta`도 og:image 하나가 아니라 **페이지의 모든 상품 이미지**(≥250px, 로고/배너 제외)를 수집. manifest **1.4.1**.

## 테스트
- 전체 `python -m pytest tests/ -q`: **9983 passed, 2 skipped**. 신규 이미지 추출 테스트 2종. 확장 JS `node --check` 통과.

---
### 나머지 지적에 대한 정직한 정리 (이 PR 범위 밖)
- **구글/네이버 로그인이 안 뜸** → 코드는 정상(카카오는 됨). **OAuth 키 미설정**이 원인입니다(서버에 `GOOGLE_CLIENT_ID/SECRET`, `NAVER_CLIENT_ID/SECRET` 없음). 로그인 페이지가 이미 ‘설정 경로 / redirect_uri / client_id’를 진단 표시합니다. 키 등록은 오너만 가능 → 원하시면 **단계별 설정 가이드**를 다음에 더 친절히 붙이겠습니다.
- **북마클릿 아이콘/hover URL** → 브라우저가 `javascript:` 북마클릿에 강제하는 동작이라 커스텀 아이콘·hover 텍스트를 우리가 바꿀 수 없습니다. **크롬 확장**은 브랜드 아이콘 + hover 정상이라, 확장을 주 사용으로 권장드립니다(이미 설치하셨습니다).
- **마켓별 카테고리 선택 + 자동 분류** → 대형 기능(퍼센티 벤치마킹)이라 **별도 PR**로 제대로 만들겠습니다.
- **가격/썸네일/이미지/상세 편집·마켓 연동 표시** → 편집 페이지에 이미 있고, 연동 표시는 더 눈에 띄게 보강 예정입니다.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_