### PR TITLE
feat(bulk): 수집 이력 일괄 한국어 번역 — 정직한 stub 폴백 (Phase 239, §3 chunk3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,10 @@
       - ✅ chunk2 — 일괄 카테고리 지정(Phase 238): `POST /seller/collect/bulk-category`(item_ids + category_code,
         또는 auto=자동분류 category_classifier). 각 항목 extra_json에 category_code 머지(셀러 격리). UI '🏷 카테고리
         지정' 버튼+모달(드롭다운 CATEGORY_OPTIONS + 🔮자동분류 체크).
-      - ⏳ 다음: 일괄 번역 → 일괄 가격/마진 → 일괄 상태변경/복제 + 검색/정렬/페이지당.
+      - ✅ chunk3 — 일괄 번역(Phase 239): `POST /seller/collect/bulk-translate`(AITranslator 재사용,
+        제목/설명 한국어 → extra_json title_ko/description_ko, 실번역 시 표시 제목 갱신). 정직성: 키 미설정
+        (stub/none) 시 원문 유지 + 안내 메시지(가짜 번역 없음). UI '🌐 한국어 번역' 버튼 → 행 제목 즉시 갱신.
+      - ⏳ 다음: 일괄 가격/마진 → 일괄 상태변경/복제 + 검색/정렬/페이지당.
 
 
 ## 📌 마켓 연동 — 검증된 팩트 (2026-06-14)

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -106,6 +106,9 @@
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkCategoryBtn" onclick="openBulkCategoryModal()" disabled>
           🏷 카테고리 지정
         </button>
+        <button type="button" class="btn btn-outline-primary btn-sm" id="bulkTranslateBtn" onclick="runBulkTranslate()" disabled>
+          🌐 한국어 번역
+        </button>
         <button type="button" class="btn btn-outline-danger btn-sm" id="bulkDeleteBtn" onclick="openBulkDeleteModal()" disabled>
           🗑 선택 삭제
         </button>
@@ -303,6 +306,8 @@ function refreshSelCount() {
   if (del) del.disabled = n === 0;
   const cat = document.getElementById('bulkCategoryBtn');
   if (cat) cat.disabled = n === 0;
+  const tr = document.getElementById('bulkTranslateBtn');
+  if (tr) tr.disabled = n === 0;
 }
 document.addEventListener('DOMContentLoaded', function () {
   const all = document.getElementById('chkAll');
@@ -312,6 +317,41 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   document.querySelectorAll('.row-chk').forEach(c => c.addEventListener('change', refreshSelCount));
 });
+async function runBulkTranslate() {
+  const ids = selectedItemIds();
+  if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }
+  const btn = document.getElementById('bulkTranslateBtn');
+  setButtonLoading(btn, true, '번역 중…');
+  try {
+    const resp = await fetch('/seller/collect/bulk-translate', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({item_ids: ids}),
+    });
+    const ctype = resp.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) { pcToast(`요청 실패 (HTTP ${resp.status}).`, 'error'); return; }
+    const data = await resp.json();
+    if (!data.ok) { pcToast(data.error || '번역 실패', 'error'); return; }
+    // 번역된 제목으로 행 갱신
+    (data.results || []).forEach(r => {
+      if (r.translated && r.title) {
+        const chk = document.querySelector(`.row-chk[value="${r.id}"]`);
+        const tr = chk && chk.closest('tr');
+        const a = tr && tr.querySelector('td a.fw-semibold');
+        if (a) { a.textContent = r.title; a.title = r.title; }
+      }
+    });
+    if (data.translated > 0) {
+      pcToast(`${data.translated}/${data.total}개 한국어로 번역했습니다.`, 'success');
+    } else {
+      pcToast(data.message || '번역기가 설정되지 않아 원문을 유지했습니다.', 'warning');
+    }
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
+  } finally {
+    setButtonLoading(btn, false);
+  }
+}
+
 function openBulkCategoryModal() {
   const ids = selectedItemIds();
   if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1831,6 +1831,82 @@ def collect_bulk_category():
     return jsonify({"ok": True, "updated": updated, "results": results})
 
 
+@bp.post("/collect/bulk-translate")
+def collect_bulk_translate():
+    """수집 이력 여러 항목의 제목/설명을 한국어로 일괄 번역 (셀러 격리).
+
+    Request: {"item_ids": [...]}
+    Response: {"ok": true, "updated": N, "translated": M, "total": T, "message"?: str}
+    정직성: OPENAI/DEEPL 키 미설정(stub) 시 원문 유지 + 안내(가짜 번역 없음).
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids") if isinstance(data.get("item_ids"), list) else []
+    item_ids = [str(i) for i in item_ids if str(i).strip()][:300]
+    if not item_ids:
+        return jsonify({"ok": False, "error": "상품을 선택하세요."}), 400
+
+    import json as _json
+    from . import collect_history_store
+    try:
+        from .ai.translator import AITranslator
+        translator = AITranslator()
+    except Exception as exc:
+        logger.warning("번역기 로드 실패: %s", exc)
+        translator = None
+
+    sid = _seller_id()
+    updated = 0
+    translated = 0
+    results = []
+    try:
+        for item_id in item_ids:
+            item = collect_history_store.get(item_id, seller_id=sid)
+            if not item:
+                results.append({"id": item_id, "ok": False, "error": "항목 없음"})
+                continue
+            try:
+                extra = _json.loads(item.get("extra_json") or "{}")
+            except (TypeError, ValueError):
+                extra = {}
+            title = item.get("title") or extra.get("title_ko") or ""
+            desc = extra.get("description") or extra.get("description_ko") or ""
+            title_ko, desc_ko, provider = title, desc, "none"
+            if translator is not None and (title or desc):
+                try:
+                    out = translator.translate_product({"title": title, "description": desc})
+                    title_ko = (out.get("title_ko") or "").strip() or title
+                    desc_ko = (out.get("description_ko") or "").strip() or desc
+                    provider = out.get("provider", "stub")
+                except Exception as exc:
+                    logger.debug("번역 실패(원문 유지): %s", exc)
+            real = provider not in ("none", "stub", "")
+            extra["title_ko"] = title_ko
+            extra["description_ko"] = desc_ko
+            fields = {"extra_json": _json.dumps(extra, ensure_ascii=False)}
+            # 실제 번역된 경우에만 표시 제목을 한국어로 갱신(가짜 번역으로 덮어쓰지 않음).
+            if real and title_ko and title_ko != item.get("title"):
+                fields["title"] = title_ko
+            ok = collect_history_store.update(item_id, seller_id=sid, **fields)
+            if ok:
+                updated += 1
+            if real:
+                translated += 1
+            results.append({"id": item_id, "ok": bool(ok), "translated": real,
+                            "title": fields.get("title", item.get("title"))})
+    except Exception as exc:
+        logger.warning("일괄 번역 오류: %s", exc)
+        return jsonify({"ok": False, "error": "일괄 번역 중 오류가 발생했습니다."}), 500
+
+    message = None
+    if translated == 0:
+        message = "번역기(OPENAI_API_KEY 또는 DEEPL_API_KEY)가 설정되지 않아 원문을 유지했습니다."
+    return jsonify({"ok": True, "updated": updated, "translated": translated,
+                    "total": len(item_ids), "message": message, "results": results})
+
+
 @bp.get("/catalog")
 def catalog():
     """상품 카탈로그 페이지 (Phase 128) — Sheets catalog 워크시트 뷰."""

--- a/tests/test_collect_bulk_translate.py
+++ b/tests/test_collect_bulk_translate.py
@@ -1,0 +1,84 @@
+"""tests/test_collect_bulk_translate.py — 수집 이력 일괄 번역 (Phase 239, 브리프 §3)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_store():
+    from src.seller_console import collect_history_store as chs
+    chs._in_memory.clear()
+    yield
+    chs._in_memory.clear()
+
+
+def _fake_translator(provider="openai"):
+    inst = MagicMock()
+    inst.translate_product.return_value = {
+        "title_ko": "번역된 제목", "description_ko": "번역된 설명", "provider": provider,
+    }
+    cls = MagicMock(return_value=inst)
+    return cls
+
+
+def test_bulk_translate_real_updates_title(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="Original Bag", seller_id="default")
+    with patch("src.seller_console.ai.translator.AITranslator", _fake_translator("openai")):
+        r = client.post("/seller/collect/bulk-translate", json={"item_ids": [a]})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["ok"] is True
+    assert data["translated"] == 1
+    row = chs._in_memory[0]
+    assert row["title"] == "번역된 제목"
+    assert json.loads(row["extra_json"])["title_ko"] == "번역된 제목"
+
+
+def test_bulk_translate_stub_keeps_original_and_warns(client):
+    """번역기 stub(키 없음) → 원문 유지 + 정직한 안내(가짜 번역 없음)."""
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="Original Bag", seller_id="default")
+    with patch("src.seller_console.ai.translator.AITranslator", _fake_translator("stub")):
+        r = client.post("/seller/collect/bulk-translate", json={"item_ids": [a]})
+    data = r.get_json()
+    assert data["ok"] is True
+    assert data["translated"] == 0
+    assert data["message"]  # 안내 메시지 존재
+    assert chs._in_memory[0]["title"] == "Original Bag"  # 원문 유지
+
+
+def test_bulk_translate_requires_ids(client):
+    r = client.post("/seller/collect/bulk-translate", json={"item_ids": []})
+    assert r.status_code == 400
+
+
+def test_history_page_has_translate_button(client):
+    rows = [{
+        "id": "i1", "collected_at": "2026-06-19T12:00:00+00:00", "source": "manual",
+        "domain": "x", "url": "https://x/1", "title": "Bag", "image_url": "", "price": "1",
+        "currency": "USD", "status": "ok", "preview_url": "/seller/collect/preview/i1",
+        "extra_json": "{}", "seller_id": "",
+    }]
+    with patch("src.seller_console.collect_history_store.list_items", return_value=rows), \
+         patch("src.seller_console.collect_history_store.summary", return_value={"total": 1, "today": 0, "domains": 1, "by_source": {"extension": 0, "bookmarklet": 0, "manual": 1, "bulk": 0}}), \
+         patch("src.seller_console.collect_history_store.distinct_domains", return_value=["x"]):
+        resp = client.get("/seller/collect/history")
+    html = resp.get_data(as_text=True)
+    assert "bulkTranslateBtn" in html
+    assert "runBulkTranslate" in html


### PR DESCRIPTION
KOHgogane 브리프 v2 **§3 수집상품 일괄관리 — 셋째 덩어리(일괄 한국어 번역)**입니다.

선택한 상품들의 제목/설명을 한 번에 한국어로 번역합니다(퍼센티 동등).

## 변경
- **`POST /seller/collect/bulk-translate`** — 수동 1건 수집과 **동일한 `AITranslator` 경로** 재사용. 각 항목 `extra_json`에 `title_ko`/`description_ko` 저장, 실제 번역된 경우만 표시 제목을 한국어로 갱신. 셀러 격리, 최대 300건.
- **정직성** — `OPENAI_API_KEY`/`DEEPL_API_KEY` 미설정(provider `stub`/`none`)이면 **원문 유지 + 안내 메시지**(가짜 번역으로 덮어쓰지 않음). 실제 번역 건수(`translated`)를 정직 보고.
- **`collect_history.html`** — 액션바 **🌐 한국어 번역** 버튼 → 성공 시 행 제목 즉시 갱신 + 토스트. 키 없으면 warning 토스트로 안내.

## 테스트
- 신규 4케이스(실번역 제목 갱신·stub 원문 유지+안내·검증·UI).
- 전체 `pytest` **10029 passed**.

## 다음 (§3 계속)
일괄 가격/마진 → 일괄 상태변경/복제 + 검색/정렬/페이지당.

> ※ 실제 번역은 Render에 `OPENAI_API_KEY` 또는 `DEEPL_API_KEY`가 있어야 동작합니다. 없으면 정직하게 원문 유지 + 안내.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_