### PR TITLE
feat(design): 로그인·랜딩 먹+금 다크 vault + 운영자 진단 숨김 (Phase 235, §2 chunk2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,12 @@
     - ✅ §2 chunk1 — 디자인 토큰·폰트(Phase 234): `app.css` 토큰을 먹(#1a1714)/한지(#f5efe3)/금(#c9a24b) + **청록 Primary(#0f9d8c)**로
       교체, Noto Serif KR(디스플레이)·Pretendard(본문) 로드, h1/디스플레이=세리프. `console.css`가 토큰 상속(콘솔=한지 라이트).
       ※ CSS만 — 브랜드 문자열/템플릿 구조 미변경(다음 chunk). 랜딩/로그인 먹 다크 vault도 다음 chunk.
-    - ⏳ 다음: §2 chunk2 공통 셸/로그인·랜딩(먹+금 다크) → chunk3 리브랜딩 문자열(코고가네/KOHgogane,
-      `branding.py` 기본값+하드코딩 30곳+테스트 5곳) → §3 일괄관리 …
+    - ✅ §2 chunk2 — 로그인·랜딩 먹+금 다크 vault(Phase 235): `auth/login.html`·`templates/landing.html`을
+      먹(#1a1714) 다크 + 금빛 글로우 + 한지 텍스트 + 청록 CTA로. 로그인 운영자 OAuth 진단은 일반 첫 화면에서
+      숨김 → `?diag=1` 또는 관리자 세션에서만(`login()` 게이트). theme-color 순흑#020010→먹#1a1714.
+      landing은 _base_app 공유(에러페이지)라 다크는 landing head에 스코프. 랜딩에 Beta 배지.
+    - ⏳ 다음: §2 chunk3 리브랜딩 문자열(코고가네/KOHgogane — `branding.py` 기본값+하드코딩 30곳+테스트 5곳) +
+      공통 셸 마감 → §3 수집상품 일괄관리(퍼센티 동등 버튼) …
 
 
 ## 📌 마켓 연동 — 검증된 팩트 (2026-06-14)

--- a/src/auth/templates/auth/login.html
+++ b/src/auth/templates/auth/login.html
@@ -8,24 +8,45 @@
   <link rel="icon" type="image/x-icon" href="/seller/static/favicon.ico?v=172">
   <link rel="apple-touch-icon" href="/seller/static/apple-touch-icon.png?v=172">
   <link rel="manifest" href="/seller/static/manifest.webmanifest?v=172">
-  <meta name="theme-color" content="#020010">
+  <meta name="theme-color" content="#1a1714">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='app.css') }}">
   <style>
-    .auth-page { min-height: 100vh; padding: 4rem 1rem; }
+    /* 먹(ink) 다크 "vault" 무드 — 금빛 글로우 + 한지 텍스트 (KOHgogane 브리프 §2.2) */
+    .auth-page {
+      min-height: 100vh; padding: 4rem 1rem;
+      background:
+        radial-gradient(1200px 480px at 50% -8%, rgba(201,162,75,.16), transparent 60%),
+        linear-gradient(180deg, #1a1714 0%, #211c17 60%, #14110e 100%) fixed;
+      color: #f5efe3;
+    }
     .auth-card { max-width: 460px; margin: 0 auto; }
-    .auth-panel { border-radius: 1rem; border: 1px solid var(--pc-color-border); box-shadow: var(--pc-shadow-md); }
+    .auth-panel {
+      border-radius: 1.1rem;
+      border: 1px solid rgba(201,162,75,.35);
+      background: #241f1a;
+      box-shadow: 0 24px 60px rgba(0,0,0,.45), inset 0 1px 0 rgba(245,239,227,.04);
+      color: #f5efe3;
+    }
+    .auth-brand { font-family: var(--pc-font-display, 'Noto Serif KR', serif); color: #e8d6a8; letter-spacing: .01em; }
+    .auth-sub { color: #c9bda6; }
+    .auth-panel .form-label { color: #e7ddc9; }
+    .auth-panel .form-control { background: #efe7d6; border-color: #c9a24b40; color: #1a1714; }
+    .auth-panel .form-control::placeholder { color: #9a8f7c; }
+    .auth-panel .form-check-label { color: #d9cfba; }
+    .auth-foot a { color: #c9bda6; }
+    .auth-foot a:hover { color: #e8d6a8; }
     .social-btn { font-size: 1rem; padding: 0.6rem 1.2rem; }
-    .divider { display: flex; align-items: center; gap: 12px; color: #aaa; margin: 1rem 0; }
-    .divider::before, .divider::after { content: ''; flex: 1; border-top: 1px solid #ddd; }
+    .divider { display: flex; align-items: center; gap: 12px; color: #b7a98c; margin: 1rem 0; }
+    .divider::before, .divider::after { content: ''; flex: 1; border-top: 1px solid rgba(201,162,75,.28); }
   </style>
 </head>
 <body class="auth-page">
 <div class="auth-card">
   <div class="card auth-panel border-0">
     <div class="card-body p-4">
-      <h4 class="fw-bold text-center mb-1">🛒 코가네 퍼센티</h4>
-      <p class="text-center text-muted small mb-4">셀러 콘솔 로그인</p>
+      <h4 class="auth-brand fw-bold text-center mb-1">🛒 코가네 퍼센티</h4>
+      <p class="auth-sub text-center small mb-4">셀러 콘솔 로그인</p>
 
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% for cat, msg in messages %}
@@ -131,7 +152,7 @@
         })();
       </script>
 
-      <div class="text-center mt-3 small">
+      <div class="auth-foot text-center mt-3 small">
         <a href="/auth/signup" class="text-decoration-none">회원가입</a>
         &nbsp;·&nbsp;
         <button type="button" class="btn btn-link btn-sm p-0 align-baseline text-decoration-none text-muted"
@@ -189,7 +210,7 @@
       </div>
     </div>
   </div>
-  <p class="text-center text-muted small mt-3">
+  <p class="auth-foot text-center small mt-3">
     <a href="/" class="text-decoration-none">← 메인으로</a>
   </p>
 </div>

--- a/src/auth/views.py
+++ b/src/auth/views.py
@@ -480,11 +480,22 @@ def login():
     kakao_status = _provider_status("kakao")
     google_status = _provider_status("google")
     naver_status = _provider_status("naver")
-    oauth_runtime = {
-        "kakao": _oauth_runtime("kakao"),
-        "google": _oauth_runtime("google"),
-        "naver": _oauth_runtime("naver"),
-    }
+    # 운영자용 OAuth 진단(콜백 URI/client_id)은 일반 사용자 첫 화면에 노출하지 않는다
+    # (KOHgogane 브리프 §2.4). 관리자 세션이거나 ?diag=1 일 때만 렌더한다.
+    show_diag = request.args.get("diag") == "1"
+    if not show_diag:
+        try:
+            from .admin_resolver import is_admin_session
+            show_diag = is_admin_session(session)[0]
+        except Exception:
+            show_diag = False
+    oauth_runtime = None
+    if show_diag:
+        oauth_runtime = {
+            "kakao": _oauth_runtime("kakao"),
+            "google": _oauth_runtime("google"),
+            "naver": _oauth_runtime("naver"),
+        }
     return render_template(
         "auth/login.html",
         next_url=next_url,

--- a/src/templates/landing.html
+++ b/src/templates/landing.html
@@ -1,19 +1,52 @@
-{# 랜딩 페이지 — Phase 148 #}
+{# 랜딩 페이지 — 먹+금 다크 vault (KOHgogane 브리프 §2.2 / Phase 235) #}
 {% extends "_base_app.html" %}
 
-{% block title %}Proxy Commerce — Kohgane Percentii{% endblock %}
+{% block title %}{{ brand_name|default('Proxy Commerce', true) }} — Kohgane Percentii{% endblock %}
 {% block head %}
 <link rel="privacy-policy" href="/privacy">
+<style>
+  /* 입구(랜딩)는 먹 다크 vault — 금빛 글로우 + 한지 텍스트 + 청록 CTA. 작업 화면은 한지 라이트. */
+  body.bg-light {
+    background:
+      radial-gradient(1100px 460px at 50% -6%, rgba(201,162,75,.18), transparent 60%),
+      linear-gradient(180deg, #1a1714 0%, #211c17 55%, #14110e 100%) fixed !important;
+    color: #f5efe3;
+  }
+  .vault-hero h1 { font-family: var(--pc-font-display, 'Noto Serif KR', serif); color: #ecdcb0; }
+  .vault-hero .lead { color: #c9bda6; }
+  .vault-rule { height: 1px; width: 120px; margin: 1.25rem auto; background: linear-gradient(90deg, transparent, #c9a24b, transparent); }
+  .vault-card {
+    background: #241f1a;
+    border: 1px solid rgba(201,162,75,.30) !important;
+    color: #f5efe3;
+    transition: border-color .18s ease, transform .18s ease, box-shadow .18s ease;
+  }
+  .vault-card:hover {
+    border-color: #0f9d8c !important;
+    transform: translateY(-3px);
+    box-shadow: 0 18px 40px rgba(0,0,0,.45);
+  }
+  .vault-card .card-title { color: #ecdcb0; }
+  .vault-card .card-text { color: #c0b49d !important; }
+  .vault-foot, .vault-foot a { color: #b7a98c !important; }
+  .vault-foot a:hover { color: #ecdcb0 !important; }
+  .vault-foot hr { border-color: rgba(201,162,75,.25); }
+  .vault-beta {
+    display: inline-block; font-size: .7rem; letter-spacing: .12em; text-transform: uppercase;
+    color: #1a1714; background: #c9a24b; border-radius: 999px; padding: .12rem .6rem; font-weight: 700;
+    vertical-align: middle; margin-left: .4rem;
+  }
+</style>
 {% endblock %}
 
 {% block content %}
-<div class="row justify-content-center mt-3">
+<div class="row justify-content-center mt-4 vault-hero">
   <div class="col-lg-8 text-center">
     <h1 class="display-5 fw-bold mb-2">
-      <i class="bi bi-bag-check-fill text-teal"></i>
-      Proxy Commerce
+      {{ brand_name|default('Proxy Commerce', true) }}<span class="vault-beta">Beta</span>
     </h1>
-    <p class="lead text-muted mb-5">퍼센티 스타일 셀러 자동화 SaaS — Kohgane Percentii</p>
+    <div class="vault-rule"></div>
+    <p class="lead mb-5">수집부터 등록까지 — 한 곳에서. 퍼센티 스타일 셀러 자동화 SaaS.</p>
   </div>
 </div>
 
@@ -21,11 +54,11 @@
   {# 셀러 콘솔 카드 #}
   <div class="col-sm-6 col-lg-3">
     <a href="/seller/" class="text-decoration-none">
-      <div class="card h-100 shadow-sm border-0 landing-card">
+      <div class="card h-100 shadow-sm vault-card landing-card">
         <div class="card-body text-center py-4">
           <div class="fs-1 mb-3">🛒</div>
           <h5 class="card-title fw-bold">셀러 콘솔</h5>
-          <p class="card-text text-muted small">상품 수집 · 마진 계산 · 마켓 업로드</p>
+          <p class="card-text small">상품 수집 · 마진 계산 · 마켓 업로드</p>
         </div>
       </div>
     </a>
@@ -34,11 +67,11 @@
   {# 관리자 패널 카드 #}
   <div class="col-sm-6 col-lg-3">
     <a href="/admin/" class="text-decoration-none">
-      <div class="card h-100 shadow-sm border-0 landing-card">
+      <div class="card h-100 shadow-sm vault-card landing-card">
         <div class="card-body text-center py-4">
           <div class="fs-1 mb-3">🛠</div>
           <h5 class="card-title fw-bold">관리자 패널</h5>
-          <p class="card-text text-muted small">주문 · 재고 · 매출 대시보드</p>
+          <p class="card-text small">주문 · 재고 · 매출 대시보드</p>
         </div>
       </div>
     </a>
@@ -47,11 +80,11 @@
   {# API 문서 카드 #}
   <div class="col-sm-6 col-lg-3">
     <a href="/api/docs" class="text-decoration-none">
-      <div class="card h-100 shadow-sm border-0 landing-card">
+      <div class="card h-100 shadow-sm vault-card landing-card">
         <div class="card-body text-center py-4">
           <div class="fs-1 mb-3">📚</div>
           <h5 class="card-title fw-bold">API 문서</h5>
-          <p class="card-text text-muted small">200+ 엔드포인트 · 검색 · 그룹화</p>
+          <p class="card-text small">200+ 엔드포인트 · 검색 · 그룹화</p>
         </div>
       </div>
     </a>
@@ -60,11 +93,11 @@
   {# 시스템 상태 카드 #}
   <div class="col-sm-6 col-lg-3">
     <a href="/health/deep" class="text-decoration-none">
-      <div class="card h-100 shadow-sm border-0 landing-card">
+      <div class="card h-100 shadow-sm vault-card landing-card">
         <div class="card-body text-center py-4">
           <div class="fs-1 mb-3">💚</div>
           <h5 class="card-title fw-bold">시스템 상태</h5>
-          <p class="card-text text-muted small">헬스체크 · 의존성 · 업타임</p>
+          <p class="card-text small">헬스체크 · 의존성 · 업타임</p>
         </div>
       </div>
     </a>
@@ -72,14 +105,14 @@
 </div>
 
 {# 푸터 #}
-<div class="row mt-5">
-  <div class="col text-center text-muted small">
+<div class="row mt-5 vault-foot">
+  <div class="col text-center small">
     <hr>
     <span>Phase {{ current_phase }}</span> &nbsp;·&nbsp;
     <span>{{ version }}</span> &nbsp;·&nbsp;
-    <a href="/privacy" class="text-muted">개인정보처리방침</a> &nbsp;·&nbsp;
-    <a href="/terms" class="text-muted">이용약관</a> &nbsp;·&nbsp;
-    <a href="https://github.com/Kohgane/proxy-commerce" class="text-muted" target="_blank" rel="noopener">
+    <a href="/privacy">개인정보처리방침</a> &nbsp;·&nbsp;
+    <a href="/terms">이용약관</a> &nbsp;·&nbsp;
+    <a href="https://github.com/Kohgane/proxy-commerce" target="_blank" rel="noopener">
       <i class="bi bi-github"></i> GitHub
     </a>
   </div>

--- a/tests/test_callback_uri.py
+++ b/tests/test_callback_uri.py
@@ -256,7 +256,8 @@ class TestLoginPageRedirectUriSmoke:
             yield c
 
     def test_login_page_contains_callback_uri(self, client):
-        rv = client.get("/auth/login")
+        # 진단(콜백 URI/client_id)은 운영자용 — ?diag=1 일 때만 렌더(브리프 §2.4).
+        rv = client.get("/auth/login?diag=1")
         assert rv.status_code == 200
         body = rv.data.decode("utf-8", errors="replace")
         # redirect_uris 섹션 또는 콜백 URI 문자열이 포함되어야 함
@@ -269,10 +270,17 @@ class TestLoginPageRedirectUriSmoke:
         monkeypatch.delenv("NAVER_CLIENT_ID", raising=False)
         monkeypatch.delenv("NAVER_OAUTH_CLIENT_ID", raising=False)
 
-        rv = client.get("/auth/login")
+        rv = client.get("/auth/login?diag=1")
 
         assert rv.status_code == 200
         body = rv.get_data(as_text=True)
         assert "google-runtime-client-id" in body
         assert "kakao-runtime-client-id" in body
         assert "미설정 — NAVER_CLIENT_ID / NAVER_OAUTH_CLIENT_ID" in body
+
+    def test_login_page_hides_diagnostics_for_general_users(self, client):
+        # 일반 사용자(미관리자·diag 없음) 첫 화면엔 운영자 진단 텍스트가 없어야 한다.
+        rv = client.get("/auth/login")
+        assert rv.status_code == 200
+        body = rv.get_data(as_text=True)
+        assert "OAuth 콜백 URI" not in body

--- a/tests/test_phase_163_favicon_assets.py
+++ b/tests/test_phase_163_favicon_assets.py
@@ -87,4 +87,5 @@ def test_public_templates_use_cache_busted_favicon_links():
         assert "favicon.ico?v=172" in text
         assert "apple-touch-icon.png?v=172" in text
         assert "manifest.webmanifest?v=172" in text
-        assert 'content="#020010"' in text
+        # 다크 테마 컬러 — 순흑 #020010 폐기(KOHgogane 브리프 §2.2) → 따뜻한 먹(#1a1714)도 허용.
+        assert ('content="#020010"' in text) or ('content="#1a1714"' in text)


### PR DESCRIPTION
KOHgogane 브리프 v2 **§2 디자인 시스템 — 둘째 덩어리(입구 = 로그인/랜딩 먹+금 다크 vault)**입니다.

작업 화면(콘솔)은 한지 라이트 가독성 유지 — **"럭셔리는 입구에서, 일은 편하게"**(브리프 부록 A). 입구(로그인/랜딩)만 catdyy식 먹 다크로.

## 변경
- **`auth/login.html`** — 먹(`#1a1714`) 다크 + **금빛 radial glow** + 한지 텍스트 + 금 테두리 패널. 브랜드 타이틀 세리프(Noto Serif KR)+금, 입력칸은 한지 톤(가독성), 로그인 CTA = **청록 Primary**(토큰). `theme-color` 순흑 `#020010` → 따뜻한 먹 `#1a1714`(브리프 §2.2 "순흑 폐기").
- **운영자 OAuth 진단 숨김**(브리프 §2.4) — 콜백 URI/client_id 진단 박스를 일반 사용자 첫 화면에서 제거. `?diag=1` 또는 **관리자 세션**일 때만 렌더. (운영자는 `/auth/login?diag=1`로 진단 확인)
- **`templates/landing.html`** — 먹 다크 vault 히어로(세리프 타이틀 + 금 디바이더), 청록 hover 카드, **Beta 배지**. `_base_app`(404/500 공유)을 건드리지 않도록 다크 스타일은 landing `head` 블록에 스코프.

## 보존
개인정보처리방침/이용약관/`/seller/` 링크, `privacy-policy` 메타, 소셜/이메일 로그인, 자동 로그인 체크 — 모두 유지.

## 테스트
- 진단 스모크 2건 → `?diag=1`로 갱신 + "일반유저 진단 숨김" 케이스 추가.
- `theme-color` 다크 허용(`#020010`/`#1a1714`).
- 전체 `pytest` **10015 passed**.

## 다음 덩어리
§2 chunk3 리브랜딩 문자열(코고가네/KOHgogane) + 공통 셸 마감 → §3 수집상품 일괄관리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_