### PR TITLE
fix: nav 중복/활성표시 + 일괄등록 전체선택 + 수집이력 썸네일 + 확장 바 토글 (Phase 232)

### DIFF
--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -410,20 +410,47 @@ function kgpBuildToolbar() {
       kgpCollect(Object.keys(_kgpCardByUrl));
     } else if (act === "close") {
       // 닫으면 같은 페이지에서 자동으로 다시 뜨지 않게 한다(URL 변경 시 초기화).
+      // 대신 작은 '다시 열기' 알약을 남겨 사용자가 켜고 끌 수 있게 한다(선택은 유지).
       _kgpClosed = true;
       bar.remove();
       document.querySelectorAll(".kgp-card-chk").forEach((b) => b.remove());
-      document.querySelectorAll("[data-kgp-outline]").forEach((el) => {
-        el.style.outline = ""; el.removeAttribute("data-kgp-outline");
-      });
+      kgpShowReopenPill();
     }
   });
   document.body.appendChild(bar);
 }
 
+const KGP_REOPEN_ID = "kgp-listing-reopen";
+
+// 닫았을 때 화면 좌상단에 작은 '고가네 수집 열기' 알약을 남긴다 → 클릭 시 바를 다시 띄운다.
+function kgpShowReopenPill() {
+  if (document.getElementById(KGP_REOPEN_ID) || !document.body) return;
+  const pill = document.createElement("button");
+  pill.id = KGP_REOPEN_ID;
+  pill.type = "button";
+  pill.title = "고가네 수집 바 다시 열기";
+  pill.innerHTML =
+    '<span style="display:flex;align-items:center;justify-content:center;width:20px;height:20px;background:#0a0a2a;border-radius:50%">' + KGP_GLOBE_SVG + '</span>' +
+    '<span style="font-weight:700;font-size:12px">수집 열기</span>';
+  pill.style.cssText = [
+    "position:fixed", "top:12px", "left:12px", "z-index:2147483646",
+    "display:flex", "align-items:center", "gap:6px", "padding:5px 10px 5px 6px",
+    "border:1.5px solid #ff8a1e", "border-radius:999px",
+    "background:linear-gradient(135deg,#0a1f5c,#13308f)", "color:#fff",
+    "cursor:pointer", "box-shadow:0 4px 14px rgba(10,31,92,.45)",
+    "font:12px/1 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
+  ].join(";");
+  pill.addEventListener("click", () => {
+    pill.remove();
+    _kgpClosed = false;
+    kgpInjectListing();          // 바 + 배지 복원(선택 유지)
+  });
+  document.body.appendChild(pill);
+}
+
 function kgpInjectListing() {
   if (window.top !== window.self || !document.body) return;
-  if (_kgpClosed) return;                        // 사용자가 닫음 → 자동 재생성 안 함
+  if (_kgpClosed) return;                        // 사용자가 닫음 → 자동 재생성 안 함(알약으로만 재오픈)
   const cards = kgpFindCards();
   if (cards.length < 3) {                        // 리스팅 아님 → 정리
     const ex = document.getElementById(KGP_TOOLBAR_ID);
@@ -478,6 +505,8 @@ setInterval(() => {
     _kgpClosed = false;
     KGP_SELECTED.clear();
     _kgpCardByUrl = {};
+    const _pill = document.getElementById(KGP_REOPEN_ID);
+    if (_pill) _pill.remove();
     setTimeout(kgpRefresh, 900);
   }
 }, 1500);

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "코가네 퍼센티 수집기",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "쇼핑 페이지를 한 클릭에 코가네 퍼센티로 수집 (인페이지 수집 + 리스팅 다중 선택 수집 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -41,14 +41,12 @@
     <ul class="nav flex-column gap-1 flex-grow-1">
       <li class="console-nav-group-title">⭐ 자주 쓰는</li>
       <li><a class="console-nav-link {% if _path == '/seller/' or _path.startswith('/seller/dashboard') %}active{% endif %}" href="/seller/dashboard"><i class="bi bi-speedometer2"></i><span>대시보드(홈)</span></a></li>
-      <li><a class="console-nav-link {% if _path.startswith('/seller/collect') or _path.startswith('/seller/manual-collect') %}active{% endif %}" href="/seller/manual-collect"><i class="bi bi-search"></i><span>상품 수집기</span></a></li>
-      <li><a class="console-nav-link {% if _path.startswith('/seller/collect-history') %}active{% endif %}" href="/seller/collect-history"><i class="bi bi-journal-text"></i><span>수집 이력</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/manual-collect') or (_path.startswith('/seller/collect') and not _path.startswith('/seller/collect/history') and not _path.startswith('/seller/collect-history')) %}active{% endif %}" href="/seller/manual-collect"><i class="bi bi-search"></i><span>상품 수집기</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/collect/history') or _path.startswith('/seller/collect-history') %}active{% endif %}" href="/seller/collect/history"><i class="bi bi-journal-text"></i><span>수집 이력</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/catalog') %}active{% endif %}" href="/seller/catalog"><i class="bi bi-box-seam"></i><span>카탈로그(상품관리)</span></a></li>
       <li><a class="console-nav-link {% if (_path.startswith('/seller/markets') and not _path.startswith('/seller/markets/connect') and not _path.startswith('/seller/markets/guide')) or _path.startswith('/seller/market-status') %}active{% endif %}" href="/seller/markets"><i class="bi bi-shop"></i><span>마켓 연동/현황</span></a></li>
 
       <li class="console-nav-group-title">상품</li>
-      <li><a class="console-nav-link {% if _path.startswith('/seller/collect') or _path.startswith('/seller/manual-collect') %}active{% endif %}" href="/seller/manual-collect"><i class="bi bi-search"></i><span>수집기</span></a></li>
-      <li><a class="console-nav-link {% if _path.startswith('/seller/catalog') %}active{% endif %}" href="/seller/catalog"><i class="bi bi-box-seam"></i><span>카탈로그(상품관리)</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/listing/ai-create') %}active{% endif %}" href="/seller/listing/ai-create"><i class="bi bi-robot"></i><span>AI 상품등록</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/listing/history') %}active{% endif %}" href="/seller/listing/history"><i class="bi bi-clock-history"></i><span>등록 이력</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/media/queue') %}active{% endif %}" href="/seller/media/queue"><i class="bi bi-image"></i><span>이미지 큐</span></a></li>
@@ -67,7 +65,6 @@
       <li><a class="console-nav-link {% if _path.startswith('/seller/pricing/fx-impact') %}active{% endif %}" href="/seller/pricing/fx-impact"><i class="bi bi-currency-exchange"></i><span>환율 영향</span></a></li>
 
       <li class="console-nav-group-title">마켓</li>
-      <li><a class="console-nav-link {% if (_path.startswith('/seller/markets') and not _path.startswith('/seller/markets/connect') and not _path.startswith('/seller/markets/guide')) or _path.startswith('/seller/market-status') %}active{% endif %}" href="/seller/markets"><i class="bi bi-shop"></i><span>마켓 연동/현황</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/markets/connect') %}active{% endif %}" href="/seller/markets/connect"><i class="bi bi-plug"></i><span>마켓 연결(키 설정)</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/markets/guide') %}active{% endif %}" href="/seller/markets/guide"><i class="bi bi-journal-text"></i><span>API 키 발급 가이드</span></a></li>
 

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -123,16 +123,20 @@
             <tr>
               <td class="ps-3"><input type="checkbox" class="row-chk" value="{{ it.id }}" data-title="{{ it.title or '(제목 없음)' }}" aria-label="선택"></td>
               <td>
+                {% if it.thumbs %}
+                <a href="/seller/collect/preview/{{ it.id }}" class="d-inline-flex align-items-center gap-1" title="확인·수정 후 등록">
+                  {% for t in it.thumbs %}
+                  <img src="{{ t }}" alt="" loading="lazy"
+                       style="width:{{ '52' if loop.first else '34' }}px;height:{{ '52' if loop.first else '34' }}px;object-fit:cover;border-radius:7px;background:#f1f3f5;border:1px solid #e9ecef"
+                       onerror="this.style.display='none'">
+                  {% endfor %}
+                </a>
+                {% else %}
                 <a href="/seller/collect/preview/{{ it.id }}">
-                  {% if it.image_url %}
-                  <img src="{{ it.image_url }}" alt="" loading="lazy"
-                       style="width:52px;height:52px;object-fit:cover;border-radius:8px;background:#f1f3f5"
-                       onerror="this.style.visibility='hidden'">
-                  {% else %}
                   <span class="d-inline-flex align-items-center justify-content-center text-muted"
                         style="width:52px;height:52px;border-radius:8px;background:#f1f3f5;font-size:18px">🖼️</span>
-                  {% endif %}
                 </a>
+                {% endif %}
               </td>
               <td style="max-width:360px">
                 <a href="/seller/collect/preview/{{ it.id }}" class="text-decoration-none fw-semibold text-dark d-block text-truncate" title="{{ it.title or '(제목 없음)' }}">
@@ -202,7 +206,11 @@
       <div class="modal-body">
         <p class="small text-muted">선택한 <strong id="modalSelCount">0</strong>개 상품을 아래 마켓에 등록합니다.</p>
         <div class="mb-3">
-          <div class="fw-semibold small mb-1">등록 마켓</div>
+          <div class="d-flex align-items-center justify-content-between mb-1">
+            <div class="fw-semibold small">등록 마켓</div>
+            <button type="button" class="btn btn-sm btn-outline-primary py-0 px-2" id="bulkSelectAllMarkets"
+                    onclick="toggleAllBulkMarkets()">전체 선택</button>
+          </div>
           <div class="d-flex flex-wrap gap-2">
             {% for m in upload_markets %}
             <label class="market-tile border rounded px-3 py-2 d-flex align-items-center gap-2 mb-0" for="bm_{{ m.code }}">
@@ -245,6 +253,14 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   document.querySelectorAll('.row-chk').forEach(c => c.addEventListener('change', refreshSelCount));
 });
+// 모달 '전체 선택' — 모든 마켓 체크 토글(전체선택↔전체해제).
+function toggleAllBulkMarkets() {
+  const boxes = Array.from(document.querySelectorAll('.bulk-market-chk'));
+  const allChecked = boxes.length > 0 && boxes.every(b => b.checked);
+  boxes.forEach(b => { b.checked = !allChecked; });
+  const btn = document.getElementById('bulkSelectAllMarkets');
+  if (btn) btn.textContent = allChecked ? '전체 선택' : '전체 해제';
+}
 function openBulkUploadModal() {
   const ids = selectedItemIds();
   if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }
@@ -265,6 +281,15 @@ async function runBulkUpload() {
       method: 'POST', headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({item_ids: ids, markets: markets, target_margin_pct: margin}),
     });
+    // 서버가 JSON이 아닌 HTML(오류/타임아웃 페이지)을 줄 수 있으므로 안전하게 처리.
+    const ctype = resp.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) {
+      const msg = resp.status === 504 || resp.status === 502
+        ? `서버 응답 지연(${resp.status}) — 한 번에 너무 많은 상품일 수 있어요. 상품 수를 줄여 다시 시도하세요.`
+        : `등록 요청 실패 (HTTP ${resp.status}). 잠시 후 다시 시도하세요.`;
+      pcToast(msg, 'error');
+      return;
+    }
     const data = await resp.json();
     if (!data.ok) { pcToast(data.error || '일괄 업로드 실패', 'error'); return; }
     let html = `<div class="alert alert-info py-2">전체 ${data.total}개 · 성공 <strong>${data.succeeded}</strong> · 실패 ${data.total - data.succeeded}</div><ul class="list-group">`;

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -4145,6 +4145,26 @@ def collect_history():
     except Exception as exc:
         logger.warning("수집 이력 조회 실패: %s", exc)
 
+    # 각 항목에 썸네일 목록(최대 5장) 부착 — 대표이미지 + extra_json의 수집 이미지들.
+    # 사람이 이름 옆에서 이미지로 바로 확인할 수 있게(오너 요청).
+    for it in items:
+        thumbs: list[str] = []
+        rep = (it.get("image_url") or "").strip()
+        if rep:
+            thumbs.append(rep)
+        try:
+            ex = json.loads(it.get("extra_json") or "{}")
+            imgs = ex.get("images") if isinstance(ex.get("images"), list) else []
+            for u in imgs:
+                u = (str(u) or "").strip()
+                if u and u not in thumbs:
+                    thumbs.append(u)
+                if len(thumbs) >= 5:
+                    break
+        except Exception:
+            pass
+        it["thumbs"] = thumbs[:5]
+
     from .upload_dispatcher import MARKET_LABELS, SUPPORTED_MARKETS
     upload_markets = [{"code": m, "label": MARKET_LABELS.get(m, m)} for m in SUPPORTED_MARKETS]
     return render_template(

--- a/tests/test_nav_and_seller_access.py
+++ b/tests/test_nav_and_seller_access.py
@@ -56,12 +56,42 @@ def test_admin_gated_pages_accessible_in_tests(client):
 
 
 def test_nav_has_quick_access_group_with_collect_history(client):
-    """좌측 nav 상단에 '자주 쓰는' 그룹 + 수집 이력 링크가 위쪽에 있다."""
+    """좌측 nav 상단 '자주 쓰는' 그룹에 수집 이력 링크가 위쪽에 있다."""
     html = client.get("/seller/dashboard").get_data(as_text=True)
     assert "자주 쓰는" in html
-    # '자주 쓰는' 그룹이 '운영' 그룹보다 먼저 등장(위쪽)
-    assert html.index("자주 쓰는") < html.index("/seller/collect-history")
-    assert html.index("/seller/collect-history") < html.index(">운영<") if ">운영<" in html else True
+    # '자주 쓰는' 그룹이 수집 이력 링크보다 먼저 등장(위쪽)
+    assert html.index("자주 쓰는") < html.index("/seller/collect/history")
+    # 수집 이력 링크가 nav 상단부(운영 그룹보다 위)에 있다
+    if "운영" in html:
+        assert html.index("/seller/collect/history") < html.rindex("운영")
+
+
+def test_nav_no_duplicate_collector_link(client):
+    """'수집기'/'상품 수집기' 중복 제거 — nav에는 '상품 수집기'만 남는다."""
+    html = client.get("/seller/dashboard").get_data(as_text=True)
+    assert "<span>상품 수집기</span>" in html
+    assert "<span>수집기</span>" not in html  # 중복 라벨 제거됨
+
+
+def test_collect_history_shows_thumbnails_and_bulk_select_all(client):
+    """수집 이력: 이름 옆 썸네일(여러 장) + 일괄 등록 모달 '전체 선택' 버튼."""
+    from unittest.mock import patch
+    rows = [{
+        "id": "abc123", "collected_at": "2026-06-19T12:00:00+00:00", "source": "extension",
+        "domain": "shop.example", "url": "https://shop.example/p/1", "title": "가방",
+        "image_url": "https://i/rep.jpg", "price": "100", "currency": "JPY", "status": "ok",
+        "preview_url": "/seller/collect/preview/abc123",
+        "extra_json": '{"images": ["https://i/rep.jpg", "https://i/2.jpg", "https://i/3.jpg"]}',
+        "seller_id": "",
+    }]
+    with patch("src.seller_console.collect_history_store.list_items", return_value=rows), \
+         patch("src.seller_console.collect_history_store.summary", return_value={"total": 1, "today": 1, "domains": 1, "by_source": {"extension": 1, "bookmarklet": 0, "manual": 0, "bulk": 0}}), \
+         patch("src.seller_console.collect_history_store.distinct_domains", return_value=["shop.example"]):
+        resp = client.get("/seller/collect/history")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "https://i/2.jpg" in html and "https://i/3.jpg" in html   # 추가 썸네일
+    assert "toggleAllBulkMarkets" in html                            # 모달 전체 선택
 
 
 def test_market_modal_has_select_all_button(client):


### PR DESCRIPTION
오너 리포트(2026-06-19 라이브 스크린샷) 후속 일괄 수정입니다.

## 코드로 고친 것 ✅
1. **nav 버튼 중복(수집기/상품 수집기)** — 같은 페이지라 '자주 쓰는'의 **상품 수집기** 하나로 통합. 카탈로그/마켓/대시보드 중복도 정리.
2. **'수집 이력' 좌측 버튼 불 안 들어옴** — 실제 경로는 `/seller/collect/history`인데 active 조건이 `/seller/collect-history`(하이픈)였음 → 링크/active 수정. 수집 이력 페이지에서 '상품 수집기'가 잘못 켜지던 것도 분리.
3. **일괄 마켓 등록 모달(3번째 이미지)에 '전체 선택' 버튼** 추가.
4. **수집 이력 목록에 썸네일** — 상품명 옆에 수집 이미지 최대 5장(대표 52px + 추가 34px). 사람이 이미지로 한눈에 확인.
5. **크롬확장 중앙 바 끄고/켜기** — 닫으면 좌상단에 작은 **'수집 열기' 알약**을 남겨 다시 켤 수 있게(선택 유지). 1.4.4→**1.4.5** (크롬에서 확장 새로고침 필요).
6. **일괄 업로드 'Unexpected token <'** — 서버가 HTML(타임아웃/오류) 응답 시 파싱 에러 대신 명확한 안내(502/504면 '상품 수 줄이기').

## 오너 설정/후속이 필요한 것 (코드 아님) ⚠️
- **구글 로그인 창 안 뜸** — 코드는 정상. 구글만 `is_configured=False`라 버튼이 비활성('설정 필요')입니다. 카카오/네이버처럼 **`GOOGLE_OAUTH_CLIENT_ID` + `GOOGLE_OAUTH_CLIENT_SECRET`**(둘 다) 설정 + 구글 콘솔에 로그인 페이지 진단 패널의 redirect_uri 등록이 필요합니다. (구글은 secret까지 있어야 활성화)
- **애플 로그인 추가** — Apple Developer 등록 + JWT client_secret 발급이 선행돼야 해서 별도 PR로 진행 권장.
- **편집·등록 404(일부 항목)** — 멀티 워커 환경에서 수집 항목이 한 워커 메모리에만 있으면 다른 워커가 404를 냅니다. 영구 저장(`GOOGLE_SHEET_ID`)이 설정돼야 모든 워커가 같은 이력을 봅니다. 미설정이면 파일 기반 폴백을 다음 PR로 추가하겠습니다.
- **토큰 발행 이력** — 이미 **API 토큰** 페이지에 발급 토큰 목록(프리픽스/발급일/마지막 사용)이 표시됩니다.

## 테스트
- `tests/test_nav_and_seller_access.py`에 nav/접근/썸네일/모달 케이스 추가.
- 전체 `python -m pytest tests/ -q` → **10013 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_