### PR TITLE
feat(groups): 수집 상품 그룹 관리(CRUD+배정+필터) (Phase 247, v3 P1-5 #1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,11 @@
       `TRANSLATION_FREE_LIMIT` 기본20). `/seller/collect/bulk-translate`가 무료 한도 내에서만 실 번역, 초과분은
       차단(blocked)+구독/충전 안내. 정직: 실제 번역된 건만 차감(stub/키없음은 차감·차단 안 함). `TRANSLATION_UNLIMITED=1`
       훅(추후 구독 연동). 수집이력 UI에 '무료 번역 N/한도 남음' 표시. ※ 토큰 차감/결제는 미연동(정직 안내)—후속.
-    - ⏳ 다음: 멀티워커 인메모리 수집이력 영구화(파일/Sheet 폴백 — 옵트인), 퍼센티 포팅, 모바일, 수집버튼 리디자인.
+    - ✅ v3 P1-5 퍼센티 포팅 #1 그룹관리(Phase 247): 신설 `collect_groups.py`(셀러별 그룹 CRUD, Sheets+인메모리).
+      라우트 `/collect/groups/create|delete`, `/collect/bulk-group`(item_ids→extra.group_id, group_name 신규생성/해제).
+      수집이력에 그룹 필터(?group=) + '🗂 그룹 지정' 버튼/모달(기존선택·새그룹·관리삭제). 셀러 격리.
+    - ⏳ 다음: 퍼센티 포팅 #2 금지어/치환 → 이미지편집UI → 통관고유부호 → 장부/애널 노출. 그리고 멀티워커 이력
+      영구화(옵트인), 모바일, 수집버튼 리디자인.
 - **KOHgogane 브리프 v2 (전면 리디자인 로드맵, 오너 제공 2026-06-20):** 코가네 퍼센티→**코고가네/KOHgogane** 리브랜딩 +
   catdyy식 디자인 토큰(먹/한지/금 + 청록 Primary) + Pretendard/Noto Serif KR + 수집상품 일괄관리(퍼센티 동등) +
   온보딩 위저드 + 게임화 + 구독 + PWA/베타. 순서: 디자인→일괄관리→온보딩→게임화→구독→앱. (대형 — 덩어리별 PR)

--- a/src/seller_console/collect_groups.py
+++ b/src/seller_console/collect_groups.py
@@ -1,0 +1,106 @@
+"""src/seller_console/collect_groups.py — 수집 상품 그룹 (Phase 247, v3 P1-5 퍼센티 그룹관리).
+
+셀러별 상품 그룹 CRUD. 상품은 extra_json.group_id 로 그룹에 배정되며, 그룹 단위로
+수집 이력 필터·일괄작업을 할 수 있다(가짜 그룹 금지 — 실제 저장).
+
+저장: GOOGLE_SHEET_ID 있으면 `collect_groups` 워크시트(id|seller_id|name|created_at),
+없으면 인메모리. (collect_history_store와 동일 패턴)
+"""
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from datetime import datetime, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
+_WS_NAME = "collect_groups"
+_HEADERS = ["id", "seller_id", "name", "created_at"]
+
+# 인메모리 폴백: list of dict
+_in_memory: list[dict] = []
+
+
+def _get_worksheet():
+    from src.utils.sheets import open_sheet
+    ws = open_sheet(_SHEET_ID, _WS_NAME)
+    try:
+        first = ws.row_values(1)
+        if not first or first[0] != "id":
+            ws.insert_row(_HEADERS, index=1)
+    except Exception:
+        pass
+    return ws
+
+
+def list_groups(seller_id: Optional[str]) -> list[dict]:
+    """셀러의 그룹 목록 (최신순)."""
+    sid = str(seller_id or "")
+    rows: list[dict] = []
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            rows = [r for r in ws.get_all_records() if str(r.get("seller_id", "") or "") == sid]
+        except Exception as exc:
+            logger.warning("그룹 목록 조회 실패(인메모리 폴백): %s", exc)
+            rows = [dict(r) for r in _in_memory if str(r.get("seller_id", "") or "") == sid]
+    else:
+        rows = [dict(r) for r in _in_memory if str(r.get("seller_id", "") or "") == sid]
+    rows.sort(key=lambda r: r.get("created_at", ""), reverse=True)
+    return [{"id": r.get("id"), "name": r.get("name", "")} for r in rows]
+
+
+def create_group(seller_id: Optional[str], name: str) -> Optional[dict]:
+    """그룹 생성. 같은 이름이 있으면 그걸 반환(중복 생성 방지)."""
+    sid = str(seller_id or "")
+    name = (name or "").strip()[:60]
+    if not name:
+        return None
+    for g in list_groups(sid):
+        if g["name"] == name:
+            return g
+    gid = secrets.token_hex(4)
+    row = {"id": gid, "seller_id": sid, "name": name,
+           "created_at": datetime.now(timezone.utc).isoformat()}
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            ws.append_row([row[h] for h in _HEADERS])
+        except Exception as exc:
+            logger.warning("그룹 생성 Sheets 실패(인메모리 폴백): %s", exc)
+            _in_memory.append(row)
+    else:
+        _in_memory.append(row)
+    return {"id": gid, "name": name}
+
+
+def delete_group(seller_id: Optional[str], group_id: str) -> bool:
+    """그룹 삭제(상품의 group_id는 그대로 — 그룹만 사라짐). 셀러 격리."""
+    sid = str(seller_id or "")
+    gid = str(group_id or "")
+    if not gid:
+        return False
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            values = ws.get_all_values()
+            if values:
+                header = values[0]
+                idx = {h: i for i, h in enumerate(header)}
+                id_i, sid_i = idx.get("id"), idx.get("seller_id")
+                for r in range(len(values), 1, -1):
+                    row = values[r - 1]
+                    if id_i is not None and id_i < len(row) and row[id_i] == gid:
+                        if sid_i is None or (sid_i < len(row) and str(row[sid_i] or "") == sid):
+                            ws.delete_rows(r)
+                            return True
+            return False
+        except Exception as exc:
+            logger.warning("그룹 삭제 Sheets 실패(인메모리 폴백): %s", exc)
+    before = len(_in_memory)
+    _in_memory[:] = [r for r in _in_memory
+                     if not (str(r.get("id")) == gid and str(r.get("seller_id", "") or "") == sid)]
+    return len(_in_memory) < before

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -86,6 +86,17 @@
             <option value="archived" {% if filters.status == "archived" %}selected{% endif %}>📦 보관</option>
           </select>
         </div>
+        {% if groups %}
+        <div class="col-6 col-md-2">
+          <label class="form-label small text-muted mb-1">그룹</label>
+          <select name="group" class="form-select form-select-sm">
+            <option value="">전체 그룹</option>
+            {% for g in groups %}
+            <option value="{{ g.id }}" {% if g.id == filters.group %}selected{% endif %}>🗂 {{ g.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        {% endif %}
         <div class="col-6 col-md-2">
           <label class="form-label small text-muted mb-1">정렬</label>
           <select name="sort" class="form-select form-select-sm">
@@ -133,6 +144,9 @@
         </button>
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkCategoryBtn" onclick="openBulkCategoryModal()" disabled>
           🏷 카테고리 지정
+        </button>
+        <button type="button" class="btn btn-outline-primary btn-sm" id="bulkGroupBtn" onclick="openBulkGroupModal()" disabled>
+          🗂 그룹 지정
         </button>
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkTranslateBtn" onclick="runBulkTranslate()" disabled>
           🌐 한국어 번역
@@ -234,7 +248,7 @@
         </table>
       </div>
       {% if pagination and pagination.total_pages > 1 %}
-      {% set _qs = '&q=' ~ filters.q ~ '&domain=' ~ filters.domain ~ '&source=' ~ filters.source ~ '&status=' ~ filters.status ~ '&sort=' ~ filters.sort ~ '&days=' ~ filters.days ~ '&per_page=' ~ filters.per_page %}
+      {% set _qs = '&q=' ~ filters.q ~ '&domain=' ~ filters.domain ~ '&source=' ~ filters.source ~ '&status=' ~ filters.status ~ '&group=' ~ filters.group ~ '&sort=' ~ filters.sort ~ '&days=' ~ filters.days ~ '&per_page=' ~ filters.per_page %}
       <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 p-2 border-top">
         <span class="small text-muted">전체 {{ pagination.total }}개 · {{ pagination.page }}/{{ pagination.total_pages }} 페이지</span>
         <nav><ul class="pagination pagination-sm mb-0">
@@ -252,7 +266,7 @@
   {% else %}
   <div class="card">
     <div class="card-body text-center py-5">
-      {% if filters.q or filters.domain or filters.source or filters.status %}
+      {% if filters.q or filters.domain or filters.source or filters.status or filters.group %}
       <p class="text-muted mb-3">조건에 맞는 수집 항목이 없습니다.</p>
       <a href="/seller/collect/history" class="btn btn-outline-secondary btn-sm">필터 초기화</a>
       {% else %}
@@ -355,6 +369,47 @@
   </div>
 </div>
 
+<!-- 일괄 그룹 지정 모달 -->
+<div class="modal fade" id="bulkGroupModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">🗂 그룹 지정</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted">선택한 <strong id="groupSelCount">0</strong>개 상품을 그룹에 묶습니다. 그룹별로 필터·일괄작업할 수 있어요.</p>
+        <label class="form-label small mb-1" for="bulkGroupSelect">기존 그룹</label>
+        <select id="bulkGroupSelect" class="form-select form-select-sm mb-2">
+          <option value="">(그룹 없음 / 해제)</option>
+          {% for g in groups %}
+          <option value="{{ g.id }}">🗂 {{ g.name }}</option>
+          {% endfor %}
+        </select>
+        <label class="form-label small mb-1" for="bulkGroupNew">또는 새 그룹 만들기</label>
+        <input type="text" id="bulkGroupNew" class="form-control form-control-sm" placeholder="새 그룹 이름(입력 시 우선)">
+        {% if groups %}
+        <div class="mt-3">
+          <div class="small text-muted mb-1">그룹 관리</div>
+          <ul class="list-group list-group-flush" id="groupManageList">
+            {% for g in groups %}
+            <li class="list-group-item d-flex justify-content-between align-items-center px-0 py-1" data-gid="{{ g.id }}">
+              <span class="small">🗂 {{ g.name }}</span>
+              <button type="button" class="btn btn-ghost btn-sm py-0" onclick="deleteGroup('{{ g.id }}', this)">삭제</button>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="bulkGroupConfirm" onclick="runBulkGroup()">적용</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- 일괄 카테고리 지정 모달 -->
 <div class="modal fade" id="bulkCategoryModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
@@ -418,6 +473,8 @@ function refreshSelCount() {
   if (del) del.disabled = n === 0;
   const cat = document.getElementById('bulkCategoryBtn');
   if (cat) cat.disabled = n === 0;
+  const grp = document.getElementById('bulkGroupBtn');
+  if (grp) grp.disabled = n === 0;
   const tr = document.getElementById('bulkTranslateBtn');
   if (tr) tr.disabled = n === 0;
   const pr = document.getElementById('bulkPriceBtn');
@@ -579,6 +636,53 @@ async function runBulkTranslate() {
     pcToast('요청 실패: ' + err.message, 'error');
   } finally {
     setButtonLoading(btn, false);
+  }
+}
+
+function openBulkGroupModal() {
+  const ids = selectedItemIds();
+  if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }
+  document.getElementById('groupSelCount').textContent = ids.length;
+  new bootstrap.Modal(document.getElementById('bulkGroupModal')).show();
+}
+async function runBulkGroup() {
+  const ids = selectedItemIds();
+  if (!ids.length) return;
+  const groupId = document.getElementById('bulkGroupSelect').value;
+  const groupName = document.getElementById('bulkGroupNew').value.trim();
+  const btn = document.getElementById('bulkGroupConfirm');
+  setButtonLoading(btn, true, '적용 중…');
+  try {
+    const resp = await fetch('/seller/collect/bulk-group', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({item_ids: ids, group_id: groupName ? '' : groupId, group_name: groupName}),
+    });
+    const ctype = resp.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) { pcToast(`요청 실패 (HTTP ${resp.status}).`, 'error'); return; }
+    const data = await resp.json();
+    if (!data.ok) { pcToast(data.error || '그룹 지정 실패', 'error'); return; }
+    bootstrap.Modal.getInstance(document.getElementById('bulkGroupModal'))?.hide();
+    pcToast(`${data.updated}개 상품을 그룹에 배정했습니다.`, 'success');
+    if (groupName) setTimeout(() => location.reload(), 700);  // 새 그룹이 필터에 보이도록
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
+  } finally {
+    setButtonLoading(btn, false);
+  }
+}
+async function deleteGroup(gid, el) {
+  if (!confirm('이 그룹을 삭제할까요? (상품은 삭제되지 않고 그룹만 해제됩니다)')) return;
+  try {
+    const resp = await fetch('/seller/collect/groups/delete', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({id: gid}),
+    });
+    const data = await resp.json();
+    if (!data.ok) { pcToast('그룹 삭제 실패', 'error'); return; }
+    const li = el.closest('li'); if (li) li.remove();
+    pcToast('그룹을 삭제했습니다.', 'success');
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
   }
 }
 

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1935,6 +1935,96 @@ def collect_bulk_translate():
                     "message": message, "results": results})
 
 
+@bp.post("/collect/groups/create")
+def collect_group_create():
+    """상품 그룹 생성 (셀러 격리). Request: {"name": "..."}"""
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    data = request.get_json(force=True, silent=True) or {}
+    name = str(data.get("name") or "").strip()
+    if not name:
+        return jsonify({"ok": False, "error": "그룹 이름을 입력하세요."}), 400
+    try:
+        from . import collect_groups
+        g = collect_groups.create_group(_seller_id(), name)
+    except Exception as exc:
+        logger.warning("그룹 생성 오류: %s", exc)
+        return jsonify({"ok": False, "error": "그룹 생성 중 오류가 발생했습니다."}), 500
+    if not g:
+        return jsonify({"ok": False, "error": "그룹 이름이 올바르지 않습니다."}), 400
+    return jsonify({"ok": True, "group": g})
+
+
+@bp.post("/collect/groups/delete")
+def collect_group_delete():
+    """상품 그룹 삭제 (셀러 격리). Request: {"id": "..."}"""
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    data = request.get_json(force=True, silent=True) or {}
+    gid = str(data.get("id") or "").strip()
+    if not gid:
+        return jsonify({"ok": False, "error": "그룹 id가 필요합니다."}), 400
+    try:
+        from . import collect_groups
+        ok = collect_groups.delete_group(_seller_id(), gid)
+    except Exception as exc:
+        logger.warning("그룹 삭제 오류: %s", exc)
+        return jsonify({"ok": False, "error": "그룹 삭제 중 오류가 발생했습니다."}), 500
+    return jsonify({"ok": bool(ok)})
+
+
+@bp.post("/collect/bulk-group")
+def collect_bulk_group():
+    """선택 상품을 그룹에 일괄 배정 (셀러 격리). group_id="" 면 그룹 해제.
+
+    Request: {"item_ids": [...], "group_id": "..."} (또는 "group_name" 신규 생성)
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids") if isinstance(data.get("item_ids"), list) else []
+    item_ids = [str(i) for i in item_ids if str(i).strip()][:1000]
+    if not item_ids:
+        return jsonify({"ok": False, "error": "상품을 선택하세요."}), 400
+    group_id = str(data.get("group_id") or "").strip()
+    group_name = str(data.get("group_name") or "").strip()
+
+    import json as _json
+    from . import collect_history_store
+    sid = _seller_id()
+    group_obj = None
+    if group_name and not group_id:
+        try:
+            from . import collect_groups
+            group_obj = collect_groups.create_group(sid, group_name)
+            group_id = (group_obj or {}).get("id", "")
+        except Exception as exc:
+            logger.warning("그룹 생성(배정 중) 오류: %s", exc)
+
+    updated = 0
+    try:
+        for item_id in item_ids:
+            item = collect_history_store.get(item_id, seller_id=sid)
+            if not item:
+                continue
+            try:
+                extra = _json.loads(item.get("extra_json") or "{}")
+            except (TypeError, ValueError):
+                extra = {}
+            if group_id:
+                extra["group_id"] = group_id
+            else:
+                extra.pop("group_id", None)  # 그룹 해제
+            if collect_history_store.update(item_id, seller_id=sid,
+                                            extra_json=_json.dumps(extra, ensure_ascii=False)):
+                updated += 1
+    except Exception as exc:
+        logger.warning("일괄 그룹 배정 오류: %s", exc)
+        return jsonify({"ok": False, "error": "그룹 배정 중 오류가 발생했습니다."}), 500
+
+    return jsonify({"ok": True, "updated": updated, "group": group_obj, "group_id": group_id})
+
+
 @bp.post("/collect/bulk-price")
 def collect_bulk_price():
     """수집 이력 여러 항목에 목표 마진율/원가 배수를 일괄 적용 (셀러 격리).
@@ -4495,6 +4585,7 @@ def collect_history():
     days = int(request.args.get("days", "30"))
     q = request.args.get("q", "").strip()
     status_f = request.args.get("status", "").strip()          # ""=전체 / ok / archived
+    group_f = request.args.get("group", "").strip()            # 그룹 id 필터
     sort = (request.args.get("sort") or "newest").strip()
     per_page = request.args.get("per_page", 50, type=int)
     if per_page not in (20, 50, 100):
@@ -4516,6 +4607,15 @@ def collect_history():
     # 상태 필터(활성/보관)
     if status_f in ("ok", "archived"):
         items = [it for it in items if (it.get("status") or "") == status_f]
+
+    # 그룹 필터 (extra_json.group_id)
+    if group_f:
+        def _grp(it):
+            try:
+                return (json.loads(it.get("extra_json") or "{}") or {}).get("group_id") or ""
+            except Exception:
+                return ""
+        items = [it for it in items if _grp(it) == group_f]
 
     # 검색(제목/도메인/URL 부분일치)
     if q:
@@ -4583,6 +4683,12 @@ def collect_history():
         }
     except Exception:
         translation_free = {"limit": 20, "used": 0, "remaining": 20}
+    # 상품 그룹(v3 P1-5)
+    try:
+        from . import collect_groups
+        groups = collect_groups.list_groups(_seller_id())
+    except Exception:
+        groups = []
     return render_template(
         "collect_history.html",
         page="collect_history",
@@ -4590,12 +4696,13 @@ def collect_history():
         summary=summ,
         domains=domains,
         filters={"domain": domain, "source": source, "days": days,
-                 "q": q, "status": status_f, "sort": sort, "per_page": per_page},
+                 "q": q, "status": status_f, "group": group_f, "sort": sort, "per_page": per_page},
         pagination={"page": page, "per_page": per_page, "total": total_filtered,
                     "total_pages": total_pages},
         upload_markets=upload_markets,
         category_options=CATEGORY_OPTIONS,
         translation_free=translation_free,
+        groups=groups,
     )
 
 

--- a/tests/test_collect_groups.py
+++ b/tests/test_collect_groups.py
@@ -1,0 +1,92 @@
+"""tests/test_collect_groups.py — 수집 상품 그룹 관리 (Phase 247, v3 P1-5)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    from src.seller_console import collect_history_store as chs
+    from src.seller_console import collect_groups as cg
+    chs._in_memory.clear()
+    cg._in_memory.clear()
+    yield
+    chs._in_memory.clear()
+    cg._in_memory.clear()
+
+
+def test_group_crud(client):
+    from src.seller_console import collect_groups as cg
+    g = cg.create_group("s1", "여름신상")
+    assert g and g["name"] == "여름신상"
+    # 중복 이름 → 같은 그룹 반환
+    g2 = cg.create_group("s1", "여름신상")
+    assert g2["id"] == g["id"]
+    assert len(cg.list_groups("s1")) == 1
+    # 타 셀러 격리
+    assert cg.list_groups("s2") == []
+    assert cg.delete_group("s1", g["id"]) is True
+    assert cg.list_groups("s1") == []
+
+
+def test_create_group_route(client):
+    r = client.post("/seller/collect/groups/create", json={"name": "가방류"})
+    assert r.status_code == 200
+    assert r.get_json()["group"]["name"] == "가방류"
+
+
+def test_bulk_group_assign_and_new(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t1", seller_id="default")
+    b = chs.append(source="manual", url="https://x/2", title="t2", seller_id="default")
+    # 새 그룹 생성하며 배정
+    r = client.post("/seller/collect/bulk-group",
+                    json={"item_ids": [a, b], "group_name": "신상"})
+    data = r.get_json()
+    assert data["ok"] is True and data["updated"] == 2
+    gid = data["group_id"]
+    for it in chs._in_memory:
+        assert json.loads(it["extra_json"])["group_id"] == gid
+
+
+def test_history_filter_by_group(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="가방A", seller_id="default")
+    chs.append(source="manual", url="https://x/2", title="기타B", seller_id="default")
+    r = client.post("/seller/collect/bulk-group", json={"item_ids": [a], "group_name": "백"})
+    gid = r.get_json()["group_id"]
+    html = client.get(f"/seller/collect/history?group={gid}").get_data(as_text=True)
+    assert "가방A" in html
+    assert "기타B" not in html
+
+
+def test_bulk_group_unassign(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t1", seller_id="default")
+    r = client.post("/seller/collect/bulk-group", json={"item_ids": [a], "group_name": "G"})
+    gid = r.get_json()["group_id"]
+    # 그룹 해제(group_id 빈값, group_name 없음)
+    client.post("/seller/collect/bulk-group", json={"item_ids": [a], "group_id": ""})
+    assert "group_id" not in json.loads(chs._in_memory[0]["extra_json"])
+    assert gid  # (생성됐던 id)
+
+
+def test_history_page_has_group_ui(client):
+    html = client.get("/seller/collect/history").get_data(as_text=True)
+    # 빈 상태에서도 그룹 버튼 JS는 로드됨
+    assert "bulkGroupBtn" in html
+    assert "runBulkGroup" in html


### PR DESCRIPTION
오너 v3 추가분 **P1-5 퍼센티 기능 포팅 — 첫 항목(그룹 상품 관리)**입니다. 퍼센티의 "그룹 지정 → 그룹별 관리"를 코고가네에 실동작으로 가져왔습니다.

## 변경
- **신설 `collect_groups.py`** — 셀러별 그룹 CRUD(create/list/delete). Sheets `collect_groups` 워크시트 + 인메모리 폴백, 중복 이름은 기존 그룹 재사용, **셀러 격리**.
- **라우트:**
  - `POST /seller/collect/groups/create` `{name}` → 그룹 생성
  - `POST /seller/collect/groups/delete` `{id}` → 그룹 삭제(상품은 유지, 그룹만 해제)
  - `POST /seller/collect/bulk-group` `{item_ids, group_id | group_name}` → 선택 상품을 `extra_json.group_id`에 배정. `group_name` 주면 신규 생성하며 배정, 빈값=그룹 해제.
- **수집 이력 UI:**
  - 필터바에 **그룹 드롭다운**(`?group=`)
  - 액션바 **🗂 그룹 지정** 버튼 + 모달(기존 그룹 선택 · 새 그룹 생성 · 그룹 관리/삭제)
  - 그룹으로 필터한 뒤 기존 **일괄작업(마켓등록/번역/가격/카테고리/삭제/상태/복제)**과 그대로 조합 가능.

## 테스트
- 신규 6케이스(CRUD·셀러 격리·배정·새 그룹·그룹 필터·해제·UI).
- 전체 `pytest` **10064 passed**.

## 다음 (P1-5 우선순위)
금지어/치환 규칙 → 이미지 편집 UI → 통관고유부호(PCCC) → 장부/애널리틱스 노출 → 직원계정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_