### PR TITLE
feat(rules): 금지어 필터 + 단어 치환 + 일괄 상품명 정제 (Phase 248, v3 P1-5 #2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,11 @@
     - ✅ v3 P1-5 퍼센티 포팅 #1 그룹관리(Phase 247): 신설 `collect_groups.py`(셀러별 그룹 CRUD, Sheets+인메모리).
       라우트 `/collect/groups/create|delete`, `/collect/bulk-group`(item_ids→extra.group_id, group_name 신규생성/해제).
       수집이력에 그룹 필터(?group=) + '🗂 그룹 지정' 버튼/모달(기존선택·새그룹·관리삭제). 셀러 격리.
-    - ⏳ 다음: 퍼센티 포팅 #2 금지어/치환 → 이미지편집UI → 통관고유부호 → 장부/애널 노출. 그리고 멀티워커 이력
-      영구화(옵트인), 모바일, 수집버튼 리디자인.
+    - ✅ v3 P1-5 포팅 #2 금지어/치환(Phase 248): 신설 `word_rules.py`(셀러별 banned[]+subs[{from,to}], Sheets+인메모리),
+      설정 페이지 `/seller/listing/word-rules`(+nav), 저장 `/word-rules/save`, 일괄 `/collect/bulk-clean`
+      (선택 제목에 치환→금지어제거 적용, 규칙 없으면 400+안내). 수집이력 '✨ 상품명 정제' 버튼.
+    - ⏳ 다음: 퍼센티 포팅 #3 이미지편집UI → #4 통관고유부호(PCCC) → #5 장부/애널 노출 → 직원계정. 그리고
+      멀티워커 이력 영구화(옵트인), 모바일, 수집버튼 리디자인.
 - **KOHgogane 브리프 v2 (전면 리디자인 로드맵, 오너 제공 2026-06-20):** 코가네 퍼센티→**코고가네/KOHgogane** 리브랜딩 +
   catdyy식 디자인 토큰(먹/한지/금 + 청록 Primary) + Pretendard/Noto Serif KR + 수집상품 일괄관리(퍼센티 동등) +
   온보딩 위저드 + 게임화 + 구독 + PWA/베타. 순서: 디자인→일괄관리→온보딩→게임화→구독→앱. (대형 — 덩어리별 PR)

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -49,6 +49,7 @@
       <li class="console-nav-group-title">상품</li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/listing/ai-create') %}active{% endif %}" href="/seller/listing/ai-create"><i class="bi bi-robot"></i><span>AI 상품등록</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/listing/history') %}active{% endif %}" href="/seller/listing/history"><i class="bi bi-clock-history"></i><span>등록 이력</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/listing/word-rules') %}active{% endif %}" href="/seller/listing/word-rules"><i class="bi bi-slash-circle"></i><span>금지어·치환 규칙</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/media/queue') %}active{% endif %}" href="/seller/media/queue"><i class="bi bi-image"></i><span>이미지 큐</span></a></li>
 
       <li class="console-nav-group-title">리서치/소싱</li>

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -151,6 +151,10 @@
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkTranslateBtn" onclick="runBulkTranslate()" disabled>
           🌐 한국어 번역
         </button>
+        <button type="button" class="btn btn-outline-primary btn-sm" id="bulkCleanBtn" onclick="runBulkClean()" disabled
+                title="설정한 금지어 제거 + 단어 치환을 제목에 적용">
+          ✨ 상품명 정제
+        </button>
         {% if translation_free %}
         <span class="small {{ 'text-muted' if translation_free.remaining > 0 else 'text-danger' }}" id="translFree"
               title="무료 번역은 실제 번역된 건수만 차감됩니다(번역기 미설정 시 차감 없음).">
@@ -477,6 +481,8 @@ function refreshSelCount() {
   if (grp) grp.disabled = n === 0;
   const tr = document.getElementById('bulkTranslateBtn');
   if (tr) tr.disabled = n === 0;
+  const cl = document.getElementById('bulkCleanBtn');
+  if (cl) cl.disabled = n === 0;
   const pr = document.getElementById('bulkPriceBtn');
   if (pr) pr.disabled = n === 0;
   const st = document.getElementById('bulkStatusBtn');
@@ -588,6 +594,43 @@ async function runBulkPrice() {
     });
     bootstrap.Modal.getInstance(document.getElementById('bulkPriceModal'))?.hide();
     pcToast(`${data.updated}개 상품에 적용했습니다.`, 'success');
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
+  } finally {
+    setButtonLoading(btn, false);
+  }
+}
+
+async function runBulkClean() {
+  const ids = selectedItemIds();
+  if (!ids.length) { pcToast('상품을 먼저 선택하세요.', 'warning'); return; }
+  const btn = document.getElementById('bulkCleanBtn');
+  setButtonLoading(btn, true, '정제 중…');
+  try {
+    const resp = await fetch('/seller/collect/bulk-clean', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({item_ids: ids}),
+    });
+    const ctype = resp.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) { pcToast(`요청 실패 (HTTP ${resp.status}).`, 'error'); return; }
+    const data = await resp.json();
+    if (!data.ok) {
+      if (data.no_rules) {
+        pcToast('금지어/치환 규칙이 없습니다. 규칙 설정으로 이동합니다.', 'warning');
+        setTimeout(() => { location.href = '/seller/listing/word-rules'; }, 900);
+      } else { pcToast(data.error || '정제 실패', 'error'); }
+      return;
+    }
+    // 변경된 제목으로 행 갱신
+    (data.results || []).forEach(r => {
+      if (r.changed && r.title != null) {
+        const chk = document.querySelector(`.row-chk[value="${r.id}"]`);
+        const tr = chk && chk.closest('tr');
+        const a = tr && tr.querySelector('td a.fw-semibold');
+        if (a) { a.textContent = r.title; a.title = r.title; }
+      }
+    });
+    pcToast(`${data.updated}개 상품명을 정제했습니다.`, 'success');
   } catch (err) {
     pcToast('요청 실패: ' + err.message, 'error');
   } finally {

--- a/src/seller_console/templates/word_rules.html
+++ b/src/seller_console/templates/word_rules.html
@@ -1,0 +1,70 @@
+{% extends "_base.html" %}
+{% block title %}금지어·치환 규칙{% endblock %}
+{% block content %}
+<div class="container-fluid py-4" style="max-width: 820px;">
+  <h1 class="h3 mb-1">🚫 금지어 · 단어 치환 규칙</h1>
+  <p class="text-muted mb-4">상품명에서 빼야 할 <strong>금지어</strong>와, 바꿔 쓸 <strong>치환 규칙</strong>을 설정하세요. 수집 이력에서 <strong>‘✨ 상품명 정제’</strong>로 선택 상품에 일괄 적용됩니다.</p>
+
+  <div class="card mb-3">
+    <div class="card-header"><strong>🚫 금지어</strong> <span class="text-muted small">— 제목에 있으면 제거됩니다</span></div>
+    <div class="card-body">
+      <textarea id="bannedInput" class="form-control" rows="5"
+                placeholder="한 줄에 하나씩 또는 쉼표로 구분&#10;예) 정품&#10;최저가&#10;특가">{{ rules.banned | join('\n') }}</textarea>
+    </div>
+  </div>
+
+  <div class="card mb-3">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span><strong>🔁 치환 규칙</strong> <span class="text-muted small">— A를 B로 바꿉니다</span></span>
+      <button type="button" class="btn btn-ghost btn-sm" onclick="addSubRow()">＋ 행 추가</button>
+    </div>
+    <div class="card-body">
+      <div id="subRows"></div>
+      <div class="text-muted small mt-1">예) <code>정품</code> → <code>(공백)</code>, <code>나이키</code> → <code>NIKE</code></div>
+    </div>
+  </div>
+
+  <button type="button" class="btn btn-primary" id="saveBtn" onclick="saveRules()">💾 규칙 저장</button>
+  <a href="/seller/collect/history" class="btn btn-outline-secondary">수집 이력으로</a>
+</div>
+
+<script>
+const INIT_SUBS = {{ rules.subs | tojson }};
+
+function addSubRow(frm, to) {
+  const wrap = document.getElementById('subRows');
+  const row = document.createElement('div');
+  row.className = 'row g-2 align-items-center mb-2 sub-row';
+  row.innerHTML =
+    '<div class="col"><input class="form-control form-control-sm sub-from" placeholder="찾을 단어" value="' + (frm ? frm.replace(/"/g,'&quot;') : '') + '"></div>' +
+    '<div class="col-auto">→</div>' +
+    '<div class="col"><input class="form-control form-control-sm sub-to" placeholder="바꿀 단어(비우면 삭제)" value="' + (to ? to.replace(/"/g,'&quot;') : '') + '"></div>' +
+    '<div class="col-auto"><button type="button" class="btn btn-ghost btn-sm" onclick="this.closest(\'.sub-row\').remove()">✕</button></div>';
+  wrap.appendChild(row);
+}
+(INIT_SUBS && INIT_SUBS.length ? INIT_SUBS : [{}]).forEach(s => addSubRow(s.from, s.to));
+
+async function saveRules() {
+  const banned = document.getElementById('bannedInput').value;
+  const subs = Array.from(document.querySelectorAll('.sub-row')).map(r => ({
+    from: r.querySelector('.sub-from').value.trim(),
+    to: r.querySelector('.sub-to').value.trim(),
+  })).filter(s => s.from);
+  const btn = document.getElementById('saveBtn');
+  setButtonLoading(btn, true, '저장 중…');
+  try {
+    const resp = await fetch('/seller/listing/word-rules/save', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({banned: banned, subs: subs}),
+    });
+    const data = await resp.json();
+    if (!data.ok) { pcToast(data.error || '저장 실패', 'error'); return; }
+    pcToast('규칙을 저장했습니다.', 'success');
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
+  } finally {
+    setButtonLoading(btn, false);
+  }
+}
+</script>
+{% endblock %}

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -2025,6 +2025,85 @@ def collect_bulk_group():
     return jsonify({"ok": True, "updated": updated, "group": group_obj, "group_id": group_id})
 
 
+@bp.get("/listing/word-rules")
+def word_rules_page():
+    """금지어/치환 규칙 설정 페이지 (v3 P1-5)."""
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.url))
+    from . import word_rules
+    rules = word_rules.get_rules(_seller_id())
+    return render_template("word_rules.html", page="word_rules", rules=rules)
+
+
+@bp.post("/listing/word-rules/save")
+def word_rules_save():
+    """규칙 저장. Request: {"banned": "..." or [...], "subs": [{from,to}...]}"""
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    data = request.get_json(force=True, silent=True) or {}
+    try:
+        from . import word_rules
+        norm = word_rules.save_rules(_seller_id(), data.get("banned"), data.get("subs"))
+    except Exception as exc:
+        logger.warning("규칙 저장 오류: %s", exc)
+        return jsonify({"ok": False, "error": "규칙 저장 중 오류가 발생했습니다."}), 500
+    return jsonify({"ok": True, "rules": norm})
+
+
+@bp.post("/collect/bulk-clean")
+def collect_bulk_clean():
+    """선택 상품의 제목에 금지어/치환 규칙을 일괄 적용 (셀러 격리).
+
+    Request: {"item_ids": [...]}
+    Response: {"ok": true, "updated": N, "results": [{id, title, changed}]}
+    """
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids") if isinstance(data.get("item_ids"), list) else []
+    item_ids = [str(i) for i in item_ids if str(i).strip()][:1000]
+    if not item_ids:
+        return jsonify({"ok": False, "error": "상품을 선택하세요."}), 400
+
+    import json as _json
+    from . import collect_history_store, word_rules
+    sid = _seller_id()
+    rules = word_rules.get_rules(sid)
+    if not rules.get("banned") and not rules.get("subs"):
+        return jsonify({"ok": False, "error": "설정된 금지어/치환 규칙이 없습니다. 먼저 규칙을 저장하세요.",
+                        "no_rules": True}), 400
+
+    updated = 0
+    results = []
+    try:
+        for item_id in item_ids:
+            item = collect_history_store.get(item_id, seller_id=sid)
+            if not item:
+                continue
+            title = item.get("title") or ""
+            res = word_rules.apply_rules(title, sid, rules=rules)
+            if not res["changed"]:
+                results.append({"id": item_id, "title": title, "changed": False})
+                continue
+            # extra_json의 title_ko도 함께 정제(표시 일관성)
+            try:
+                extra = _json.loads(item.get("extra_json") or "{}")
+            except (TypeError, ValueError):
+                extra = {}
+            extra["title_ko"] = res["text"]
+            ok = collect_history_store.update(item_id, seller_id=sid, title=res["text"],
+                                              extra_json=_json.dumps(extra, ensure_ascii=False))
+            if ok:
+                updated += 1
+            results.append({"id": item_id, "title": res["text"], "changed": True,
+                            "removed": res["removed"], "substituted": res["substituted"]})
+    except Exception as exc:
+        logger.warning("상품명 정제 오류: %s", exc)
+        return jsonify({"ok": False, "error": "상품명 정제 중 오류가 발생했습니다."}), 500
+
+    return jsonify({"ok": True, "updated": updated, "results": results})
+
+
 @bp.post("/collect/bulk-price")
 def collect_bulk_price():
     """수집 이력 여러 항목에 목표 마진율/원가 배수를 일괄 적용 (셀러 격리).

--- a/src/seller_console/word_rules.py
+++ b/src/seller_console/word_rules.py
@@ -1,0 +1,137 @@
+"""src/seller_console/word_rules.py — 금지어 필터 + 단어 치환 규칙 (Phase 248, v3 P1-5).
+
+셀러별로 상품명/설명에서 ① 금지어(빼야 할 단어) ② 치환 규칙(A→B)을 설정하고,
+등록·정제 시 적용한다. 퍼센티의 '금지어 필터 / 키워드·단어 치환'에 대응(실동작).
+
+저장: GOOGLE_SHEET_ID 있으면 `word_rules` 워크시트(seller_id|banned|subs_json),
+없으면 인메모리. (collect_history_store와 동일 패턴)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
+_WS_NAME = "word_rules"
+_HEADERS = ["seller_id", "banned", "subs_json"]
+
+# 인메모리 폴백: seller_id → {"banned": [...], "subs": [{"from","to"}]}
+_in_memory: dict[str, dict] = {}
+
+
+def _get_worksheet():
+    from src.utils.sheets import open_sheet
+    ws = open_sheet(_SHEET_ID, _WS_NAME)
+    try:
+        first = ws.row_values(1)
+        if not first or first[0] != "seller_id":
+            ws.insert_row(_HEADERS, index=1)
+    except Exception:
+        pass
+    return ws
+
+
+def _parse_banned(raw) -> list[str]:
+    if isinstance(raw, list):
+        items = raw
+    else:
+        items = re.split(r"[\n,]", str(raw or ""))
+    out, seen = [], set()
+    for w in items:
+        w = (w or "").strip()
+        if w and w.lower() not in seen:
+            seen.add(w.lower())
+            out.append(w)
+    return out
+
+
+def _parse_subs(raw) -> list[dict]:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw or "[]")
+        except (TypeError, ValueError):
+            raw = []
+    out = []
+    for s in (raw or []):
+        if isinstance(s, dict):
+            frm = (s.get("from") or "").strip()
+            to = (s.get("to") or "").strip()
+            if frm:
+                out.append({"from": frm, "to": to})
+    return out
+
+
+def get_rules(seller_id: Optional[str]) -> dict:
+    """셀러의 규칙 {"banned": [...], "subs": [{"from","to"}]}."""
+    sid = str(seller_id or "")
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            for row in ws.get_all_records():
+                if str(row.get("seller_id", "") or "") == sid:
+                    return {"banned": _parse_banned(row.get("banned")),
+                            "subs": _parse_subs(row.get("subs_json"))}
+            return {"banned": [], "subs": []}
+        except Exception as exc:
+            logger.warning("규칙 조회 실패(인메모리 폴백): %s", exc)
+    r = _in_memory.get(sid) or {}
+    return {"banned": list(r.get("banned", [])), "subs": list(r.get("subs", []))}
+
+
+def save_rules(seller_id: Optional[str], banned, subs) -> dict:
+    """규칙 저장(전체 교체). 정규화 후 반환."""
+    sid = str(seller_id or "")
+    norm = {"banned": _parse_banned(banned), "subs": _parse_subs(subs)}
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            values = ws.get_all_values()
+            header = values[0] if values else _HEADERS
+            col = {h: i for i, h in enumerate(header)}
+            banned_str = "\n".join(norm["banned"])
+            subs_str = json.dumps(norm["subs"], ensure_ascii=False)
+            for r, row in enumerate(values[1:], start=2):
+                if col.get("seller_id", 0) < len(row) and str(row[col["seller_id"]] or "") == sid:
+                    ws.update_cell(r, col.get("banned", 1) + 1, banned_str)
+                    ws.update_cell(r, col.get("subs_json", 2) + 1, subs_str)
+                    return norm
+            new_row = [""] * len(header)
+            new_row[col.get("seller_id", 0)] = sid
+            new_row[col.get("banned", 1)] = banned_str
+            new_row[col.get("subs_json", 2)] = subs_str
+            ws.append_row(new_row)
+            return norm
+        except Exception as exc:
+            logger.warning("규칙 저장 실패(인메모리 폴백): %s", exc)
+    _in_memory[sid] = norm
+    return norm
+
+
+def apply_rules(text: str, seller_id: Optional[str], rules: Optional[dict] = None) -> dict:
+    """text에 치환→금지어 제거 순으로 적용.
+
+    Returns: {"text": 정제본, "substituted": [{from,to}...], "removed": [금지어...], "changed": bool}
+    """
+    original = text or ""
+    if rules is None:
+        rules = get_rules(seller_id)
+    out = original
+    substituted = []
+    for s in rules.get("subs", []):
+        frm, to = s.get("from", ""), s.get("to", "")
+        if frm and frm in out:
+            out = out.replace(frm, to)
+            substituted.append({"from": frm, "to": to})
+    removed = []
+    for w in rules.get("banned", []):
+        if w and w in out:
+            out = out.replace(w, "")
+            removed.append(w)
+    # 공백 정리
+    out = re.sub(r"\s{2,}", " ", out).strip()
+    return {"text": out, "substituted": substituted, "removed": removed, "changed": out != original}

--- a/tests/test_word_rules.py
+++ b/tests/test_word_rules.py
@@ -1,0 +1,81 @@
+"""tests/test_word_rules.py — 금지어/치환 규칙 (Phase 248, v3 P1-5)."""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    from src.seller_console import collect_history_store as chs
+    from src.seller_console import word_rules as wr
+    chs._in_memory.clear()
+    wr._in_memory.clear()
+    yield
+    chs._in_memory.clear()
+    wr._in_memory.clear()
+
+
+def test_apply_rules_substitute_and_remove():
+    from src.seller_console import word_rules as wr
+    rules = {"banned": ["정품", "최저가"], "subs": [{"from": "나이키", "to": "NIKE"}]}
+    res = wr.apply_rules("정품 나이키 운동화 최저가", "s1", rules=rules)
+    assert "정품" not in res["text"]
+    assert "최저가" not in res["text"]
+    assert "NIKE" in res["text"]
+    assert res["changed"] is True
+    assert "정품" in res["removed"]
+
+
+def test_save_and_get_rules_route(client):
+    r = client.post("/seller/listing/word-rules/save",
+                    json={"banned": "정품\n특가, 최저가", "subs": [{"from": "A", "to": "B"}]})
+    assert r.status_code == 200
+    rules = r.get_json()["rules"]
+    assert "정품" in rules["banned"] and "특가" in rules["banned"] and "최저가" in rules["banned"]
+    assert rules["subs"] == [{"from": "A", "to": "B"}]
+
+
+def test_bulk_clean_applies_to_titles(client):
+    from src.seller_console import collect_history_store as chs
+    from src.seller_console import word_rules as wr
+    wr.save_rules("default", ["정품"], [{"from": "신발", "to": "운동화"}])
+    a = chs.append(source="manual", url="https://x/1", title="정품 신발 멋짐", seller_id="default")
+    r = client.post("/seller/collect/bulk-clean", json={"item_ids": [a]})
+    data = r.get_json()
+    assert data["ok"] is True and data["updated"] == 1
+    new_title = chs._in_memory[0]["title"]
+    assert "정품" not in new_title
+    assert "운동화" in new_title
+
+
+def test_bulk_clean_no_rules_returns_hint(client):
+    from src.seller_console import collect_history_store as chs
+    a = chs.append(source="manual", url="https://x/1", title="t", seller_id="default")
+    r = client.post("/seller/collect/bulk-clean", json={"item_ids": [a]})
+    assert r.status_code == 400
+    assert r.get_json().get("no_rules") is True
+
+
+def test_word_rules_page_and_nav(client):
+    html = client.get("/seller/listing/word-rules").get_data(as_text=True)
+    assert "금지어" in html and "치환" in html
+    nav = client.get("/seller/dashboard").get_data(as_text=True)
+    assert "/seller/listing/word-rules" in nav
+
+
+def test_history_has_clean_button(client):
+    html = client.get("/seller/collect/history").get_data(as_text=True)
+    assert "bulkCleanBtn" in html and "runBulkClean" in html


### PR DESCRIPTION
오너 v3 추가분 **P1-5 퍼센티 기능 포팅 — 둘째(금지어 필터 + 단어 치환)**입니다.

## 변경
- **신설 `word_rules.py`** — 셀러별 규칙(`banned[]` + `subs[{from,to}]`) 저장(Sheets `word_rules` + 인메모리). `apply_rules(text)` = **치환 → 금지어 제거 → 공백 정리**(변경 내역 반환). 셀러 격리.
- **설정 페이지 `/seller/listing/word-rules`** (+ nav ‘금지어·치환 규칙’) — 금지어 textarea + 치환 규칙 행 추가/삭제 UI + 저장.
- **일괄 `/collect/bulk-clean`** — 선택 상품 제목에 규칙 적용·저장(`title` + `extra.title_ko`). 규칙이 없으면 400 + 규칙 설정 페이지로 안내.
- **수집 이력 액션바 ‘✨ 상품명 정제’** 버튼 — 적용 후 변경된 제목 즉시 갱신.

예) 금지어 `정품/최저가`, 치환 `나이키→NIKE` → "정품 나이키 운동화 최저가" → "NIKE 운동화".

## 테스트
- 신규 6케이스(치환·제거·저장·일괄 적용·규칙 없음 안내·페이지/nav/버튼).
- 전체 `pytest` **10070 passed**.

## 다음 (P1-5)
이미지 편집 UI → 통관고유부호(PCCC) → 장부/애널리틱스 노출 → 직원계정.

> ※ 현재는 셀러 전역 규칙 + ‘정제’ 일괄 적용입니다. 마켓별 규칙 분리·업로드 시 자동 적용은 후속으로 확장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_