### PR TITLE
fix: 확장 다중선택 안정화 + 마켓 모달 전체선택 + nav 재배치 + 비관리자 셀러 접근 (Phase 231)

### DIFF
--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -253,7 +253,8 @@ function injectCollectButton() {
 const KGP_TOOLBAR_ID = "kgp-listing-toolbar";
 const KGP_SELECTED = new Set();   // 선택된 상품 url 집합(재스캔에도 유지)
 let _kgpCards = [];
-let _kgpCardByUrl = {};           // url → 카드 데이터(el 포함)
+let _kgpCardByUrl = {};           // url → 카드 데이터(el 포함) — 재스캔 시 '병합'(절대 비우지 않음)
+let _kgpClosed = false;           // 사용자가 툴바를 닫았으면 자동 재생성 안 함(같은 URL 동안)
 
 function _kgpPrice(text) {
   const m = String(text || "").match(/([\d][\d.,]{1,})\s*원|(?:₩|\$|¥|€|£)\s*([\d][\d.,]{1,})/);
@@ -315,11 +316,11 @@ function kgpSetCardSelected(url, badge, el, selected) {
   if (selected) {
     KGP_SELECTED.add(url);
     if (badge) { badge.textContent = "✓ 선택"; badge.style.cssText = kgpCardBadgeStyle(true); }
-    if (el) { el.style.outline = "3px solid #ff8a1e"; el.style.outlineOffset = "-3px"; }
+    if (el) { el.style.outline = "3px solid #ff8a1e"; el.style.outlineOffset = "-3px"; el.setAttribute("data-kgp-outline", "1"); }
   } else {
     KGP_SELECTED.delete(url);
     if (badge) { badge.textContent = "수집"; badge.style.cssText = kgpCardBadgeStyle(false); }
-    if (el) { el.style.outline = ""; }
+    if (el) { el.style.outline = ""; el.removeAttribute("data-kgp-outline"); }
   }
 }
 
@@ -408,8 +409,13 @@ function kgpBuildToolbar() {
     } else if (act === "collect-all") {
       kgpCollect(Object.keys(_kgpCardByUrl));
     } else if (act === "close") {
+      // 닫으면 같은 페이지에서 자동으로 다시 뜨지 않게 한다(URL 변경 시 초기화).
+      _kgpClosed = true;
       bar.remove();
       document.querySelectorAll(".kgp-card-chk").forEach((b) => b.remove());
+      document.querySelectorAll("[data-kgp-outline]").forEach((el) => {
+        el.style.outline = ""; el.removeAttribute("data-kgp-outline");
+      });
     }
   });
   document.body.appendChild(bar);
@@ -417,35 +423,36 @@ function kgpBuildToolbar() {
 
 function kgpInjectListing() {
   if (window.top !== window.self || !document.body) return;
+  if (_kgpClosed) return;                        // 사용자가 닫음 → 자동 재생성 안 함
   const cards = kgpFindCards();
-  if (cards.length < 3) {                       // 리스팅 아님 → 정리
+  if (cards.length < 3) {                        // 리스팅 아님 → 정리
     const ex = document.getElementById(KGP_TOOLBAR_ID);
     if (ex) { ex.remove(); document.querySelectorAll(".kgp-card-chk").forEach((b) => b.remove()); }
     return;
   }
-  // 재스캔(무한스크롤/동적로딩)에도 선택을 지우지 않는다. url 기준으로 카드맵 갱신 +
-  // 배지 없는 카드에만 배지 주입(기존 선택 유지).
+  // 재스캔(무한스크롤/동적로딩)에도 선택을 지우지 않는다.
+  // ★중요★ 카드맵을 비우지 않고 '병합'한다 — 비우면 선택된 url의 카드 데이터가 사라져
+  //   '선택 수집/전체 수집'이 '선택된 상품 없음'으로 실패하던 버그(오너 리포트) 방지.
   _kgpCards = cards;
-  _kgpCardByUrl = {};
   cards.forEach((c) => { _kgpCardByUrl[c.url] = c; });
   cards.forEach((c) => {
     try {
-      if (c.el.querySelector(":scope > .kgp-card-chk")) {
-        // 이미 배지 있음 — 선택 상태만 동기화
-        const b = c.el.querySelector(":scope > .kgp-card-chk");
-        const sel = KGP_SELECTED.has(c.url);
-        b.textContent = sel ? "✓ 선택" : "수집";
-        b.style.cssText = kgpCardBadgeStyle(sel);
+      const existing = c.el.querySelector(":scope > .kgp-card-chk");
+      const sel = KGP_SELECTED.has(c.url);
+      if (existing) {
+        // 이미 배지 있음 — 선택 상태만 동기화(선택을 풀지 않음)
+        existing.textContent = sel ? "✓ 선택" : "수집";
+        existing.style.cssText = kgpCardBadgeStyle(sel);
+        if (sel) { c.el.style.outline = "3px solid #ff8a1e"; c.el.style.outlineOffset = "-3px"; c.el.setAttribute("data-kgp-outline", "1"); }
         return;
       }
       if (getComputedStyle(c.el).position === "static") c.el.style.position = "relative";
       const badge = document.createElement("div");
       badge.className = "kgp-card-chk";
       badge.dataset.url = c.url;
-      const sel = KGP_SELECTED.has(c.url);
       badge.textContent = sel ? "✓ 선택" : "수집";
       badge.style.cssText = kgpCardBadgeStyle(sel);
-      if (sel) { c.el.style.outline = "3px solid #ff8a1e"; c.el.style.outlineOffset = "-3px"; }
+      if (sel) { c.el.style.outline = "3px solid #ff8a1e"; c.el.style.outlineOffset = "-3px"; c.el.setAttribute("data-kgp-outline", "1"); }
       badge.addEventListener("click", (e) => {
         e.preventDefault(); e.stopPropagation();
         kgpToggleCard(c.url, badge, c.el);
@@ -467,6 +474,10 @@ let _kgpLastUrl = location.href;
 setInterval(() => {
   if (location.href !== _kgpLastUrl) {
     _kgpLastUrl = location.href;
+    // 새 페이지로 이동 → 닫음 상태/선택 초기화(다른 상품 목록이므로).
+    _kgpClosed = false;
+    KGP_SELECTED.clear();
+    _kgpCardByUrl = {};
     setTimeout(kgpRefresh, 900);
   }
 }, 1500);

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "코가네 퍼센티 수집기",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "쇼핑 페이지를 한 클릭에 코가네 퍼센티로 수집 (인페이지 수집 + 리스팅 다중 선택 수집 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -39,8 +39,12 @@
     </a>
 
     <ul class="nav flex-column gap-1 flex-grow-1">
-      <li class="console-nav-group-title">대시보드</li>
+      <li class="console-nav-group-title">⭐ 자주 쓰는</li>
       <li><a class="console-nav-link {% if _path == '/seller/' or _path.startswith('/seller/dashboard') %}active{% endif %}" href="/seller/dashboard"><i class="bi bi-speedometer2"></i><span>대시보드(홈)</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/collect') or _path.startswith('/seller/manual-collect') %}active{% endif %}" href="/seller/manual-collect"><i class="bi bi-search"></i><span>상품 수집기</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/collect-history') %}active{% endif %}" href="/seller/collect-history"><i class="bi bi-journal-text"></i><span>수집 이력</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/catalog') %}active{% endif %}" href="/seller/catalog"><i class="bi bi-box-seam"></i><span>카탈로그(상품관리)</span></a></li>
+      <li><a class="console-nav-link {% if (_path.startswith('/seller/markets') and not _path.startswith('/seller/markets/connect') and not _path.startswith('/seller/markets/guide')) or _path.startswith('/seller/market-status') %}active{% endif %}" href="/seller/markets"><i class="bi bi-shop"></i><span>마켓 연동/현황</span></a></li>
 
       <li class="console-nav-group-title">상품</li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/collect') or _path.startswith('/seller/manual-collect') %}active{% endif %}" href="/seller/manual-collect"><i class="bi bi-search"></i><span>수집기</span></a></li>
@@ -79,7 +83,6 @@
       <li><a class="console-nav-link {% if _path.startswith('/seller/ads/keywords') %}active{% endif %}" href="/seller/ads/keywords"><i class="bi bi-bullseye"></i><span>키워드 최적화</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/marketing/campaigns') %}active{% endif %}" href="/seller/marketing/campaigns"><i class="bi bi-ticket-perforated"></i><span>할인 캠페인</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/inventory/reorder') %}active{% endif %}" href="/seller/inventory/reorder"><i class="bi bi-arrow-repeat"></i><span>자동 리오더</span></a></li>
-      <li><a class="console-nav-link {% if _path.startswith('/seller/collect-history') %}active{% endif %}" href="/seller/collect-history"><i class="bi bi-journal-text"></i><span>수집 이력</span></a></li>
 
       <li class="console-nav-group-title">설정</li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/api/status') or _path.startswith('/seller/api-status') %}active{% endif %}" href="/seller/api/status"><i class="bi bi-key"></i><span>API 상태</span></a></li>

--- a/src/seller_console/templates/collect_preview.html
+++ b/src/seller_console/templates/collect_preview.html
@@ -55,7 +55,11 @@
             <button type="button" class="btn btn-outline-primary btn-sm py-0 px-2" id="btnConvertKrw"
                     onclick="convertToKrw()" title="환율을 적용해 가격을 원화(KRW)로 바꿉니다">↻ 원화로 환산</button>
           </div>
-          <div class="text-muted mb-3" id="fxNote" style="font-size:.74rem;"></div>
+          <div class="text-muted mb-1" id="fxNote" style="font-size:.74rem;"></div>
+          <div class="alert alert-warning py-1 px-2 mb-3 d-none" id="priceWarn" style="font-size:.8rem;">
+            ⚠️ <strong>판매가(가격)가 0이거나 비어 있습니다.</strong> 이 상태로는 마켓이 등록을 거부합니다
+            (“연결됨”이어도 업로드 실패). 위에 가격을 입력하거나 <strong>↻ 원화로 환산</strong>으로 채워주세요.
+          </div>
         </div>
       </div>
 
@@ -174,7 +178,11 @@
         <!-- Step 1: 마켓 선택 + 마진율 설정 -->
         <div id="stepSelect">
           <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
-            <h6 class="fw-semibold mb-0">1. 등록할 마켓 선택</h6>
+            <div class="d-flex align-items-center gap-2">
+              <h6 class="fw-semibold mb-0">1. 등록할 마켓 선택</h6>
+              <button type="button" class="btn btn-sm btn-outline-primary py-0 px-2" id="btnSelectAllMarkets"
+                      onclick="toggleAllMarkets()">전체 선택</button>
+            </div>
             {% set conn = market_connected or {} %}
             {% set total = conn|length %}
             {% set okcnt = conn.values()|select|list|length %}
@@ -383,6 +391,10 @@ function updateKrwPreview() {
   const noteEl = document.getElementById('fxNote');
   const btn = document.getElementById('btnConvertKrw');
   const srcLabel = _FX_MOCK ? '기본값(실시간 연결 전)' : '실시간';
+
+  // 가격 0/빈값이면 경고 표시 — '연결됨'인데 업로드가 실패하는 가장 흔한 원인.
+  const warnEl = document.getElementById('priceWarn');
+  if (warnEl) warnEl.classList.toggle('d-none', price > 0);
 
   if (cur === 'KRW') {
     prevEl.textContent = price > 0 ? `원화 ${_fmtKrw(price)}원` : '원화 입력';
@@ -593,9 +605,25 @@ function _syncMarketTile(input) {
   if (tile) tile.classList.toggle('selected', input.checked);
 }
 document.querySelectorAll('.market-upload-check').forEach(input => {
-  input.addEventListener('change', () => _syncMarketTile(input));
+  input.addEventListener('change', () => { _syncMarketTile(input); _refreshSelectAllLabel(); });
   _syncMarketTile(input);
 });
+
+// '전체 선택' 토글 — 모두 선택돼 있으면 전체 해제, 아니면 전체 선택.
+function toggleAllMarkets() {
+  const boxes = Array.from(document.querySelectorAll('.market-upload-check'));
+  const allChecked = boxes.length > 0 && boxes.every(b => b.checked);
+  boxes.forEach(b => { b.checked = !allChecked; _syncMarketTile(b); });
+  _refreshSelectAllLabel();
+}
+function _refreshSelectAllLabel() {
+  const btn = document.getElementById('btnSelectAllMarkets');
+  if (!btn) return;
+  const boxes = Array.from(document.querySelectorAll('.market-upload-check'));
+  const allChecked = boxes.length > 0 && boxes.every(b => b.checked);
+  btn.textContent = allChecked ? '전체 해제' : '전체 선택';
+}
+_refreshSelectAllLabel();
 
 function openUploadModal() {
   const modal = new bootstrap.Modal(document.getElementById('uploadModal'));

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -5335,13 +5335,17 @@ def sourcing_monitor_check():
 
 
 def _sourcing_require_admin():
-    """소싱 페이지 관리자 권한 확인."""
-    from src.auth.admin_resolver import is_admin_session
+    """소싱/등록/이미지 페이지 접근 가드.
+
+    멀티유저 SaaS — 로그인한 셀러면 누구나 접근 가능(소싱 watches/후보 큐/등록 이력/
+    이미지 큐는 셀러 작업 화면이라 관리자 전용이 아님). 과거엔 관리자 전용이라
+    ADMIN_EMAILS 미설정 시 셀러가 403을 받아 좌측 메뉴가 '동작 안 함'으로 보였다.
+    인증 강제(_AUTH_ENABLED)가 켜져 있을 때만 로그인을 요구하고, 그 외(테스트/오픈)는 통과.
+    """
+    if not _AUTH_ENABLED:
+        return None
     if not session.get("user_id"):
         return redirect(url_for("auth.login", next=request.url))
-    admin_ok, _ = is_admin_session(session)
-    if not admin_ok:
-        return jsonify({"ok": False, "error": "관리자 권한이 필요합니다"}), 403
     return None
 
 

--- a/tests/test_nav_and_seller_access.py
+++ b/tests/test_nav_and_seller_access.py
@@ -1,0 +1,77 @@
+"""tests/test_nav_and_seller_access.py — 좌측 nav 재배치 + 셀러 접근 가드 회귀.
+
+오너 리포트(2026-06-19): 좌측의 등록 이력/이미지 큐/소싱 watches/후보 큐 버튼이
+'동작하지 않음' — 원인은 _sourcing_require_admin()이 ADMIN_EMAILS 미설정 셀러에게
+403을 돌려줬기 때문. 멀티유저 SaaS에서 이들은 셀러 작업 화면이므로 로그인만 요구한다.
+또한 '수집 이력'을 잘 보이는 위쪽 '자주 쓰는' 그룹으로 옮기고, 마켓 업로드 모달에
+'전체 선택' 버튼을 추가했다.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_sourcing_guard_allows_logged_in_seller_when_auth_on(monkeypatch):
+    """인증 강제 ON + 비관리자 셀러 세션 → 가드 통과(None). 과거엔 403."""
+    from src.order_webhook import app
+    import src.seller_console.views as v
+    monkeypatch.setattr(v, "_AUTH_ENABLED", True, raising=False)
+    with app.test_request_context("/seller/sourcing/watches"):
+        from flask import session
+        session["user_id"] = "seller-123"
+        session["user_role"] = "seller"   # 비관리자
+        assert v._sourcing_require_admin() is None
+
+
+def test_sourcing_guard_redirects_anonymous_when_auth_on(monkeypatch):
+    """인증 강제 ON + 미로그인 → 로그인으로 리다이렉트(가드가 응답 반환)."""
+    from src.order_webhook import app
+    import src.seller_console.views as v
+    monkeypatch.setattr(v, "_AUTH_ENABLED", True, raising=False)
+    with app.test_request_context("/seller/sourcing/watches"):
+        guard = v._sourcing_require_admin()
+        assert guard is not None  # redirect 응답
+
+
+def test_admin_gated_pages_accessible_in_tests(client):
+    """테스트 환경(_AUTH_ENABLED off)에서 4개 페이지가 200(403 아님)."""
+    for path in ("/seller/sourcing/watches", "/seller/sourcing/candidates",
+                 "/seller/listing/history", "/seller/media/queue"):
+        resp = client.get(path)
+        assert resp.status_code == 200, f"{path} → {resp.status_code}"
+
+
+def test_nav_has_quick_access_group_with_collect_history(client):
+    """좌측 nav 상단에 '자주 쓰는' 그룹 + 수집 이력 링크가 위쪽에 있다."""
+    html = client.get("/seller/dashboard").get_data(as_text=True)
+    assert "자주 쓰는" in html
+    # '자주 쓰는' 그룹이 '운영' 그룹보다 먼저 등장(위쪽)
+    assert html.index("자주 쓰는") < html.index("/seller/collect-history")
+    assert html.index("/seller/collect-history") < html.index(">운영<") if ">운영<" in html else True
+
+
+def test_market_modal_has_select_all_button(client):
+    """편집/업로드 페이지 마켓 모달에 '전체 선택' 버튼(toggleAllMarkets)이 있다."""
+    from unittest.mock import patch
+    draft = {"id": "p1", "title_ko": "테스트", "title": "t", "images": ["https://i/1.jpg"],
+             "price": "10", "currency": "USD", "source": "x", "status": "collected"}
+    with patch("src.seller_console.collect_history_store.get", return_value=draft):
+        resp = client.get("/seller/collect/preview/p1")
+    if resp.status_code == 200:
+        html = resp.get_data(as_text=True)
+        assert "toggleAllMarkets" in html
+        assert "전체 선택" in html


### PR DESCRIPTION
오너 리포트(2026-06-19 라이브 스크린샷)를 차근차근 일괄 수정했습니다.

## 1. 크롬확장 리스팅 '전체선택/선택수집/전체수집' 미작동 (핵심 버그)
- **원인**: 4초마다 도는 재스캔(`kgpInjectListing`)이 `_kgpCardByUrl = {}`로 카드맵을 **통째로 비워**, 선택된 url의 카드 데이터가 사라짐 → '선택 수집/전체 수집'이 `선택된 상품 없음`으로 실패하고, 선택 배지가 '바로 풀려버리는' 것처럼 보였음.
- **수정**: 카드맵을 비우지 않고 **병합**(절대 손실 없음). 선택 배지/주황 아웃라인을 재스캔에도 유지. `manifest` 1.4.3→**1.4.4**.

## 2. 중앙 '고가네 수집' 바 끄고/켜기
- 닫으면 `_kgpClosed` 플래그로 **같은 페이지에서 자동 재생성 안 함**(URL 변경 시 초기화). 닫을 때 카드 배지/아웃라인 정리.

## 3. 마켓 업로드 모달 '전체 선택' 버튼
- '1. 등록할 마켓 선택' 옆에 **전체 선택** 버튼 추가(`toggleAllMarkets`, 전체선택↔전체해제 토글).

## 4. 좌측 nav 재배치 ('수집 이력' 위로 + 자주 쓰는 버튼 잘 보이게)
- 상단에 **⭐ 자주 쓰는** 그룹 신설: 대시보드 / 상품 수집기 / **수집 이력** / 카탈로그 / 마켓 연동. 묻혀 있던 하단의 수집 이력을 위로 이동.

## 5. '동작하지 않는 버튼들' (등록 이력/이미지 큐/소싱 watches/후보 큐)
- **원인**: `_sourcing_require_admin()`이 `ADMIN_EMAILS` 미설정 셀러에게 **403**을 돌려줘 좌측 메뉴가 '동작 안 함'으로 보였음.
- **수정**: 멀티유저 SaaS에서 이들은 셀러 작업 화면이므로 **로그인만 요구**(인증 강제 ON일 때). 비관리자 셀러도 접근 가능.

## 6. '연결됨인데 업로드 실패' 혼란
- 가장 흔한 원인인 **가격 0/빈값**을 편집 페이지에서 업로드 전 **명확히 경고**(환율 환산 안내). 정직성 유지(가짜 성공 없음).

## 테스트
- `tests/test_nav_and_seller_access.py` 신설(가드/nav/모달 회귀 5케이스).
- 전체 `python -m pytest tests/ -q` → **10011 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_