### PR TITLE
feat(design): CTA 위계 강화 — 청록 Primary 채움 + 금/고스트 유틸 (Phase 245, v3 P1-3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,10 @@
       ok=true, 실패 시 502 정직(가짜 성공 금지). 응답에 item_id 추가. v3 P0-1 로그인 튕김: SECRET_KEY 미설정 시
       워커마다 다른 임시키→세션 무효화였음 → 컨테이너-로컬 파일(`/tmp/kohgogane_session_secret`, O_EXCL)로 모든 워커가
       동일 키 공유(즉시 튕김 방지). **영구 고정은 오너가 Render에 `SECRET_KEY` 설정 권장.**
-    - ⏳ 다음: 멀티워커 인메모리 수집이력 영구화(파일/Sheet 폴백 — 옵트인), CTA 가시성, 번역 과금, 퍼센티 포팅, 모바일.
+    - ✅ v3 P1-3 CTA 가시성(Phase 245): `app.css` 버튼 위계 토큰 강화 — `.btn-primary`=청록 채움+굵게(700)+
+      hover lift+청록 글로우(화면당 1개 핵심행동), `.btn-outline-primary` 진한 청록, 신설 `.btn-gold`(금 아웃라인
+      Secondary)·`.btn-ghost`(Tertiary). CSS만 — 전 화면 .btn-primary 자동 강조.
+    - ⏳ 다음: 멀티워커 인메모리 수집이력 영구화(파일/Sheet 폴백 — 옵트인), 번역 무료20+과금, 퍼센티 포팅, 모바일, 수집버튼 리디자인.
 - **KOHgogane 브리프 v2 (전면 리디자인 로드맵, 오너 제공 2026-06-20):** 코가네 퍼센티→**코고가네/KOHgogane** 리브랜딩 +
   catdyy식 디자인 토큰(먹/한지/금 + 청록 Primary) + Pretendard/Noto Serif KR + 수집상품 일괄관리(퍼센티 동등) +
   온보딩 위저드 + 게임화 + 구독 + PWA/베타. 순서: 디자인→일괄관리→온보딩→게임화→구독→앱. (대형 — 덩어리별 PR)

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -106,12 +106,50 @@ a:hover {
   border-radius: var(--pc-radius-sm);
   transition: transform var(--pc-transition), box-shadow var(--pc-transition), background-color var(--pc-transition);
 }
+/* CTA 위계(브리프 v3 P1-3) — "은은하되 확실히".
+   Primary(청록 채움)=화면당 1개, 그 화면의 핵심 행동. 굵게 + hover lift + 청록 글로우. */
 .btn-primary {
   background: linear-gradient(135deg, var(--pc-color-primary), var(--pc-color-primary-strong));
   border-color: transparent;
+  color: #fff;
+  font-weight: 700;
+  box-shadow: 0 6px 16px rgba(15, 157, 140, .26);
 }
-.btn-outline-primary { border-color: var(--pc-color-primary); color: var(--pc-color-primary); }
-.btn-outline-primary:hover { background: var(--pc-color-primary); border-color: var(--pc-color-primary); }
+.btn-primary:hover,
+.btn-primary:focus {
+  background: linear-gradient(135deg, #12a897, var(--pc-color-primary-strong));
+  border-color: transparent;
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(15, 157, 140, .34);
+}
+.btn-outline-primary { border-color: var(--pc-color-primary); color: var(--pc-color-primary-strong); font-weight: 600; }
+.btn-outline-primary:hover { background: var(--pc-color-primary); border-color: var(--pc-color-primary); color: #fff; }
+/* Secondary(금 아웃라인) — Primary보다 한 단계 약하게. 명시적으로 .btn-gold. */
+.btn-gold {
+  background: transparent;
+  border: 1.5px solid var(--pc-color-accent-gold);
+  color: #8a6d22;
+  font-weight: 600;
+}
+.btn-gold:hover,
+.btn-gold:focus {
+  background: rgba(201, 162, 75, .12);
+  border-color: var(--pc-color-accent-gold);
+  color: #6f561a;
+}
+/* Tertiary(고스트) — 보조 동작. */
+.btn-ghost {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--pc-color-text-muted);
+  font-weight: 600;
+}
+.btn-ghost:hover,
+.btn-ghost:focus {
+  background: var(--pc-color-surface-muted);
+  color: var(--pc-color-text);
+}
 .btn:disabled,
 .btn.disabled {
   opacity: 1;


### PR DESCRIPTION
오너 v3 추가분 **P1-3 CTA 가시성**입니다. "바로가기 / 지금 연동하기 / 필터 적용" 버튼이 옅고 작아 안 보이던 문제 → **은은하되 확실히** 보이게 버튼 위계를 토큰으로 강화.

## 변경 (app.css 토큰, 전 화면 일괄 적용)
- **`.btn-primary` = 청록 채움** + **굵게(700)** + hover 시 살짝 lift + 청록 글로우 → 그 화면의 핵심 행동(화면당 1개)이 확 띕니다.
- **`.btn-outline-primary`** = 진한 청록(strong) + 굵게.
- 신설 **`.btn-gold`**(금 아웃라인 Secondary), **`.btn-ghost`**(텍스트/보조 Tertiary) → 위계 3단계(청록 Primary > 금 Secondary > 고스트).

## 안전/범위
- **CSS만** 변경 — 전 화면의 `.btn-primary`가 자동으로 강조됩니다(예: '필터 적용' 등). 접근성 대비 확보.
- 테스트는 색/폰트 값에 비의존 → 영향 없음. UI 스모크 통과.

> 화면별로 금 Secondary/고스트를 더 입히는 건 후속 화면 폴리시로 점진 적용합니다(`.btn-gold`/`.btn-ghost` 준비됨).

## 다음 (v3/v4)
번역 무료 20회+과금(P1-4) → 퍼센티 기능 포팅(P1-5) → 모바일(P1-6) → 수집버튼 리디자인(v4 P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_