### PR TITLE
feat(extension): 크롬 확장 다운로드+설치 가이드 + 모바일 PWA 공유 수집 (Phase 226)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,17 @@
 - **오너 액션(개인화 강제)**: 소비자 로그인 강제는 `SELLER_CONSOLE_AUTH=1`(Render)로 켜짐 — 켜야 콘솔이 로그인을
   요구하고 수집/마켓연동/소싱처가 셀러별 개인화됨(자격증명은 이미 셀러별, 수집이력 seller_id 격리).
 
+## 🔧 크롬 확장 실제 설치 + 모바일 수집 (오너 지시 2026-06-17 "설치가 실제로 되어야지, 모바일도")
+- ✅ **확장 다운로드 + 설치 가이드** (Phase 226): 앱에 확장 배포 경로가 없어 설치 불가였음 → 신설
+  `GET /seller/extension/download`(서버가 `extensions/chrome-collector`를 즉석 ZIP 패키징·`kohgane-collector/…`
+  구조로 내려줌) + `GET /seller/extension` **설치 가이드 페이지**(다운로드→압축풀기→`chrome://extensions`→개발자모드
+  ON→압축해제된 확장 로드→토큰 입력→수집버튼 등장, 단계별·복사버튼). 수집 페이지 안내에 ‘🧩 확장 설치하기’ 링크.
+  ※ 정석은 크롬 웹스토어 게시(오너 1회)지만, 그 전에도 ‘압축해제 로드’로 즉시 설치 가능.
+- ✅ **모바일 수집(PWA share_target)** (Phase 226): 모바일은 확장 미지원 → 앱 PWA 매니페스트(json+webmanifest 동기)에
+  `share_target`(GET `/seller/collect/quick`, params title/text/**u**) 추가 → 안드로이드에서 쇼핑앱 **공유 → 고가네
+  퍼센티**로 URL 전송 시 로그인 세션으로 수집. `/collect/quick`이 `u`/`url`/`text`(텍스트 내 URL 추출)도 허용.
+  설치 가이드에 ‘URL 붙여넣기/공유하기’ 모바일 방법 명시. (URL 붙여넣기 수집은 기존에도 모바일 동작)
+
 ## 작업 방식
 - 브랜치 `claude/magical-noether-oo4831`에서 작업 → PR 생성·main 머지(오너 승인됨)로 배포.
 - 변경 후 전체 테스트(`python -m pytest tests/ -q`) 통과 확인.

--- a/src/seller_console/static/manifest.json
+++ b/src/seller_console/static/manifest.json
@@ -24,6 +24,15 @@
     }
   ],
   "categories": ["business", "shopping"],
+  "share_target": {
+    "action": "/seller/collect/quick",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "u"
+    }
+  },
   "shortcuts": [
     {
       "name": "주문 관리",

--- a/src/seller_console/static/manifest.webmanifest
+++ b/src/seller_console/static/manifest.webmanifest
@@ -24,6 +24,15 @@
     }
   ],
   "categories": ["business", "shopping"],
+  "share_target": {
+    "action": "/seller/collect/quick",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "u"
+    }
+  },
   "shortcuts": [
     {
       "name": "주문 관리",

--- a/src/seller_console/templates/extension_install.html
+++ b/src/seller_console/templates/extension_install.html
@@ -1,0 +1,59 @@
+{% extends "_base.html" %}
+{% block title %}크롬 확장 설치{% endblock %}
+{% block content %}
+<div class="container-fluid py-3" style="max-width:860px">
+  <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+    <div>
+      <h1 class="h4 mb-1">🧩 고가네 수집 — 크롬 확장 설치</h1>
+      <p class="text-muted mb-0">설치하면 쇼핑몰 상품/검색 페이지에 <b>‘고가네 수집’ 버튼</b>이 떠서 클릭 한 번에 수집됩니다.</p>
+    </div>
+    <a href="/seller/extension/download" class="btn btn-primary">
+      <i class="bi bi-download"></i> 확장 다운로드 (v{{ version or '—' }})
+    </a>
+  </div>
+
+  <!-- 단계 가이드 -->
+  <div class="card console-card mb-3">
+    <div class="card-body">
+      <h2 class="h6 mb-3">설치 방법 (1~2분)</h2>
+      <ol class="mb-0">
+        <li class="mb-2">
+          위 <b>‘확장 다운로드’</b>를 눌러 <code>kohgane-collector-v{{ version }}.zip</code>을 받고
+          <b>압축을 풉니다</b>(폴더가 생깁니다).
+        </li>
+        <li class="mb-2">
+          크롬 주소창에 <code>chrome://extensions</code> 입력 → 엔터.
+          <a href="#" onclick="navigator.clipboard.writeText('chrome://extensions');return false;" class="small">📋 복사</a>
+        </li>
+        <li class="mb-2">오른쪽 위 <b>‘개발자 모드’</b>를 <b>켭니다</b>(토글 ON).</li>
+        <li class="mb-2">왼쪽 위 <b>‘압축해제된 확장 프로그램 로드’</b> 클릭 → 방금 <b>압축 푼 폴더</b>(<code>kohgane-collector</code>) 선택.</li>
+        <li class="mb-2"><b>‘코가네 퍼센티 수집기’</b>가 확장 목록에 나타나면 설치 완료 ✅</li>
+        <li class="mb-2">
+          확장의 <b>옵션</b>에 <b>개인 토큰</b>을 넣습니다(딱 1회).
+          <a href="/seller/me/tokens" target="_blank">토큰 발급 →</a>
+          <div class="small text-muted">확장 아이콘 우클릭 → ‘옵션’ → 서버 URL <code>{{ request.host_url.rstrip('/') }}</code> + 토큰 붙여넣기</div>
+        </li>
+        <li>쇼핑몰 상품 페이지로 가면 우하단에 <b>고가네 수집</b> 버튼이, 검색/목록 페이지엔 카드마다 <b>수집 배지</b>가 뜹니다.</li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="alert alert-light border small mb-3">
+    <i class="bi bi-info-circle text-primary"></i>
+    버튼이 안 보이면: ① 확장이 <b>켜져 있는지</b>(파란 토글) ② <code>chrome://extensions</code>에서 <b>새로고침(↻)</b>
+    ③ 상품 <b>상세 페이지</b>인지(목록 페이지는 카드 배지) ④ 옵션에 <b>토큰</b>이 들어갔는지 확인하세요.
+  </div>
+
+  <!-- 모바일 안내 -->
+  <div class="card console-card">
+    <div class="card-body">
+      <h2 class="h6 mb-2">📱 모바일에서 수집하기</h2>
+      <p class="small text-muted mb-2">모바일 브라우저는 크롬 확장을 지원하지 않습니다. 대신 두 가지 방법이 있어요.</p>
+      <ol class="small mb-0">
+        <li class="mb-2"><b>URL 붙여넣기</b>: 상품 페이지에서 주소 복사 → 고가네 <a href="/seller/collect">수집기</a>에 붙여넣고 <b>즉시 수집</b>.</li>
+        <li><b>공유하기(안드로이드)</b>: 고가네 퍼센티를 홈 화면에 추가(앱처럼 설치)하면, 쇼핑 앱에서 <b>공유 → 고가네 퍼센티</b>로 보내 바로 수집됩니다.</li>
+      </ol>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/seller_console/templates/manual_collect.html
+++ b/src/seller_console/templates/manual_collect.html
@@ -59,7 +59,7 @@
         우하단의 <b>“고가네 수집”</b> 버튼으로 한 번에, ②<b>검색·목록 페이지</b>에서는 상품마다 뜨는 <b>‘수집’ 배지</b>와
         상단 <b>전체/선택 수집</b> 바로 <b>여러 상품을 한 번에</b> 수집·한국어 번역됩니다. 설치가 부담되면
         <a href="/seller/bookmarklet">북마클릿(토큰 불필요)</a>으로도 수집할 수 있어요.
-        <a href="/seller/markets/guide" class="ms-1 text-decoration-none">설치/사용 가이드 →</a>
+        <a href="/seller/extension" class="ms-1 fw-semibold text-decoration-none">🧩 확장 설치하기 →</a>
       </div>
     </div>
   </div>

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1151,7 +1151,13 @@ def collect_quick():
     if not _check_auth():
         return redirect(url_for("auth.login", next=request.full_path))
 
-    url = (request.args.get("u") or "").strip()
+    # u(북마클릿) 외에 url/text(모바일 PWA 공유 share_target)도 허용 — 공유 시 URL 추출
+    url = (request.args.get("u") or request.args.get("url") or "").strip()
+    if not url.startswith(("http://", "https://")):
+        shared = request.args.get("text") or request.args.get("title") or ""
+        m = re.search(r"https?://[^\s]+", shared)
+        if m:
+            url = m.group(0).strip()
     if not url.startswith(("http://", "https://")):
         return render_template(
             "collect_quick_result.html", ok=False,
@@ -3920,6 +3926,63 @@ def bookmarklet():
         page="bookmarklet",
         server_url=server_url,
         user_id=user_id,
+    )
+
+
+def _chrome_extension_dir() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "extensions", "chrome-collector"))
+
+
+def _chrome_extension_version() -> str:
+    try:
+        with open(os.path.join(_chrome_extension_dir(), "manifest.json"), encoding="utf-8") as f:
+            return str(json.load(f).get("version", ""))
+    except Exception:
+        return ""
+
+
+@bp.get("/extension")
+def extension_install():
+    """크롬 확장 설치 가이드 + 다운로드 (Phase 226)."""
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.url))
+    return render_template("extension_install.html", page="collect", version=_chrome_extension_version())
+
+
+@bp.get("/extension/download")
+def extension_download():
+    """크롬 확장(고가네 수집)을 ZIP으로 즉석 패키징해 내려준다 — 설치용."""
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.url))
+    import io
+    import zipfile
+
+    ext_dir = _chrome_extension_dir()
+    if not os.path.isdir(ext_dir):
+        abort(404)
+    include = [
+        "manifest.json", "background.js", "content_script.js",
+        "popup.html", "popup.js", "options.html", "options.js", "README.md",
+    ]
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for name in include:
+            p = os.path.join(ext_dir, name)
+            if os.path.isfile(p):
+                z.write(p, arcname=f"kohgane-collector/{name}")
+        icons_dir = os.path.join(ext_dir, "icons")
+        if os.path.isdir(icons_dir):
+            for ic in sorted(os.listdir(icons_dir)):
+                fp = os.path.join(icons_dir, ic)
+                if os.path.isfile(fp):
+                    z.write(fp, arcname=f"kohgane-collector/icons/{ic}")
+    buf.seek(0)
+    version = _chrome_extension_version() or "1"
+    fname = f"kohgane-collector-v{version}.zip"
+    return Response(
+        buf.getvalue(),
+        mimetype="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{fname}"'},
     )
 
 

--- a/tests/test_extension_install.py
+++ b/tests/test_extension_install.py
@@ -1,0 +1,63 @@
+"""tests/test_extension_install.py — 크롬 확장 설치 가이드/다운로드 + PWA 공유 수집."""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import zipfile
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_extension_guide_page(client):
+    r = client.get("/seller/extension")
+    assert r.status_code == 200
+    html = r.get_data(as_text=True)
+    assert "압축해제된" in html
+    assert "chrome://extensions" in html
+    assert "/seller/extension/download" in html
+
+
+def test_extension_download_zip(client):
+    r = client.get("/seller/extension/download")
+    assert r.status_code == 200
+    assert r.headers["Content-Type"] == "application/zip"
+    assert ".zip" in r.headers.get("Content-Disposition", "")
+    z = zipfile.ZipFile(io.BytesIO(r.data))
+    names = z.namelist()
+    for need in ("kohgane-collector/manifest.json", "kohgane-collector/content_script.js",
+                 "kohgane-collector/background.js"):
+        assert need in names
+    assert any(n.startswith("kohgane-collector/icons/") for n in names)
+    assert z.testzip() is None
+
+
+def test_pwa_manifest_has_share_target():
+    import json
+    with open("src/seller_console/static/manifest.webmanifest", encoding="utf-8") as f:
+        m = json.load(f)
+    st = m.get("share_target")
+    assert st and st["action"] == "/seller/collect/quick"
+    assert st["params"]["url"] == "u"
+
+
+def test_quick_collect_accepts_shared_text_url(client):
+    """모바일 공유(share_target)가 text에 URL을 담아 보내도 수집된다."""
+    draft = {"title_ko": "t", "title": "t", "images": ["https://i/1.jpg"],
+             "price_original": "10", "currency": "USD", "source": "x"}
+    with patch("src.seller_console.views._collect_real_draft", return_value=draft), \
+         patch("src.seller_console.collect_history_store.append", return_value="qid"):
+        r = client.get("/seller/collect/quick?text=" + "good%20https://shop.example/p/1%20deal")
+    assert r.status_code == 200
+    assert "수집 완료" in r.get_data(as_text=True)


### PR DESCRIPTION
오너: "크롬 확장(고가네 수집) 설치를 어디서 어떻게 하는지 — 실제로 설치되고 수집 버튼이 떠야지. 그리고 모바일에서도 수집됐으면."

## ① 크롬 확장 — 실제 설치 가능하게
- **문제**: 확장 소스는 repo에 있었지만 **앱에서 받을 방법이 없어** 설치가 불가능했습니다.
- **수정**:
  - **`GET /seller/extension/download`** — 서버가 `extensions/chrome-collector`를 **즉석 ZIP**으로 패키징해 내려줍니다(`kohgane-collector/…` 폴더 구조).
  - **`GET /seller/extension`** — 설치 가이드 페이지: ① 다운로드 → 압축 풀기 ② `chrome://extensions` ③ **개발자 모드 ON** ④ **‘압축해제된 확장 프로그램 로드’ → 폴더 선택** ⑤ 확장 목록에 ‘코가네 퍼센티 수집기’ 등장 ⑥ 옵션에 토큰 입력 ⑦ 상품/목록 페이지에 **수집 버튼** 표시. (각 단계 + 복사 버튼 + 안 보일 때 체크리스트)
  - 수집 페이지 안내에 **‘🧩 확장 설치하기 →’** 링크.
  - ※ 정석은 크롬 웹스토어 게시(오너 1회, 심사)지만, 그 전에도 ‘압축해제 로드’로 **지금 바로 설치** 가능합니다.

## ② 모바일 수집 — 어렵지 않게, PWA 공유로
- 모바일 브라우저는 크롬 확장을 지원하지 않습니다. 대신:
  - **공유하기(안드로이드)**: 앱이 PWA라, 매니페스트에 **`share_target`** 추가 → 고가네 퍼센티를 홈 화면에 추가하면 쇼핑 앱에서 **공유 → 고가네 퍼센티**로 URL을 보내 **로그인 세션으로 바로 수집**됩니다.
  - `/seller/collect/quick`이 `u`/`url`/`text`(텍스트 속 URL 추출)도 받도록 보강.
  - **URL 붙여넣기**: 상품 주소 복사 → 수집기에 붙여넣고 즉시 수집(기존에도 모바일 동작).

## 테스트
- 전체 `python -m pytest tests/ -q`: **10000 passed, 2 skipped**. 신규: 가이드/ZIP 다운로드 무결성/share_target/텍스트공유 4종.

### 오너 액션
- 지금: `/seller/extension`에서 다운로드 후 개발자 모드 로드(누구나 가능). 
- 더 쉽게(소비자 대상): 크롬 웹스토어에 1회 게시하면 ‘설치’ 버튼 한 번으로 끝 — 원하시면 게시용 패키지/스토어 등록 안내를 도와드리겠습니다.

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_