### PR TITLE
feat(bulk): 수집 이력 일괄 가격/마진 적용 (Phase 240, §3 chunk4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,10 @@
       - ✅ chunk3 — 일괄 번역(Phase 239): `POST /seller/collect/bulk-translate`(AITranslator 재사용,
         제목/설명 한국어 → extra_json title_ko/description_ko, 실번역 시 표시 제목 갱신). 정직성: 키 미설정
         (stub/none) 시 원문 유지 + 안내 메시지(가짜 번역 없음). UI '🌐 한국어 번역' 버튼 → 행 제목 즉시 갱신.
-      - ⏳ 다음: 일괄 가격/마진 → 일괄 상태변경/복제 + 검색/정렬/페이지당.
+      - ✅ chunk4 — 일괄 가격/마진(Phase 240): `POST /seller/collect/bulk-price`(target_margin_pct→extra 저장,
+        price_multiplier→수집가 배수 적용, 둘 중 1+). 비숫자 가격은 가격 건너뛰고 마진만 적용(정직). UI '💰 가격/마진'
+        모달(마진율·배수 입력) → 행 가격 즉시 갱신. 범위 검증(마진 0~90, 배수>0).
+      - ⏳ 다음: 일괄 상태변경/복제 + 검색/정렬/페이지당.
 
 
 ## 📌 마켓 연동 — 검증된 팩트 (2026-06-14)

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -109,6 +109,9 @@
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkTranslateBtn" onclick="runBulkTranslate()" disabled>
           🌐 한국어 번역
         </button>
+        <button type="button" class="btn btn-outline-primary btn-sm" id="bulkPriceBtn" onclick="openBulkPriceModal()" disabled>
+          💰 가격/마진
+        </button>
         <button type="button" class="btn btn-outline-danger btn-sm" id="bulkDeleteBtn" onclick="openBulkDeleteModal()" disabled>
           🗑 선택 삭제
         </button>
@@ -243,6 +246,35 @@
   </div>
 </div>
 
+<!-- 일괄 가격/마진 모달 -->
+<div class="modal fade" id="bulkPriceModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">💰 가격/마진 일괄 적용</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted">선택한 <strong id="priceSelCount">0</strong>개 상품에 적용합니다. 둘 중 하나만 입력해도 됩니다.</p>
+        <div class="mb-3">
+          <label class="form-label small mb-1" for="bulkMarginPct">목표 마진율 (%)</label>
+          <input type="number" id="bulkMarginPct" class="form-control form-control-sm" placeholder="예: 25" min="0" max="90" step="1">
+          <div class="form-text">업로드 시 판매가 계산에 사용됩니다(각 상품에 저장).</div>
+        </div>
+        <div class="mb-1">
+          <label class="form-label small mb-1" for="bulkPriceMult">수집가(원가) 배수 (×)</label>
+          <input type="number" id="bulkPriceMult" class="form-control form-control-sm" placeholder="예: 1.1 = +10%" min="0" step="0.01">
+          <div class="form-text">저장된 수집가에 배수를 곱합니다. 가격이 숫자가 아니면 그 항목은 건너뜁니다.</div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="bulkPriceConfirm" onclick="runBulkPrice()">적용</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- 일괄 카테고리 지정 모달 -->
 <div class="modal fade" id="bulkCategoryModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
@@ -308,6 +340,8 @@ function refreshSelCount() {
   if (cat) cat.disabled = n === 0;
   const tr = document.getElementById('bulkTranslateBtn');
   if (tr) tr.disabled = n === 0;
+  const pr = document.getElementById('bulkPriceBtn');
+  if (pr) pr.disabled = n === 0;
 }
 document.addEventListener('DOMContentLoaded', function () {
   const all = document.getElementById('chkAll');
@@ -317,6 +351,51 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   document.querySelectorAll('.row-chk').forEach(c => c.addEventListener('change', refreshSelCount));
 });
+function openBulkPriceModal() {
+  const ids = selectedItemIds();
+  if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }
+  document.getElementById('priceSelCount').textContent = ids.length;
+  document.getElementById('bulkMarginPct').value = '';
+  document.getElementById('bulkPriceMult').value = '';
+  new bootstrap.Modal(document.getElementById('bulkPriceModal')).show();
+}
+async function runBulkPrice() {
+  const ids = selectedItemIds();
+  if (!ids.length) return;
+  const marginRaw = document.getElementById('bulkMarginPct').value.trim();
+  const multRaw = document.getElementById('bulkPriceMult').value.trim();
+  if (!marginRaw && !multRaw) { pcToast('마진율 또는 가격 배수를 입력하세요.', 'warning'); return; }
+  const body = {item_ids: ids};
+  if (marginRaw) body.target_margin_pct = parseFloat(marginRaw);
+  if (multRaw) body.price_multiplier = parseFloat(multRaw);
+  const btn = document.getElementById('bulkPriceConfirm');
+  setButtonLoading(btn, true, '적용 중…');
+  try {
+    const resp = await fetch('/seller/collect/bulk-price', {
+      method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body),
+    });
+    const ctype = resp.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) { pcToast(`요청 실패 (HTTP ${resp.status}).`, 'error'); return; }
+    const data = await resp.json();
+    if (!data.ok) { pcToast(data.error || '적용 실패', 'error'); return; }
+    // 변경된 가격을 행에 반영
+    (data.results || []).forEach(r => {
+      if (r.ok && r.price != null) {
+        const chk = document.querySelector(`.row-chk[value="${r.id}"]`);
+        const tr = chk && chk.closest('tr');
+        const priceEl = tr && tr.querySelector('td.small .fw-semibold');
+        if (priceEl) priceEl.textContent = r.price;
+      }
+    });
+    bootstrap.Modal.getInstance(document.getElementById('bulkPriceModal'))?.hide();
+    pcToast(`${data.updated}개 상품에 적용했습니다.`, 'success');
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
+  } finally {
+    setButtonLoading(btn, false);
+  }
+}
+
 async function runBulkTranslate() {
   const ids = selectedItemIds();
   if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1907,6 +1907,83 @@ def collect_bulk_translate():
                     "total": len(item_ids), "message": message, "results": results})
 
 
+@bp.post("/collect/bulk-price")
+def collect_bulk_price():
+    """수집 이력 여러 항목에 목표 마진율/원가 배수를 일괄 적용 (셀러 격리).
+
+    Request: {"item_ids": [...], "target_margin_pct"?: float, "price_multiplier"?: float}
+      - target_margin_pct: 각 항목 extra_json.target_margin_pct 에 저장(업로드 시 사용).
+      - price_multiplier: 저장된 수집가(원가)에 배수 적용(예 1.1 = +10%). >0 필요.
+    Response: {"ok": true, "updated": N, "results": [...]}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids") if isinstance(data.get("item_ids"), list) else []
+    item_ids = [str(i) for i in item_ids if str(i).strip()][:1000]
+    if not item_ids:
+        return jsonify({"ok": False, "error": "상품을 선택하세요."}), 400
+
+    margin = data.get("target_margin_pct")
+    multiplier = data.get("price_multiplier")
+    try:
+        margin = None if margin in (None, "") else float(margin)
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "error": "마진율이 올바르지 않습니다."}), 400
+    try:
+        multiplier = None if multiplier in (None, "") else float(multiplier)
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "error": "가격 배수가 올바르지 않습니다."}), 400
+    if margin is None and multiplier is None:
+        return jsonify({"ok": False, "error": "목표 마진율 또는 가격 배수 중 하나는 입력하세요."}), 400
+    if margin is not None and not (0 <= margin <= 90):
+        return jsonify({"ok": False, "error": "마진율은 0~90% 범위여야 합니다."}), 400
+    if multiplier is not None and not (multiplier > 0):
+        return jsonify({"ok": False, "error": "가격 배수는 0보다 커야 합니다."}), 400
+
+    import json as _json
+    from . import collect_history_store
+    sid = _seller_id()
+    updated = 0
+    results = []
+    try:
+        for item_id in item_ids:
+            item = collect_history_store.get(item_id, seller_id=sid)
+            if not item:
+                results.append({"id": item_id, "ok": False, "error": "항목 없음"})
+                continue
+            try:
+                extra = _json.loads(item.get("extra_json") or "{}")
+            except (TypeError, ValueError):
+                extra = {}
+            fields = {}
+            if margin is not None:
+                extra["target_margin_pct"] = margin
+                fields["extra_json"] = _json.dumps(extra, ensure_ascii=False)
+            new_price = None
+            if multiplier is not None:
+                try:
+                    cur = float(str(item.get("price") or "").replace(",", "").strip())
+                    new_price = round(cur * multiplier, 2)
+                    fields["price"] = str(new_price)
+                except (TypeError, ValueError):
+                    # 가격이 숫자가 아니면 가격 변경은 건너뛰되 마진은 적용(정직).
+                    pass
+            if not fields:
+                results.append({"id": item_id, "ok": False, "error": "적용할 변경 없음(가격 비숫자)"})
+                continue
+            ok = collect_history_store.update(item_id, seller_id=sid, **fields)
+            if ok:
+                updated += 1
+            results.append({"id": item_id, "ok": bool(ok), "price": new_price})
+    except Exception as exc:
+        logger.warning("일괄 가격/마진 오류: %s", exc)
+        return jsonify({"ok": False, "error": "일괄 가격/마진 적용 중 오류가 발생했습니다."}), 500
+
+    return jsonify({"ok": True, "updated": updated, "results": results})
+
+
 @bp.get("/catalog")
 def catalog():
     """상품 카탈로그 페이지 (Phase 128) — Sheets catalog 워크시트 뷰."""

--- a/tests/test_collect_bulk_price.py
+++ b/tests/test_collect_bulk_price.py
@@ -1,0 +1,84 @@
+"""tests/test_collect_bulk_price.py — 수집 이력 일괄 가격/마진 (Phase 240, 브리프 §3)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_store():
+    from src.seller_console import collect_history_store as chs
+    chs._in_memory.clear()
+    yield
+    chs._in_memory.clear()
+
+
+def test_bulk_margin_stored_in_extra(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t", price="100", seller_id="default")
+    r = client.post("/seller/collect/bulk-price", json={"item_ids": [a], "target_margin_pct": 30})
+    assert r.status_code == 200
+    assert r.get_json()["updated"] == 1
+    assert json.loads(chs._in_memory[0]["extra_json"])["target_margin_pct"] == 30.0
+
+
+def test_bulk_price_multiplier_applies(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t", price="100", seller_id="default")
+    r = client.post("/seller/collect/bulk-price", json={"item_ids": [a], "price_multiplier": 1.1})
+    assert r.status_code == 200
+    assert chs._in_memory[0]["price"] == "110.0"
+
+
+def test_bulk_price_non_numeric_skips_price_but_margin_ok(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t", price="문의", seller_id="default")
+    r = client.post("/seller/collect/bulk-price",
+                    json={"item_ids": [a], "target_margin_pct": 20, "price_multiplier": 2})
+    assert r.status_code == 200
+    row = chs._in_memory[0]
+    assert row["price"] == "문의"  # 비숫자 → 가격 그대로
+    assert json.loads(row["extra_json"])["target_margin_pct"] == 20.0  # 마진은 적용
+
+
+def test_bulk_price_requires_one_field(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t", price="100", seller_id="default")
+    r = client.post("/seller/collect/bulk-price", json={"item_ids": [a]})
+    assert r.status_code == 400
+
+
+def test_bulk_price_validates_ranges(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t", price="100", seller_id="default")
+    assert client.post("/seller/collect/bulk-price", json={"item_ids": [a], "target_margin_pct": 99}).status_code == 400
+    assert client.post("/seller/collect/bulk-price", json={"item_ids": [a], "price_multiplier": -1}).status_code == 400
+
+
+def test_history_page_has_price_button(client):
+    rows = [{
+        "id": "i1", "collected_at": "2026-06-19T12:00:00+00:00", "source": "manual",
+        "domain": "x", "url": "https://x/1", "title": "t", "image_url": "", "price": "1",
+        "currency": "USD", "status": "ok", "preview_url": "/seller/collect/preview/i1",
+        "extra_json": "{}", "seller_id": "",
+    }]
+    with patch("src.seller_console.collect_history_store.list_items", return_value=rows), \
+         patch("src.seller_console.collect_history_store.summary", return_value={"total": 1, "today": 0, "domains": 1, "by_source": {"extension": 0, "bookmarklet": 0, "manual": 1, "bulk": 0}}), \
+         patch("src.seller_console.collect_history_store.distinct_domains", return_value=["x"]):
+        html = client.get("/seller/collect/history").get_data(as_text=True)
+    assert "bulkPriceBtn" in html
+    assert "runBulkPrice" in html


### PR DESCRIPTION
KOHgogane 브리프 v2 **§3 수집상품 일괄관리 — 넷째 덩어리(일괄 가격/마진)**입니다.

선택한 상품들에 목표 마진율 또는 원가 배수를 한 번에 적용합니다(퍼센티 동등).

## 변경
- **`POST /seller/collect/bulk-price`** — `target_margin_pct`(각 항목 `extra_json`에 저장 → 업로드 시 판매가 계산에 사용) + `price_multiplier`(저장된 수집가에 배수, 예 `1.1` = +10%). **둘 중 하나 이상** 입력. 셀러 격리, 최대 1000건.
  - **정직성**: 가격이 숫자가 아니면(예 "문의") 그 항목은 가격 변경을 건너뛰고 **마진만** 적용.
  - 범위 검증: 마진 0~90%, 배수 > 0.
- **`collect_history.html`** — 액션바 **💰 가격/마진** 버튼 + 모달(마진율·원가 배수 입력) → 적용 후 행 가격 즉시 갱신 + 토스트.

## 테스트
- 신규 6케이스(마진 저장·배수 적용·비숫자 스킵·검증·UI).
- 전체 `pytest` **10035 passed**.

## 다음 (§3 마무리)
일괄 상태변경/복제 + 검색/정렬/페이지당 개수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_