### PR TITLE
feat(finance): 장부·정산 노출 + 실 주문 KPI (Phase 251, v3 P1-5 #5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,10 @@
     - ✅ v3 P1-5 포팅 #4 통관고유부호(Phase 250): 신설 `pccc_store.py`(셀러별 고객 PCCC CRUD+검색, Sheets+인메모리,
       P+12자리 형식검증). 페이지 `/seller/customs/pccc`(+nav '통관고유부호') 입력폼·검색·목록·삭제. 형식 안 맞으면
       저장은 하되 경고(정직). 개인정보 주의 안내.
-    - ⏳ 다음: 퍼센티 포팅 #5 장부/애널 노출 → 직원계정. 그리고 멀티워커 이력 영구화(옵트인), 모바일, 수집버튼 리디자인.
+    - ✅ v3 P1-5 포팅 #5 장부/애널 노출(Phase 251): 기존 settlement_report(`/seller/settlement`)를 '장부·정산'으로
+      프레이밍 + nav 노출(운영 그룹). 실 주문 KPI(OrderSyncService.kpi_summary, 미연동 0 정직) 추가 + BI 분석/마진
+      계산기/CSV·Excel 링크. (BI 분석 /seller/analytics는 이미 nav에 있음.)
+    - ⏳ 다음: 퍼센티 포팅 직원계정(후순위). 그리고 멀티워커 이력 영구화(옵트인), 모바일(P1-6), 수집버튼 리디자인(v4 P1).
 - **KOHgogane 브리프 v2 (전면 리디자인 로드맵, 오너 제공 2026-06-20):** 코가네 퍼센티→**코고가네/KOHgogane** 리브랜딩 +
   catdyy식 디자인 토큰(먹/한지/금 + 청록 Primary) + Pretendard/Noto Serif KR + 수집상품 일괄관리(퍼센티 동등) +
   온보딩 위저드 + 게임화 + 구독 + PWA/베타. 순서: 디자인→일괄관리→온보딩→게임화→구독→앱. (대형 — 덩어리별 PR)

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -79,6 +79,7 @@
       <li><a class="console-nav-link {% if _path.startswith('/seller/cs/autoreply') %}active{% endif %}" href="/seller/cs/autoreply"><i class="bi bi-magic"></i><span>CS 자동응답</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/cs/inbox') %}active{% endif %}" href="/seller/cs/inbox"><i class="bi bi-inbox"></i><span>CS 통합 인박스</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/analytics') %}active{% endif %}" href="/seller/analytics"><i class="bi bi-graph-up-arrow"></i><span>BI 분석</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/settlement') %}active{% endif %}" href="/seller/settlement"><i class="bi bi-cash-coin"></i><span>장부·정산</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/ads/campaigns') %}active{% endif %}" href="/seller/ads/campaigns"><i class="bi bi-megaphone"></i><span>광고 캠페인</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/ads/keywords') %}active{% endif %}" href="/seller/ads/keywords"><i class="bi bi-bullseye"></i><span>키워드 최적화</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/marketing/campaigns') %}active{% endif %}" href="/seller/marketing/campaigns"><i class="bi bi-ticket-perforated"></i><span>할인 캠페인</span></a></li>

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -7323,24 +7323,45 @@ def settlement_report():
     channels = "".join(
         f"<li>{ch}: {amt:,}원</li>" for ch, amt in report["by_channel"].items()
     ) or "<li>-</li>"
+
+    # 실 주문 KPI(연동 시 실데이터, 미연동 시 0 — 가짜 값 금지)
+    kpi = {"today_new": 0, "pending_ship": 0, "shipped": 0, "returned_exchanged": 0}
+    try:
+        from .orders.sync_service import OrderSyncService
+        k = OrderSyncService().kpi_summary() or {}
+        for key in kpi:
+            kpi[key] = int(k.get(key, 0) or 0)
+    except Exception as exc:
+        logger.debug("장부 주문 KPI 조회 실패: %s", exc)
+
     body = (
-        "<h4 class='mb-3'>💰 월별 정산 리포트</h4>"
+        "<h4 class='mb-1'>💰 장부 · 정산 (수익 관리)</h4>"
+        "<p class='text-muted small mb-3'>매출·정산 요약과 주문 현황입니다. 숫자는 연동된 마켓/주문 데이터 기준이며, "
+        "미연동 시 0으로 정직하게 표시됩니다.</p>"
         "<form class='row g-2 mb-3'>"
         "<div class='col-auto'><input name='month' class='form-control form-control-sm' value='"
         + month
         + "'></div>"
-        "<div class='col-auto'><button class='btn btn-sm btn-primary'>조회</button></div>"
+        "<div class='col-auto'><button class='btn btn-primary btn-sm'>조회</button></div>"
         "</form>"
+        "<div class='row g-2 mb-3'>"
+        f"<div class='col-6 col-md-3'><div class='card text-center p-2'><div class='fs-5 fw-bold'>{kpi['today_new']}</div><small class='text-muted'>오늘 신규주문</small></div></div>"
+        f"<div class='col-6 col-md-3'><div class='card text-center p-2'><div class='fs-5 fw-bold text-warning'>{kpi['pending_ship']}</div><small class='text-muted'>배송 대기</small></div></div>"
+        f"<div class='col-6 col-md-3'><div class='card text-center p-2'><div class='fs-5 fw-bold text-success'>{kpi['shipped']}</div><small class='text-muted'>배송 완료</small></div></div>"
+        f"<div class='col-6 col-md-3'><div class='card text-center p-2'><div class='fs-5 fw-bold text-danger'>{kpi['returned_exchanged']}</div><small class='text-muted'>반품/교환</small></div></div>"
+        "</div>"
         f"<div class='alert alert-light border'>이번달 매출(예정): <strong>{report['total_sales_krw']:,}원</strong><br>"
         f"실 입금 예정액: <strong>{report['total_expected_deposit_krw']:,}원</strong><br>"
         f"다음 정산일: {report['next_settlement_date']}</div>"
         "<h6>채널별 순이익</h6><ul>" + channels + "</ul>"
-        "<div class='d-flex gap-2'>"
-        f"<a class='btn btn-outline-secondary btn-sm' href='/seller/settlement/export.csv?month={month}'>CSV 내보내기</a>"
-        f"<a class='btn btn-outline-secondary btn-sm' href='/seller/settlement/export.xlsx?month={month}'>Excel 내보내기</a>"
+        "<div class='d-flex flex-wrap gap-2'>"
+        f"<a class='btn btn-gold btn-sm' href='/seller/settlement/export.csv?month={month}'>CSV 내보내기</a>"
+        f"<a class='btn btn-gold btn-sm' href='/seller/settlement/export.xlsx?month={month}'>Excel 내보내기</a>"
+        "<a class='btn btn-outline-secondary btn-sm' href='/seller/analytics'>📊 BI 분석</a>"
+        "<a class='btn btn-outline-secondary btn-sm' href='/seller/margin'>🧮 마진 계산기</a>"
         "</div>"
     )
-    return _render_seller_page("💰 정산 리포트", body, page="settlement")
+    return _render_seller_page("💰 장부 · 정산", body, page="settlement")
 
 
 @bp.get("/settlement/export.csv")

--- a/tests/test_settlement_ledger.py
+++ b/tests/test_settlement_ledger.py
@@ -1,0 +1,43 @@
+"""tests/test_settlement_ledger.py — 장부·정산 노출 (Phase 251, v3 P1-5 #5)."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_settlement_page_200_and_ledger_framing(client):
+    resp = client.get("/seller/settlement")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "장부" in html and "정산" in html
+    # 도구 링크 노출(애널리틱스/마진)
+    assert "/seller/analytics" in html
+    assert "/seller/margin" in html
+
+
+def test_settlement_shows_real_order_kpi(client):
+    fake = {"today_new": 7, "pending_ship": 3, "shipped": 11, "returned_exchanged": 1}
+    with patch("src.seller_console.orders.sync_service.OrderSyncService") as MockSvc:
+        MockSvc.return_value.kpi_summary.return_value = fake
+        resp = client.get("/seller/settlement")
+    html = resp.get_data(as_text=True)
+    assert ">7<" in html and ">11<" in html  # 실 주문 KPI 반영
+
+
+def test_settlement_in_nav(client):
+    html = client.get("/seller/dashboard").get_data(as_text=True)
+    assert "/seller/settlement" in html
+    assert "장부·정산" in html


### PR DESCRIPTION
오너 v3 추가분 **P1-5 퍼센티 기능 포팅 — 다섯째(장부/애널리틱스 노출)**입니다.

기존 finance/정산 모듈(`settlement_report`)이 만들어져 있었지만 **nav에 없어 접근 불가**였습니다 → 셀러 화면에 연결·노출.

## 변경
- `/seller/settlement`을 **‘장부·정산(수익 관리)’**로 프레이밍 + **nav ‘장부·정산’** 노출(운영 그룹). (BI 분석 `/seller/analytics`는 이미 nav에 있음)
- **실 주문 KPI 추가** — `OrderSyncService.kpi_summary`(신규/배송대기/배송완료/반품). 미연동 시 **0으로 정직 표시**(가짜 값 금지).
- 장부 도구 링크: CSV/Excel 내보내기 + BI 분석 + 마진 계산기(금 Secondary 버튼 적용).

## 테스트
- 신규 3케이스(장부 프레이밍·실 주문 KPI 반영·nav 노출).
- 전체 `pytest` **10084 passed**.

## P1-5 남은 것
직원계정(서브 계정 초대·권한) — 후순위. 이후 모바일(P1-6) → 수집버튼 리디자인(v4 P1).

> ※ 매출/정산 금액은 마켓/주문 연동 데이터 기준입니다. 주문 동기화가 설정되면 실수치가 채워지고, 미설정 시 0(정직).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_