### PR TITLE
feat(bulk): 수집 이력 일괄 삭제 — 셀러 격리 + 확인 모달 (Phase 237, §3 chunk1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,11 @@
       markets_guide SVG, admin navbar, api docs title. 테스트 갱신(pwa·seller_console). 전체 10015 passed.
       ※ 남은 잔재(비-UI, env override 가능, 후속): CLI 설명·slack/discord bot username·grafana json·
         SEO_SITE_NAME·SMTP_FROM_NAME·export_manager sender 등 13곳(.py) — 사용자 화면 아님.
-    - ⏳ 다음: §3 수집상품 일괄관리(퍼센티 동등 — 일괄 업로드/삭제/카테고리/가격/번역/복제 + 다중선택·액션바·행별결과) …
+    - ⏳ §3 수집상품 일괄관리(퍼센티 동등) 진행 중:
+      - ✅ chunk1 — 일괄 삭제(Phase 237): `collect_history_store.delete(item_ids, seller_id)`(셀러 격리, 시트/메모리),
+        `POST /seller/collect/bulk-delete`, collect_history.html에 '🗑 선택 삭제' 버튼+확인 모달+행 즉시 제거,
+        액션바 sticky(pc-bulk-toolbar). (일괄 마켓 등록·전체선택은 기존)
+      - ⏳ 다음: 일괄 카테고리 지정 → 일괄 번역 → 일괄 가격/마진 → 일괄 상태변경/복제 + 검색/정렬/페이지당.
 
 
 ## 📌 마켓 연동 — 검증된 팩트 (2026-06-14)

--- a/src/seller_console/collect_history_store.py
+++ b/src/seller_console/collect_history_store.py
@@ -219,6 +219,60 @@ def update(item_id: str, *, seller_id: Optional[str] = None, **fields) -> bool:
     return False
 
 
+def delete(item_ids, *, seller_id: Optional[str] = None) -> int:
+    """수집 이력에서 여러 항목을 삭제 (일괄 삭제 — Phase 237).
+
+    seller_id 지정 시 해당 셀러 항목만 삭제(타 셀러 차단).
+
+    Returns:
+        삭제된 건수.
+    """
+    ids = {str(i) for i in (item_ids or []) if str(i).strip()}
+    if not ids:
+        return 0
+
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            _ensure_headers(ws)
+            values = ws.get_all_values()
+            deleted = 0
+            if values:
+                header = values[0]
+                col_idx = {h: i for i, h in enumerate(header)}
+                id_i = col_idx.get("id")
+                sid_i = col_idx.get("seller_id")
+                # 행 번호가 밀리지 않도록 아래에서 위로 삭제.
+                to_delete = []
+                for r, row in enumerate(values[1:], start=2):
+                    if id_i is None or id_i >= len(row) or row[id_i] not in ids:
+                        continue
+                    if seller_id is not None and sid_i is not None:
+                        row_sid = row[sid_i] if sid_i < len(row) else ""
+                        if str(row_sid or "") != str(seller_id):
+                            continue
+                    to_delete.append(r)
+                for r in sorted(to_delete, reverse=True):
+                    ws.delete_rows(r)
+                    deleted += 1
+            if deleted:
+                logger.info("수집 이력 삭제: %d건", deleted)
+            return deleted
+        except Exception as exc:
+            logger.warning("수집 이력 Sheets 삭제 실패: %s", exc)
+
+    before = len(_in_memory)
+    kept = []
+    for row in _in_memory:
+        if row.get("id") in ids and (
+            seller_id is None or str(row.get("seller_id", "") or "") == str(seller_id)
+        ):
+            continue
+        kept.append(row)
+    _in_memory[:] = kept
+    return before - len(_in_memory)
+
+
 def summary(days: int = 30, seller_id: Optional[str] = None) -> dict:
     """기간별 요약 통계."""
     items = list_items(days=days, seller_id=seller_id)

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -98,10 +98,13 @@
   {% if items %}
   <div class="card">
     <div class="card-body p-0">
-      <div class="d-flex flex-wrap align-items-center gap-2 p-2 border-bottom bg-light">
+      <div class="pc-bulk-toolbar d-flex flex-wrap align-items-center gap-2 p-2 border-bottom">
         <span class="small text-muted">선택 <strong id="selCount">0</strong>개</span>
         <button type="button" class="btn btn-success btn-sm" id="bulkUploadBtn" onclick="openBulkUploadModal()" disabled>
           📤 선택 상품 일괄 마켓 등록
+        </button>
+        <button type="button" class="btn btn-outline-danger btn-sm" id="bulkDeleteBtn" onclick="openBulkDeleteModal()" disabled>
+          🗑 선택 삭제
         </button>
       </div>
       <div class="table-responsive">
@@ -234,6 +237,26 @@
   </div>
 </div>
 
+<!-- 일괄 삭제 확인 모달 -->
+<div class="modal fade" id="bulkDeleteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">🗑 선택 상품 삭제</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        <p class="mb-2">선택한 <strong id="delSelCount">0</strong>개 수집 항목을 <strong>삭제</strong>합니다.</p>
+        <p class="small text-muted mb-0">수집 이력에서만 제거되며, 이미 마켓에 등록한 상품은 영향받지 않습니다. 되돌릴 수 없습니다.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-danger" id="bulkDeleteConfirm" onclick="runBulkDelete()">🗑 삭제</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script>
 function selectedItemIds() {
   return Array.from(document.querySelectorAll('.row-chk:checked')).map(c => c.value);
@@ -244,6 +267,8 @@ function refreshSelCount() {
   if (el) el.textContent = n;
   const btn = document.getElementById('bulkUploadBtn');
   if (btn) btn.disabled = n === 0;
+  const del = document.getElementById('bulkDeleteBtn');
+  if (del) del.disabled = n === 0;
 }
 document.addEventListener('DOMContentLoaded', function () {
   const all = document.getElementById('chkAll');
@@ -253,6 +278,44 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   document.querySelectorAll('.row-chk').forEach(c => c.addEventListener('change', refreshSelCount));
 });
+function openBulkDeleteModal() {
+  const ids = selectedItemIds();
+  if (!ids.length) { pcToast('삭제할 상품을 먼저 선택하세요.', 'warning'); return; }
+  document.getElementById('delSelCount').textContent = ids.length;
+  new bootstrap.Modal(document.getElementById('bulkDeleteModal')).show();
+}
+async function runBulkDelete() {
+  const ids = selectedItemIds();
+  if (!ids.length) return;
+  const btn = document.getElementById('bulkDeleteConfirm');
+  setButtonLoading(btn, true, '삭제 중…');
+  try {
+    const resp = await fetch('/seller/collect/bulk-delete', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({item_ids: ids}),
+    });
+    const ctype = resp.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) {
+      pcToast(`삭제 요청 실패 (HTTP ${resp.status}).`, 'error'); return;
+    }
+    const data = await resp.json();
+    if (!data.ok) { pcToast(data.error || '삭제 실패', 'error'); return; }
+    // 삭제된 행을 화면에서 제거
+    ids.forEach(id => {
+      const chk = document.querySelector(`.row-chk[value="${id}"]`);
+      const tr = chk && chk.closest('tr');
+      if (tr) tr.remove();
+    });
+    bootstrap.Modal.getInstance(document.getElementById('bulkDeleteModal'))?.hide();
+    refreshSelCount();
+    pcToast(`${data.deleted}개 항목을 삭제했습니다.`, 'success');
+  } catch (err) {
+    pcToast('삭제 요청 실패: ' + err.message, 'error');
+  } finally {
+    setButtonLoading(btn, false);
+  }
+}
+
 // 모달 '전체 선택' — 모든 마켓 체크 토글(전체선택↔전체해제).
 function toggleAllBulkMarkets() {
   const boxes = Array.from(document.querySelectorAll('.bulk-market-chk'));

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1748,6 +1748,32 @@ def collect_bulk_upload():
     return jsonify({"ok": True, "total": len(item_ids), "succeeded": succeeded, "results": results})
 
 
+@bp.post("/collect/bulk-delete")
+def collect_bulk_delete():
+    """수집 이력의 여러 항목을 일괄 삭제 (셀러 격리).
+
+    Request: {"item_ids": [...]}
+    Response: {"ok": true, "deleted": N}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids") if isinstance(data.get("item_ids"), list) else []
+    item_ids = [str(i) for i in item_ids if str(i).strip()][:1000]
+    if not item_ids:
+        return jsonify({"ok": False, "error": "삭제할 상품을 선택하세요."}), 400
+
+    try:
+        from . import collect_history_store
+        deleted = collect_history_store.delete(item_ids, seller_id=_seller_id())
+    except Exception as exc:
+        logger.warning("일괄 삭제 오류: %s", exc)
+        return jsonify({"ok": False, "error": "일괄 삭제 중 오류가 발생했습니다."}), 500
+
+    return jsonify({"ok": True, "deleted": deleted})
+
+
 @bp.get("/catalog")
 def catalog():
     """상품 카탈로그 페이지 (Phase 128) — Sheets catalog 워크시트 뷰."""

--- a/tests/test_collect_bulk_delete.py
+++ b/tests/test_collect_bulk_delete.py
@@ -1,0 +1,86 @@
+"""tests/test_collect_bulk_delete.py — 수집 이력 일괄 삭제 (Phase 237, 브리프 §3)."""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_store():
+    from src.seller_console import collect_history_store as chs
+    chs._in_memory.clear()
+    yield
+    chs._in_memory.clear()
+
+
+def _seed(chs, n=3, seller="s1"):
+    ids = []
+    for i in range(n):
+        ids.append(chs.append(source="manual", url=f"https://x/{i}", title=f"item{i}", seller_id=seller))
+    return ids
+
+
+def test_store_delete_removes_only_selected_and_seller_isolated():
+    from src.seller_console import collect_history_store as chs
+    a, b, c = _seed(chs, 3, seller="s1")
+    other = chs.append(source="manual", url="https://x/o", title="other", seller_id="s2")
+    # s1이 a,b 삭제 — c와 타 셀러 other는 유지
+    deleted = chs.delete([a, b], seller_id="s1")
+    assert deleted == 2
+    remaining_ids = {r["id"] for r in chs._in_memory}
+    assert a not in remaining_ids and b not in remaining_ids
+    assert c in remaining_ids and other in remaining_ids
+
+
+def test_store_delete_seller_isolation_blocks_other_seller():
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="x", seller_id="s1")
+    # 다른 셀러는 삭제 못 함
+    assert chs.delete([a], seller_id="s2") == 0
+    assert any(r["id"] == a for r in chs._in_memory)
+
+
+def test_bulk_delete_route_requires_ids(client):
+    r = client.post("/seller/collect/bulk-delete", json={"item_ids": []})
+    assert r.status_code == 400
+    assert r.get_json()["ok"] is False
+
+
+def test_bulk_delete_route_deletes(client):
+    from src.seller_console import collect_history_store as chs
+    ids = _seed(chs, 3, seller="default")  # _seller_id() 기본값
+    r = client.post("/seller/collect/bulk-delete", json={"item_ids": ids[:2]})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["ok"] is True
+    assert data["deleted"] == 2
+
+
+def test_history_page_has_bulk_delete_button(client):
+    from unittest.mock import patch
+    rows = [{
+        "id": "i1", "collected_at": "2026-06-19T12:00:00+00:00", "source": "manual",
+        "domain": "x", "url": "https://x/1", "title": "가방", "image_url": "", "price": "1",
+        "currency": "USD", "status": "ok", "preview_url": "/seller/collect/preview/i1",
+        "extra_json": "{}", "seller_id": "",
+    }]
+    with patch("src.seller_console.collect_history_store.list_items", return_value=rows), \
+         patch("src.seller_console.collect_history_store.summary", return_value={"total": 1, "today": 0, "domains": 1, "by_source": {"extension": 0, "bookmarklet": 0, "manual": 1, "bulk": 0}}), \
+         patch("src.seller_console.collect_history_store.distinct_domains", return_value=["x"]):
+        resp = client.get("/seller/collect/history")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "bulkDeleteBtn" in html
+    assert "runBulkDelete" in html


### PR DESCRIPTION
KOHgogane 브리프 v2 **§3 수집상품 일괄관리 — 첫 덩어리(일괄 삭제)**입니다.

퍼센티 동등 일괄 동작 중 가장 명백히 빠져 있던 **일괄 삭제**를 추가했습니다. (다중선택·전체선택·일괄 마켓 등록은 이미 있음)

## 변경
- **`collect_history_store.delete(item_ids, seller_id)`** — 셀러 격리 일괄 삭제. Sheets는 행을 아래→위로 안전하게 삭제, 인메모리 폴백. 반환 = 삭제 건수. 타 셀러 항목은 삭제 차단.
- **`POST /seller/collect/bulk-delete`** — 로그인 필수, 셀러별, 최대 1000건. JSON 응답.
- **`collect_history.html`** — 액션바에 **🗑 선택 삭제** 버튼(선택 0이면 비활성) + **확인 모달**("수집 이력에서만 제거 · 마켓 등록물 영향 없음 · 되돌릴 수 없음"). 성공 시 해당 행 즉시 제거 + 토스트. 액션바를 **sticky**(`pc-bulk-toolbar`)로 — 스크롤해도 보임. JSON 아닌 응답도 안전 처리.

## 테스트
- 신규 일괄 삭제 5케이스(셀러 격리·라우트·버튼 렌더).
- 전체 `pytest` **10020 passed**.

## 다음 덩어리 (§3 계속)
일괄 카테고리 지정 → 일괄 번역 → 일괄 가격/마진 → 일괄 상태변경/복제 + 검색/정렬/페이지당 개수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_