### PR TITLE
feat(translation): 번역 무료 20회 미터 + 초과 차단(구독/충전 안내) (Phase 246, v3 P1-4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,11 @@
     - ✅ v3 P1-3 CTA 가시성(Phase 245): `app.css` 버튼 위계 토큰 강화 — `.btn-primary`=청록 채움+굵게(700)+
       hover lift+청록 글로우(화면당 1개 핵심행동), `.btn-outline-primary` 진한 청록, 신설 `.btn-gold`(금 아웃라인
       Secondary)·`.btn-ghost`(Tertiary). CSS만 — 전 화면 .btn-primary 자동 강조.
-    - ⏳ 다음: 멀티워커 인메모리 수집이력 영구화(파일/Sheet 폴백 — 옵트인), 번역 무료20+과금, 퍼센티 포팅, 모바일, 수집버튼 리디자인.
+    - ✅ v3 P1-4 번역 무료20+과금(Phase 246): 신설 `translation_usage.py`(셀러별 free_used 카운터, Sheets+인메모리,
+      `TRANSLATION_FREE_LIMIT` 기본20). `/seller/collect/bulk-translate`가 무료 한도 내에서만 실 번역, 초과분은
+      차단(blocked)+구독/충전 안내. 정직: 실제 번역된 건만 차감(stub/키없음은 차감·차단 안 함). `TRANSLATION_UNLIMITED=1`
+      훅(추후 구독 연동). 수집이력 UI에 '무료 번역 N/한도 남음' 표시. ※ 토큰 차감/결제는 미연동(정직 안내)—후속.
+    - ⏳ 다음: 멀티워커 인메모리 수집이력 영구화(파일/Sheet 폴백 — 옵트인), 퍼센티 포팅, 모바일, 수집버튼 리디자인.
 - **KOHgogane 브리프 v2 (전면 리디자인 로드맵, 오너 제공 2026-06-20):** 코가네 퍼센티→**코고가네/KOHgogane** 리브랜딩 +
   catdyy식 디자인 토큰(먹/한지/금 + 청록 Primary) + Pretendard/Noto Serif KR + 수집상품 일괄관리(퍼센티 동등) +
   온보딩 위저드 + 게임화 + 구독 + PWA/베타. 순서: 디자인→일괄관리→온보딩→게임화→구독→앱. (대형 — 덩어리별 PR)

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -137,6 +137,12 @@
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkTranslateBtn" onclick="runBulkTranslate()" disabled>
           🌐 한국어 번역
         </button>
+        {% if translation_free %}
+        <span class="small {{ 'text-muted' if translation_free.remaining > 0 else 'text-danger' }}" id="translFree"
+              title="무료 번역은 실제 번역된 건수만 차감됩니다(번역기 미설정 시 차감 없음).">
+          무료 번역 <strong id="translRemain">{{ translation_free.remaining }}</strong>/{{ translation_free.limit }}회 남음
+        </span>
+        {% endif %}
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkPriceBtn" onclick="openBulkPriceModal()" disabled>
           💰 가격/마진
         </button>
@@ -555,8 +561,17 @@ async function runBulkTranslate() {
         if (a) { a.textContent = r.title; a.title = r.title; }
       }
     });
-    if (data.translated > 0) {
-      pcToast(`${data.translated}/${data.total}개 한국어로 번역했습니다.`, 'success');
+    // 무료 잔여 갱신
+    if (typeof data.free_remaining === 'number') {
+      const rem = document.getElementById('translRemain');
+      if (rem) rem.textContent = data.free_remaining;
+      const wrap = document.getElementById('translFree');
+      if (wrap) wrap.className = 'small ' + (data.free_remaining > 0 ? 'text-muted' : 'text-danger');
+    }
+    if (data.blocked > 0) {
+      pcToast(data.message || `무료 번역 한도 소진 — ${data.blocked}개 번역 못 함.`, 'warning');
+    } else if (data.translated > 0) {
+      pcToast(`${data.translated}/${data.total}개 한국어로 번역했습니다. (무료 ${data.free_remaining}회 남음)`, 'success');
     } else {
       pcToast(data.message || '번역기가 설정되지 않아 원문을 유지했습니다.', 'warning');
     }

--- a/src/seller_console/translation_usage.py
+++ b/src/seller_console/translation_usage.py
@@ -1,0 +1,104 @@
+"""src/seller_console/translation_usage.py — 셀러별 번역 무료 사용량 미터 (Phase 246, v3 P1-4).
+
+무료 번역 한도(기본 20회)를 셀러별로 '실제 카운트'로 관리한다(가짜 차감/가짜 무료 금지).
+- 무료 잔여 = max(0, FREE_LIMIT - free_used)
+- 초과 시: 활성 구독이면 허용, 아니면 토큰 차감 또는 차단(결제 미설정 시 정직 안내).
+
+저장: GOOGLE_SHEET_ID 있으면 `translation_usage` 워크시트(seller_id|free_used),
+없으면 인메모리. (collect_history_store와 동일 패턴)
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
+_WS_NAME = "translation_usage"
+_HEADERS = ["seller_id", "free_used"]
+
+# 인메모리 폴백 (seller_id → free_used)
+_in_memory: dict[str, int] = {}
+
+
+def free_limit() -> int:
+    try:
+        return max(0, int(os.getenv("TRANSLATION_FREE_LIMIT", "20") or "20"))
+    except (TypeError, ValueError):
+        return 20
+
+
+def _get_worksheet():
+    from src.utils.sheets import open_sheet
+    ws = open_sheet(_SHEET_ID, _WS_NAME)
+    try:
+        first = ws.row_values(1)
+        if not first or first[0] != "seller_id":
+            ws.insert_row(_HEADERS, index=1)
+    except Exception:
+        pass
+    return ws
+
+
+def get_used(seller_id: Optional[str]) -> int:
+    """셀러의 무료 번역 사용 횟수."""
+    sid = str(seller_id or "")
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            for row in ws.get_all_records():
+                if str(row.get("seller_id", "") or "") == sid:
+                    try:
+                        return max(0, int(row.get("free_used", 0) or 0))
+                    except (TypeError, ValueError):
+                        return 0
+            return 0
+        except Exception as exc:
+            logger.warning("번역 사용량 조회 실패(인메모리 폴백): %s", exc)
+    return max(0, int(_in_memory.get(sid, 0)))
+
+
+def remaining(seller_id: Optional[str]) -> int:
+    """무료 잔여 횟수."""
+    return max(0, free_limit() - get_used(seller_id))
+
+
+def increment(seller_id: Optional[str], n: int) -> int:
+    """무료 사용 n회 증가 후 새 누계 반환 (n<=0이면 변화 없음)."""
+    sid = str(seller_id or "")
+    n = int(n or 0)
+    if n <= 0:
+        return get_used(sid)
+
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            values = ws.get_all_values()
+            header = values[0] if values else _HEADERS
+            col = {h: i for i, h in enumerate(header)}
+            sid_i = col.get("seller_id", 0)
+            used_i = col.get("free_used", 1)
+            for r, row in enumerate(values[1:], start=2):
+                if sid_i < len(row) and str(row[sid_i] or "") == sid:
+                    cur = 0
+                    try:
+                        cur = int(row[used_i]) if used_i < len(row) and row[used_i] else 0
+                    except (TypeError, ValueError):
+                        cur = 0
+                    new_total = cur + n
+                    ws.update_cell(r, used_i + 1, str(new_total))
+                    return new_total
+            # 신규 셀러 행 추가
+            new_total = n
+            new_row = [""] * len(header)
+            new_row[sid_i] = sid
+            new_row[used_i] = str(new_total)
+            ws.append_row(new_row)
+            return new_total
+        except Exception as exc:
+            logger.warning("번역 사용량 증가 실패(인메모리 폴백): %s", exc)
+
+    _in_memory[sid] = max(0, int(_in_memory.get(sid, 0))) + n
+    return _in_memory[sid]

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1858,8 +1858,17 @@ def collect_bulk_translate():
         translator = None
 
     sid = _seller_id()
+    # 번역 무료 사용량 미터(v3 P1-4): 무료 한도 내에서만 실제 번역, 초과 시 차단(구독/충전 안내).
+    # 정직성: 무료 차감은 '실제 번역된 건'만(stub/키 없음은 차감·차단하지 않음).
+    from . import translation_usage
+    _limit = translation_usage.free_limit()
+    _used_before = translation_usage.get_used(sid)
+    _remaining = max(0, _limit - _used_before)
+    _unlimited = os.getenv("TRANSLATION_UNLIMITED", "0") == "1"  # 구독/무제한 훅(추후 구독 연동)
+
     updated = 0
     translated = 0
+    blocked = 0
     results = []
     try:
         for item_id in item_ids:
@@ -1873,8 +1882,10 @@ def collect_bulk_translate():
                 extra = {}
             title = item.get("title") or extra.get("title_ko") or ""
             desc = extra.get("description") or extra.get("description_ko") or ""
+            # 무료 한도 도달 시(실 번역기 있음) 이후 항목은 번역 차단 — 원문 유지.
+            allow = _unlimited or (translated < _remaining)
             title_ko, desc_ko, provider = title, desc, "none"
-            if translator is not None and (title or desc):
+            if allow and translator is not None and (title or desc):
                 try:
                     out = translator.translate_product({"title": title, "description": desc})
                     title_ko = (out.get("title_ko") or "").strip() or title
@@ -1883,6 +1894,9 @@ def collect_bulk_translate():
                 except Exception as exc:
                     logger.debug("번역 실패(원문 유지): %s", exc)
             real = provider not in ("none", "stub", "")
+            # 실 번역기가 있는데 무료 한도로 막힌 경우만 '차단'으로 집계(stub은 차단 아님).
+            if (not allow) and translator is not None and (title or desc):
+                blocked += 1
             extra["title_ko"] = title_ko
             extra["description_ko"] = desc_ko
             fields = {"extra_json": _json.dumps(extra, ensure_ascii=False)}
@@ -1900,11 +1914,25 @@ def collect_bulk_translate():
         logger.warning("일괄 번역 오류: %s", exc)
         return jsonify({"ok": False, "error": "일괄 번역 중 오류가 발생했습니다."}), 500
 
+    # 실제 번역된 건수만큼만 무료 사용량 차감(정직).
+    if translated > 0 and not _unlimited:
+        try:
+            translation_usage.increment(sid, translated)
+        except Exception as exc:
+            logger.warning("번역 사용량 증가 실패: %s", exc)
+    new_remaining = _limit if _unlimited else max(0, _limit - (_used_before + translated))
+
     message = None
-    if translated == 0:
+    if translated == 0 and blocked == 0:
         message = "번역기(OPENAI_API_KEY 또는 DEEPL_API_KEY)가 설정되지 않아 원문을 유지했습니다."
+    elif blocked > 0:
+        message = (f"무료 번역 {_limit}회를 모두 사용했습니다. {blocked}개는 번역하지 못했어요 — "
+                   "구독하거나 토큰을 충전하면 계속 번역할 수 있습니다(결제 미설정 시 운영자 문의).")
     return jsonify({"ok": True, "updated": updated, "translated": translated,
-                    "total": len(item_ids), "message": message, "results": results})
+                    "total": len(item_ids), "blocked": blocked,
+                    "free_limit": _limit, "free_used": _used_before + translated,
+                    "free_remaining": new_remaining, "unlimited": _unlimited,
+                    "message": message, "results": results})
 
 
 @bp.post("/collect/bulk-price")
@@ -4544,6 +4572,17 @@ def collect_history():
     from .upload_dispatcher import MARKET_LABELS, SUPPORTED_MARKETS
     upload_markets = [{"code": m, "label": MARKET_LABELS.get(m, m)} for m in SUPPORTED_MARKETS]
     from .category_classifier import CATEGORY_OPTIONS
+    # 번역 무료 사용량(v3 P1-4) — UI에 '무료 N/한도 남음' 표시
+    try:
+        from . import translation_usage
+        _sid2 = _seller_id()
+        translation_free = {
+            "limit": translation_usage.free_limit(),
+            "used": translation_usage.get_used(_sid2),
+            "remaining": translation_usage.remaining(_sid2),
+        }
+    except Exception:
+        translation_free = {"limit": 20, "used": 0, "remaining": 20}
     return render_template(
         "collect_history.html",
         page="collect_history",
@@ -4556,6 +4595,7 @@ def collect_history():
                     "total_pages": total_pages},
         upload_markets=upload_markets,
         category_options=CATEGORY_OPTIONS,
+        translation_free=translation_free,
     )
 
 

--- a/tests/test_translation_usage.py
+++ b/tests/test_translation_usage.py
@@ -1,0 +1,98 @@
+"""tests/test_translation_usage.py — 번역 무료 20회 + 초과 차단 (Phase 246, v3 P1-4)."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear(monkeypatch):
+    from src.seller_console import collect_history_store as chs
+    from src.seller_console import translation_usage as tu
+    chs._in_memory.clear()
+    tu._in_memory.clear()
+    monkeypatch.setenv("TRANSLATION_FREE_LIMIT", "3")  # 테스트는 무료 3회로
+    monkeypatch.delenv("TRANSLATION_UNLIMITED", raising=False)
+    yield
+    chs._in_memory.clear()
+    tu._in_memory.clear()
+
+
+def _real_translator():
+    inst = MagicMock()
+    inst.translate_product.return_value = {"title_ko": "번역됨", "description_ko": "설명", "provider": "openai"}
+    return MagicMock(return_value=inst)
+
+
+def _stub_translator():
+    inst = MagicMock()
+    inst.translate_product.return_value = {"title_ko": "x", "description_ko": "y", "provider": "stub"}
+    return MagicMock(return_value=inst)
+
+
+def test_usage_counter_increments_and_remaining():
+    from src.seller_console import translation_usage as tu
+    assert tu.remaining("s1") == 3
+    tu.increment("s1", 2)
+    assert tu.get_used("s1") == 2
+    assert tu.remaining("s1") == 1
+
+
+def test_bulk_translate_blocks_over_free_limit(client):
+    """무료 3회 → 4개 요청 시 3개만 번역, 1개 차단."""
+    from src.seller_console import collect_history_store as chs
+    ids = [chs.append(source="manual", url=f"https://x/{i}", title=f"t{i}", seller_id="default") for i in range(4)]
+    with patch("src.seller_console.ai.translator.AITranslator", _real_translator()):
+        r = client.post("/seller/collect/bulk-translate", json={"item_ids": ids})
+    data = r.get_json()
+    assert data["ok"] is True
+    assert data["translated"] == 3
+    assert data["blocked"] == 1
+    assert data["free_remaining"] == 0
+    assert "무료 번역" in (data["message"] or "")
+
+
+def test_bulk_translate_stub_does_not_consume_free(client):
+    """번역기 stub(키 없음)이면 무료 차감/차단 없음(정직)."""
+    from src.seller_console import collect_history_store as chs
+    from src.seller_console import translation_usage as tu
+    ids = [chs.append(source="manual", url=f"https://x/{i}", title=f"t{i}", seller_id="default") for i in range(5)]
+    with patch("src.seller_console.ai.translator.AITranslator", _stub_translator()):
+        r = client.post("/seller/collect/bulk-translate", json={"item_ids": ids})
+    data = r.get_json()
+    assert data["translated"] == 0
+    assert data["blocked"] == 0
+    assert tu.get_used("default") == 0  # 차감 없음
+    assert data["free_remaining"] == 3
+
+
+def test_unlimited_env_bypasses_limit(client):
+    from src.seller_console import collect_history_store as chs
+    ids = [chs.append(source="manual", url=f"https://x/{i}", title=f"t{i}", seller_id="default") for i in range(5)]
+    with patch.dict(os.environ, {"TRANSLATION_UNLIMITED": "1"}), \
+         patch("src.seller_console.ai.translator.AITranslator", _real_translator()):
+        r = client.post("/seller/collect/bulk-translate", json={"item_ids": ids})
+    data = r.get_json()
+    assert data["translated"] == 5
+    assert data["blocked"] == 0
+
+
+def test_history_page_shows_free_balance(client):
+    from src.seller_console import collect_history_store as chs
+    chs.append(source="manual", url="https://x/1", title="t", seller_id="default")
+    html = client.get("/seller/collect/history").get_data(as_text=True)
+    assert "무료 번역" in html
+    assert "translRemain" in html


### PR DESCRIPTION
오너 v3 추가분 **P1-4 번역 무료 20회 + 이후 구독/토큰**입니다.

## 변경
- **신설 `translation_usage.py`** — 셀러별 `free_used` 카운터(Sheets `translation_usage` 워크시트 + 인메모리 폴백). 무료 한도 `TRANSLATION_FREE_LIMIT`(기본 **20**). `get_used/remaining/increment`.
- **`/seller/collect/bulk-translate`** — 무료 한도 내에서만 실제 번역하고, **초과분은 차단(blocked)**하여 원문 유지 + ‘구독/충전’ 안내. 응답에 `free_limit/free_used/free_remaining/blocked`.
- **정직성(핵심):** 무료 차감은 **실제 번역된 건만** — 번역기 stub/키 미설정은 **차감·차단하지 않음**(가짜 차감 금지). `TRANSLATION_UNLIMITED=1` 훅(추후 구독 연동 자리).
- **수집 이력 UI:** 액션바에 **‘무료 번역 N/한도 남음’** 표시(소진 시 빨강) + 번역 후 잔여 즉시 갱신, 한도 초과 시 안내 토스트.

## 정직하게 남겨둔 것 (가짜 금지)
- **토큰 차감/결제(토스/PortOne)는 미연동** — 결제 시스템이 안 붙은 상태라 가짜 차감을 만들지 않고, 초과 시 ‘구독/충전 필요(결제 미설정 시 운영자 문의)’로 정직 안내. 결제·구독 연동은 v2 §6에서 이어붙입니다.

## 테스트
- 신규 6케이스(카운터·초과 차단=3/4·stub 무차감·무제한 바이패스·UI 표시).
- 전체 `pytest` **10058 passed**.

## 다음 (v3/v4)
퍼센티 기능 포팅(P1-5) → 모바일(P1-6) → 수집버튼 리디자인(v4 P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_