### PR TITLE
feat(bulk): 수집 이력 일괄 상태변경(보관)/복제 (Phase 241, §3 chunk5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,10 @@
       - ✅ chunk4 — 일괄 가격/마진(Phase 240): `POST /seller/collect/bulk-price`(target_margin_pct→extra 저장,
         price_multiplier→수집가 배수 적용, 둘 중 1+). 비숫자 가격은 가격 건너뛰고 마진만 적용(정직). UI '💰 가격/마진'
         모달(마진율·배수 입력) → 행 가격 즉시 갱신. 범위 검증(마진 0~90, 배수>0).
-      - ⏳ 다음: 일괄 상태변경/복제 + 검색/정렬/페이지당.
+      - ✅ chunk5 — 일괄 상태변경/복제(Phase 241): `POST /seller/collect/bulk-status`(ok/archived),
+        `POST /seller/collect/bulk-duplicate`(복제본 새 항목+'(복제)' 접미). UI '📦 상태'(활성/보관 모달)·'📋 복제'
+        버튼. archived 배지(📦 보관) 렌더. (셀러 격리)
+      - ⏳ 다음(§3 마지막): 검색/정렬/페이지당 개수.
 
 
 ## 📌 마켓 연동 — 검증된 팩트 (2026-06-14)

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -112,6 +112,12 @@
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkPriceBtn" onclick="openBulkPriceModal()" disabled>
           💰 가격/마진
         </button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="bulkStatusBtn" onclick="openBulkStatusModal()" disabled>
+          📦 상태
+        </button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="bulkDuplicateBtn" onclick="runBulkDuplicate()" disabled>
+          📋 복제
+        </button>
         <button type="button" class="btn btn-outline-danger btn-sm" id="bulkDeleteBtn" onclick="openBulkDeleteModal()" disabled>
           🗑 선택 삭제
         </button>
@@ -178,6 +184,8 @@
               <td>
                 {% if it.status == "ok" %}
                   <span class="badge bg-success">✓</span>
+                {% elif it.status == "archived" %}
+                  <span class="badge bg-secondary">📦 보관</span>
                 {% else %}
                   <span class="badge bg-danger">{{ it.status }}</span>
                 {% endif %}
@@ -241,6 +249,25 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">닫기</button>
         <button type="button" class="btn btn-success" id="bulkUploadConfirm" onclick="runBulkUpload()">📤 등록 실행</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 일괄 상태변경 모달 -->
+<div class="modal fade" id="bulkStatusModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">📦 상태 변경</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted">선택한 <strong id="statusSelCount">0</strong>개 상품의 상태를 바꿉니다. ‘보관’은 작업이 끝난 상품을 정리할 때 사용합니다(삭제 아님).</p>
+        <div class="d-flex gap-2">
+          <button type="button" class="btn btn-success flex-grow-1" onclick="runBulkStatus('ok')">✓ 활성</button>
+          <button type="button" class="btn btn-secondary flex-grow-1" onclick="runBulkStatus('archived')">📦 보관</button>
+        </div>
       </div>
     </div>
   </div>
@@ -342,6 +369,10 @@ function refreshSelCount() {
   if (tr) tr.disabled = n === 0;
   const pr = document.getElementById('bulkPriceBtn');
   if (pr) pr.disabled = n === 0;
+  const st = document.getElementById('bulkStatusBtn');
+  if (st) st.disabled = n === 0;
+  const dup = document.getElementById('bulkDuplicateBtn');
+  if (dup) dup.disabled = n === 0;
 }
 document.addEventListener('DOMContentLoaded', function () {
   const all = document.getElementById('chkAll');
@@ -351,6 +382,64 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   document.querySelectorAll('.row-chk').forEach(c => c.addEventListener('change', refreshSelCount));
 });
+function openBulkStatusModal() {
+  const ids = selectedItemIds();
+  if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }
+  document.getElementById('statusSelCount').textContent = ids.length;
+  new bootstrap.Modal(document.getElementById('bulkStatusModal')).show();
+}
+async function runBulkStatus(status) {
+  const ids = selectedItemIds();
+  if (!ids.length) return;
+  try {
+    const resp = await fetch('/seller/collect/bulk-status', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({item_ids: ids, status: status}),
+    });
+    const ctype = resp.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) { pcToast(`요청 실패 (HTTP ${resp.status}).`, 'error'); return; }
+    const data = await resp.json();
+    if (!data.ok) { pcToast(data.error || '상태 변경 실패', 'error'); return; }
+    // 상태 배지 갱신
+    const badge = status === 'archived'
+      ? '<span class="badge bg-secondary">📦 보관</span>'
+      : '<span class="badge bg-success">✓</span>';
+    ids.forEach(id => {
+      const chk = document.querySelector(`.row-chk[value="${id}"]`);
+      const tr = chk && chk.closest('tr');
+      const tds = tr && tr.querySelectorAll('td');
+      if (tds && tds.length >= 7) tds[6].innerHTML = badge;  // 상태 컬럼(7번째)
+    });
+    bootstrap.Modal.getInstance(document.getElementById('bulkStatusModal'))?.hide();
+    pcToast(`${data.updated}개 상품 상태를 변경했습니다.`, 'success');
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
+  }
+}
+async function runBulkDuplicate() {
+  const ids = selectedItemIds();
+  if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }
+  if (!confirm(`선택한 ${ids.length}개 상품을 복제할까요? 복제본이 새 항목으로 추가됩니다.`)) return;
+  const btn = document.getElementById('bulkDuplicateBtn');
+  setButtonLoading(btn, true, '복제 중…');
+  try {
+    const resp = await fetch('/seller/collect/bulk-duplicate', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({item_ids: ids}),
+    });
+    const ctype = resp.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) { pcToast(`요청 실패 (HTTP ${resp.status}).`, 'error'); return; }
+    const data = await resp.json();
+    if (!data.ok) { pcToast(data.error || '복제 실패', 'error'); return; }
+    pcToast(`${data.duplicated}개 복제했습니다. 목록을 새로고침합니다.`, 'success');
+    setTimeout(() => location.reload(), 800);
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
+  } finally {
+    setButtonLoading(btn, false);
+  }
+}
+
 function openBulkPriceModal() {
   const ids = selectedItemIds();
   if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1984,6 +1984,90 @@ def collect_bulk_price():
     return jsonify({"ok": True, "updated": updated, "results": results})
 
 
+# 일괄 상태변경 허용 값 (활성/보관)
+_BULK_STATUS_ALLOWED = {"ok", "archived"}
+
+
+@bp.post("/collect/bulk-status")
+def collect_bulk_status():
+    """수집 이력 여러 항목의 상태를 일괄 변경 (활성 ok / 보관 archived). 셀러 격리.
+
+    Request: {"item_ids": [...], "status": "archived"}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids") if isinstance(data.get("item_ids"), list) else []
+    item_ids = [str(i) for i in item_ids if str(i).strip()][:1000]
+    status = str(data.get("status") or "").strip()
+    if not item_ids:
+        return jsonify({"ok": False, "error": "상품을 선택하세요."}), 400
+    if status not in _BULK_STATUS_ALLOWED:
+        return jsonify({"ok": False, "error": "상태값이 올바르지 않습니다."}), 400
+
+    from . import collect_history_store
+    sid = _seller_id()
+    updated = 0
+    try:
+        for item_id in item_ids:
+            if collect_history_store.update(item_id, seller_id=sid, status=status):
+                updated += 1
+    except Exception as exc:
+        logger.warning("일괄 상태변경 오류: %s", exc)
+        return jsonify({"ok": False, "error": "일괄 상태변경 중 오류가 발생했습니다."}), 500
+
+    return jsonify({"ok": True, "updated": updated, "status": status})
+
+
+@bp.post("/collect/bulk-duplicate")
+def collect_bulk_duplicate():
+    """수집 이력 여러 항목을 복제 (셀러 격리). 새 항목으로 추가.
+
+    Request: {"item_ids": [...]}
+    Response: {"ok": true, "duplicated": N, "new_ids": [...]}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids") if isinstance(data.get("item_ids"), list) else []
+    item_ids = [str(i) for i in item_ids if str(i).strip()][:200]
+    if not item_ids:
+        return jsonify({"ok": False, "error": "상품을 선택하세요."}), 400
+
+    import json as _json
+    from . import collect_history_store
+    sid = _seller_id()
+    new_ids = []
+    try:
+        for item_id in item_ids:
+            item = collect_history_store.get(item_id, seller_id=sid)
+            if not item:
+                continue
+            try:
+                extra = _json.loads(item.get("extra_json") or "{}")
+            except (TypeError, ValueError):
+                extra = {}
+            new_id = collect_history_store.append(
+                source=item.get("source") or "manual",
+                url=item.get("url") or "",
+                title=((item.get("title") or "") + " (복제)").strip(),
+                image=item.get("image_url") or "",
+                price=item.get("price") or "",
+                currency=item.get("currency") or "",
+                status="ok",
+                extra=extra,
+                seller_id=sid,
+            )
+            new_ids.append(new_id)
+    except Exception as exc:
+        logger.warning("일괄 복제 오류: %s", exc)
+        return jsonify({"ok": False, "error": "일괄 복제 중 오류가 발생했습니다."}), 500
+
+    return jsonify({"ok": True, "duplicated": len(new_ids), "new_ids": new_ids})
+
+
 @bp.get("/catalog")
 def catalog():
     """상품 카탈로그 페이지 (Phase 128) — Sheets catalog 워크시트 뷰."""

--- a/tests/test_collect_bulk_status_duplicate.py
+++ b/tests/test_collect_bulk_status_duplicate.py
@@ -1,0 +1,76 @@
+"""tests/test_collect_bulk_status_duplicate.py — 일괄 상태변경/복제 (Phase 241, 브리프 §3)."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_store():
+    from src.seller_console import collect_history_store as chs
+    chs._in_memory.clear()
+    yield
+    chs._in_memory.clear()
+
+
+def test_bulk_status_archive(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t", seller_id="default")
+    r = client.post("/seller/collect/bulk-status", json={"item_ids": [a], "status": "archived"})
+    assert r.status_code == 200
+    assert r.get_json()["updated"] == 1
+    assert chs._in_memory[0]["status"] == "archived"
+
+
+def test_bulk_status_rejects_bad_value(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t", seller_id="default")
+    r = client.post("/seller/collect/bulk-status", json={"item_ids": [a], "status": "deleted"})
+    assert r.status_code == 400
+
+
+def test_bulk_duplicate_creates_copies(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="가방", price="100", seller_id="default")
+    before = len(chs._in_memory)
+    r = client.post("/seller/collect/bulk-duplicate", json={"item_ids": [a]})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["ok"] is True and data["duplicated"] == 1
+    assert len(chs._in_memory) == before + 1
+    titles = [row["title"] for row in chs._in_memory]
+    assert any("(복제)" in t for t in titles)
+
+
+def test_bulk_duplicate_requires_ids(client):
+    r = client.post("/seller/collect/bulk-duplicate", json={"item_ids": []})
+    assert r.status_code == 400
+
+
+def test_history_page_has_status_and_duplicate_buttons(client):
+    rows = [{
+        "id": "i1", "collected_at": "2026-06-19T12:00:00+00:00", "source": "manual",
+        "domain": "x", "url": "https://x/1", "title": "t", "image_url": "", "price": "1",
+        "currency": "USD", "status": "archived", "preview_url": "/seller/collect/preview/i1",
+        "extra_json": "{}", "seller_id": "",
+    }]
+    with patch("src.seller_console.collect_history_store.list_items", return_value=rows), \
+         patch("src.seller_console.collect_history_store.summary", return_value={"total": 1, "today": 0, "domains": 1, "by_source": {"extension": 0, "bookmarklet": 0, "manual": 1, "bulk": 0}}), \
+         patch("src.seller_console.collect_history_store.distinct_domains", return_value=["x"]):
+        html = client.get("/seller/collect/history").get_data(as_text=True)
+    assert "bulkStatusBtn" in html and "bulkDuplicateBtn" in html
+    assert "runBulkDuplicate" in html
+    assert "📦 보관" in html  # archived 배지 렌더


### PR DESCRIPTION
KOHgogane 브리프 v2 **§3 수집상품 일괄관리 — 다섯째 덩어리(일괄 상태변경/복제)**입니다.

## 변경
- **`POST /seller/collect/bulk-status`** — 선택 상품 상태를 **활성(ok)** / **보관(archived)**으로 일괄 변경(셀러 격리). ‘보관’은 작업 끝난 상품을 정리할 때(삭제 아님). 상태 컬럼에 **📦 보관** 배지 추가.
- **`POST /seller/collect/bulk-duplicate`** — 선택 항목을 복제 → 새 수집 항목으로 추가(제목에 **(복제)** 접미, `extra_json` 포함 복사). 최대 200건.
- **`collect_history.html`** — 액션바 **📦 상태**(활성/보관 모달) + **📋 복제**(확인 → 복제 → 목록 새로고침) 버튼. 상태 변경 시 배지 즉시 갱신.

## 테스트
- 신규 5케이스(보관·잘못된 상태 거부·복제·검증·UI).
- 전체 `pytest` **10040 passed**.

## §3 진행 현황
삭제 ✅ · 카테고리 ✅ · 번역 ✅ · 가격/마진 ✅ · **상태변경/복제 ✅**. 남은 마지막: **검색/정렬/페이지당 개수**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_