### PR TITLE
feat(bulk): 수집 이력 일괄 카테고리 지정(수동+자동 분류) (Phase 238, §3 chunk2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,10 @@
       - ✅ chunk1 — 일괄 삭제(Phase 237): `collect_history_store.delete(item_ids, seller_id)`(셀러 격리, 시트/메모리),
         `POST /seller/collect/bulk-delete`, collect_history.html에 '🗑 선택 삭제' 버튼+확인 모달+행 즉시 제거,
         액션바 sticky(pc-bulk-toolbar). (일괄 마켓 등록·전체선택은 기존)
-      - ⏳ 다음: 일괄 카테고리 지정 → 일괄 번역 → 일괄 가격/마진 → 일괄 상태변경/복제 + 검색/정렬/페이지당.
+      - ✅ chunk2 — 일괄 카테고리 지정(Phase 238): `POST /seller/collect/bulk-category`(item_ids + category_code,
+        또는 auto=자동분류 category_classifier). 각 항목 extra_json에 category_code 머지(셀러 격리). UI '🏷 카테고리
+        지정' 버튼+모달(드롭다운 CATEGORY_OPTIONS + 🔮자동분류 체크).
+      - ⏳ 다음: 일괄 번역 → 일괄 가격/마진 → 일괄 상태변경/복제 + 검색/정렬/페이지당.
 
 
 ## 📌 마켓 연동 — 검증된 팩트 (2026-06-14)

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -103,6 +103,9 @@
         <button type="button" class="btn btn-success btn-sm" id="bulkUploadBtn" onclick="openBulkUploadModal()" disabled>
           📤 선택 상품 일괄 마켓 등록
         </button>
+        <button type="button" class="btn btn-outline-primary btn-sm" id="bulkCategoryBtn" onclick="openBulkCategoryModal()" disabled>
+          🏷 카테고리 지정
+        </button>
         <button type="button" class="btn btn-outline-danger btn-sm" id="bulkDeleteBtn" onclick="openBulkDeleteModal()" disabled>
           🗑 선택 삭제
         </button>
@@ -237,6 +240,35 @@
   </div>
 </div>
 
+<!-- 일괄 카테고리 지정 모달 -->
+<div class="modal fade" id="bulkCategoryModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">🏷 카테고리 일괄 지정</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted">선택한 <strong id="catSelCount">0</strong>개 상품에 카테고리를 지정합니다. 각 마켓 업로더가 이 코드를 자기 마켓 카테고리로 매핑합니다.</p>
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="checkbox" id="bulkCatAuto" onchange="document.getElementById('bulkCatSelect').disabled=this.checked">
+          <label class="form-check-label" for="bulkCatAuto">🔮 자동 분류 (제목·키워드로 각 상품 자동 판정)</label>
+        </div>
+        <label class="form-label small mb-1" for="bulkCatSelect">카테고리</label>
+        <select id="bulkCatSelect" class="form-select form-select-sm">
+          {% for c in category_options %}
+          <option value="{{ c.code }}">{{ c.label }} ({{ c.code }})</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="bulkCategoryConfirm" onclick="runBulkCategory()">적용</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- 일괄 삭제 확인 모달 -->
 <div class="modal fade" id="bulkDeleteModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
@@ -269,6 +301,8 @@ function refreshSelCount() {
   if (btn) btn.disabled = n === 0;
   const del = document.getElementById('bulkDeleteBtn');
   if (del) del.disabled = n === 0;
+  const cat = document.getElementById('bulkCategoryBtn');
+  if (cat) cat.disabled = n === 0;
 }
 document.addEventListener('DOMContentLoaded', function () {
   const all = document.getElementById('chkAll');
@@ -278,6 +312,37 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   document.querySelectorAll('.row-chk').forEach(c => c.addEventListener('change', refreshSelCount));
 });
+function openBulkCategoryModal() {
+  const ids = selectedItemIds();
+  if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }
+  document.getElementById('catSelCount').textContent = ids.length;
+  new bootstrap.Modal(document.getElementById('bulkCategoryModal')).show();
+}
+async function runBulkCategory() {
+  const ids = selectedItemIds();
+  if (!ids.length) return;
+  const auto = document.getElementById('bulkCatAuto').checked;
+  const code = document.getElementById('bulkCatSelect').value;
+  const btn = document.getElementById('bulkCategoryConfirm');
+  setButtonLoading(btn, true, '적용 중…');
+  try {
+    const resp = await fetch('/seller/collect/bulk-category', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({item_ids: ids, category_code: auto ? '' : code, auto: auto}),
+    });
+    const ctype = resp.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) { pcToast(`요청 실패 (HTTP ${resp.status}).`, 'error'); return; }
+    const data = await resp.json();
+    if (!data.ok) { pcToast(data.error || '카테고리 지정 실패', 'error'); return; }
+    bootstrap.Modal.getInstance(document.getElementById('bulkCategoryModal'))?.hide();
+    pcToast(`${data.updated}개 상품에 카테고리를 지정했습니다.`, 'success');
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
+  } finally {
+    setButtonLoading(btn, false);
+  }
+}
+
 function openBulkDeleteModal() {
   const ids = selectedItemIds();
   if (!ids.length) { pcToast('삭제할 상품을 먼저 선택하세요.', 'warning'); return; }

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1774,6 +1774,63 @@ def collect_bulk_delete():
     return jsonify({"ok": True, "deleted": deleted})
 
 
+@bp.post("/collect/bulk-category")
+def collect_bulk_category():
+    """수집 이력 여러 항목에 카테고리를 일괄 지정 (셀러 격리).
+
+    Request: {"item_ids": [...], "category_code": "BAG"}  또는  {"item_ids": [...], "auto": true}
+      - auto=true 면 각 항목 제목/키워드로 category_classifier.classify 자동 분류.
+    Response: {"ok": true, "updated": N, "results": [{id, ok, category_code}]}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids") if isinstance(data.get("item_ids"), list) else []
+    item_ids = [str(i) for i in item_ids if str(i).strip()][:1000]
+    category_code = str(data.get("category_code") or "").strip().upper()
+    auto = bool(data.get("auto"))
+    if not item_ids:
+        return jsonify({"ok": False, "error": "상품을 선택하세요."}), 400
+    if not auto and not category_code:
+        return jsonify({"ok": False, "error": "카테고리를 선택하거나 자동 분류를 켜세요."}), 400
+
+    import json as _json
+    from . import collect_history_store
+    from .category_classifier import classify as _classify
+    sid = _seller_id()
+    updated = 0
+    results = []
+    try:
+        for item_id in item_ids:
+            item = collect_history_store.get(item_id, seller_id=sid)
+            if not item:
+                results.append({"id": item_id, "ok": False, "error": "항목 없음"})
+                continue
+            try:
+                extra = _json.loads(item.get("extra_json") or "{}")
+            except (TypeError, ValueError):
+                extra = {}
+            code = category_code
+            if auto:
+                title = item.get("title") or extra.get("title_ko") or ""
+                kws = extra.get("keywords")
+                kw = ",".join(kws) if isinstance(kws, list) else (kws or "")
+                code = _classify(title, extra.get("description_ko") or extra.get("description") or "", kw).get("code", "GEN")
+            extra["category_code"] = code
+            ok = collect_history_store.update(
+                item_id, seller_id=sid, extra_json=_json.dumps(extra, ensure_ascii=False)
+            )
+            if ok:
+                updated += 1
+            results.append({"id": item_id, "ok": bool(ok), "category_code": code})
+    except Exception as exc:
+        logger.warning("일괄 카테고리 오류: %s", exc)
+        return jsonify({"ok": False, "error": "일괄 카테고리 지정 중 오류가 발생했습니다."}), 500
+
+    return jsonify({"ok": True, "updated": updated, "results": results})
+
+
 @bp.get("/catalog")
 def catalog():
     """상품 카탈로그 페이지 (Phase 128) — Sheets catalog 워크시트 뷰."""
@@ -4194,6 +4251,7 @@ def collect_history():
 
     from .upload_dispatcher import MARKET_LABELS, SUPPORTED_MARKETS
     upload_markets = [{"code": m, "label": MARKET_LABELS.get(m, m)} for m in SUPPORTED_MARKETS]
+    from .category_classifier import CATEGORY_OPTIONS
     return render_template(
         "collect_history.html",
         page="collect_history",
@@ -4202,6 +4260,7 @@ def collect_history():
         domains=domains,
         filters={"domain": domain, "source": source, "days": days},
         upload_markets=upload_markets,
+        category_options=CATEGORY_OPTIONS,
     )
 
 

--- a/tests/test_collect_bulk_category.py
+++ b/tests/test_collect_bulk_category.py
@@ -1,0 +1,81 @@
+"""tests/test_collect_bulk_category.py — 수집 이력 일괄 카테고리 지정 (Phase 238, 브리프 §3)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_store():
+    from src.seller_console import collect_history_store as chs
+    chs._in_memory.clear()
+    yield
+    chs._in_memory.clear()
+
+
+def test_bulk_category_explicit_code(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="무지 티셔츠", seller_id="default")
+    b = chs.append(source="manual", url="https://x/2", title="아무거나", seller_id="default")
+    r = client.post("/seller/collect/bulk-category", json={"item_ids": [a, b], "category_code": "CLO"})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["ok"] is True and data["updated"] == 2
+    for it in chs._in_memory:
+        assert json.loads(it["extra_json"])["category_code"] == "CLO"
+
+
+def test_bulk_category_auto_classifies_by_title(client):
+    from src.seller_console import collect_history_store as chs
+    bag = chs.append(source="manual", url="https://x/1", title="크로스백 가방", seller_id="default")
+    r = client.post("/seller/collect/bulk-category", json={"item_ids": [bag], "auto": True})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["ok"] is True
+    code = json.loads(chs._in_memory[0]["extra_json"])["category_code"]
+    assert code == "BAG"
+
+
+def test_bulk_category_requires_code_or_auto(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="x", seller_id="default")
+    r = client.post("/seller/collect/bulk-category", json={"item_ids": [a]})
+    assert r.status_code == 400
+    assert r.get_json()["ok"] is False
+
+
+def test_bulk_category_requires_ids(client):
+    r = client.post("/seller/collect/bulk-category", json={"item_ids": [], "category_code": "BAG"})
+    assert r.status_code == 400
+
+
+def test_history_page_has_bulk_category_ui(client):
+    from unittest.mock import patch
+    rows = [{
+        "id": "i1", "collected_at": "2026-06-19T12:00:00+00:00", "source": "manual",
+        "domain": "x", "url": "https://x/1", "title": "가방", "image_url": "", "price": "1",
+        "currency": "USD", "status": "ok", "preview_url": "/seller/collect/preview/i1",
+        "extra_json": "{}", "seller_id": "",
+    }]
+    with patch("src.seller_console.collect_history_store.list_items", return_value=rows), \
+         patch("src.seller_console.collect_history_store.summary", return_value={"total": 1, "today": 0, "domains": 1, "by_source": {"extension": 0, "bookmarklet": 0, "manual": 1, "bulk": 0}}), \
+         patch("src.seller_console.collect_history_store.distinct_domains", return_value=["x"]):
+        resp = client.get("/seller/collect/history")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "bulkCategoryBtn" in html
+    assert "runBulkCategory" in html
+    assert "자동 분류" in html


### PR DESCRIPTION
KOHgogane 브리프 v2 **§3 수집상품 일괄관리 — 둘째 덩어리(일괄 카테고리 지정)**입니다.

선택한 상품들에 카테고리를 한 번에 지정합니다(퍼센티 동등).

## 변경
- **`POST /seller/collect/bulk-category`** — `item_ids` + `category_code`(수동 선택), 또는 `auto=true`면 각 항목 제목/키워드로 `category_classifier.classify` **자동 분류**. 각 항목 `extra_json`에 `category_code` 머지(셀러 격리, 최대 1000건). 각 마켓 업로더가 이 코드를 자기 마켓 카테고리로 매핑(쿠팡 CATEGORY_MAP 등).
- `collect_history` 뷰가 `CATEGORY_OPTIONS` 주입.
- **`collect_history.html`** — 액션바 **🏷 카테고리 지정** 버튼 + 모달(정규화 카테고리 드롭다운 + **🔮 자동 분류** 체크박스 → 체크 시 드롭다운 비활성). 적용 후 토스트.

## 테스트
- 신규 5케이스(수동 코드·자동 분류=BAG·검증·UI 렌더).
- 전체 `pytest` **10025 passed**.

## 다음 (§3 계속)
일괄 번역 → 일괄 가격/마진 → 일괄 상태변경/복제 + 검색/정렬/페이지당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_