### PR TITLE
feat(ux): 개발자 문구 "?" 툴팁 숨김 + About 소개 페이지 (Phase 254, v5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,11 @@
     /auth/google/start)→마켓 연동(실제 /markets/connect)→확장 설치(실제 /extension)→첫 수집(/manual-collect).
     각 단계 실제 동작 링크(가이드 아님), localStorage 진행저장·재진입, 로그인/마켓연결 자동 완료판정. 미로그인도 진입.
     대시보드+랜딩에 '✨ For Beginners·처음이신가요?'(주황 .btn-cta) 진입버튼.
-  - ⏳ 다음: 개발자 문구 "?" 팝오버 숨김 → About 소개 → 주황 CTA 추가 적용. (P0 실구글로그인=오너 콘솔 게시 사안)
+  - ✅ "?" 개발자문구 숨김 + About 소개(Phase 254): `.pc-help`("?" 원형) + _base.html 전역 Bootstrap 툴팁 init.
+    markets_connect 기술문구(MARKET_CRED_ENC_KEY·연결테스트 원리)를 본문→'?' 툴팁으로(본문은 '🔒 안전하게 암호화' 한 줄).
+    신설 `/seller/about`(about.html, 애플톤 수집/다듬기/등록 3카드 + 누구를 위한 건가 + 시작하기 CTA), 랜딩 푸터+고급nav 링크.
+  - ⏳ 다음(v5 남음): 주황 CTA 더 적용(로그인 구글버튼 등), For Beginners 서버측 진행저장(현재 localStorage). 
+    (P0 실구글로그인 계정선택=오너 콘솔 '프로덕션 게시' 사안.) — v5 큰 줄기 거의 완료.
 
 ## 🔑 검증된 환경/핸드오프 (오너 제공 — 누적, 두 번 묻지 말 것 / 2026-06-20)
 > 오너 지시(2026-06-20): "업데이트되는 정보는 핸드오프에 저장하고 두 번 일 시키지 마라."

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -102,6 +102,7 @@
       <li><a class="console-nav-link {% if _path.startswith('/seller/me/subscriptions') %}active{% endif %}" href="/seller/me/subscriptions"><i class="bi bi-person-check"></i><span>내 구독</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/wholesale/tiers') %}active{% endif %}" href="/seller/wholesale/tiers"><i class="bi bi-building"></i><span>도매 등급</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/wholesale/applications') %}active{% endif %}" href="/seller/wholesale/applications"><i class="bi bi-ui-checks"></i><span>B2B 신청 큐</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/about') %}active{% endif %}" href="/seller/about"><i class="bi bi-info-circle"></i><span>코고가네란?(소개)</span></a></li>
     </ul>
     </details>
     </div>
@@ -207,6 +208,15 @@ function closeSidebar() {
 (function () {
   var adv = document.getElementById('advNav');
   if (adv && adv.querySelector('.console-nav-link.active')) adv.open = true;
+})();
+
+// "?" 도움말 툴팁 초기화 — 개발자 문구를 본문에서 숨기고 클릭/hover 시에만(v5).
+(function () {
+  try {
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+      new bootstrap.Tooltip(el);
+    });
+  } catch (e) { /* bootstrap 미로드 시 무시 */ }
 })();
 
 if ('serviceWorker' in navigator) {

--- a/src/seller_console/templates/about.html
+++ b/src/seller_console/templates/about.html
@@ -1,0 +1,43 @@
+{% extends "_base.html" %}
+{% block title %}코고가네란?{% endblock %}
+{% block content %}
+<div class="container py-5" style="max-width: 760px;">
+
+  <div class="text-center mb-5">
+    <div style="font-size:3.4rem;">🛒</div>
+    <h1 class="display-5 fw-bold mb-2">코고가네</h1>
+    <p class="lead text-muted">해외 상품을 수집하고, 한국어로 다듬고, 우리 마켓에 등록까지.<br>구매대행 셀러를 위한 가장 쉬운 길.</p>
+    <a href="/seller/start" class="btn btn-cta btn-lg mt-2">✨ 처음이신가요? 시작하기</a>
+  </div>
+
+  <div class="row g-4 text-center mb-5">
+    <div class="col-md-4">
+      <div class="fs-1 mb-2">🔎</div>
+      <h5 class="fw-bold">수집</h5>
+      <p class="text-muted small">타오바오·아마존·알리 등 어떤 상품이든 버튼 한 번으로 가져와요. 크롬 확장·모바일 공유·붙여넣기까지.</p>
+    </div>
+    <div class="col-md-4">
+      <div class="fs-1 mb-2">🌐</div>
+      <h5 class="fw-bold">다듬기</h5>
+      <p class="text-muted small">제목·설명을 한국어로 번역하고, 금지어를 정리하고, 가격·마진을 한 번에 맞춰요.</p>
+    </div>
+    <div class="col-md-4">
+      <div class="fs-1 mb-2">🚀</div>
+      <h5 class="fw-bold">등록</h5>
+      <p class="text-muted small">쿠팡·스마트스토어·11번가 등 여러 마켓에 한 번에 올리고, 주문·정산까지 한곳에서.</p>
+    </div>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-body">
+      <h5 class="fw-bold mb-2">누구를 위한 건가요?</h5>
+      <p class="text-muted mb-0">처음 구매대행을 시작하는 분, 여러 마켓을 함께 운영하는 셀러, 반복 작업을 줄이고 싶은 분. 전문 용어 없이, 클릭만으로 따라올 수 있게 만들었어요.</p>
+    </div>
+  </div>
+
+  <div class="text-center">
+    <a href="/seller/start" class="btn btn-cta btn-lg">시작하기</a>
+    <a href="/seller/dashboard" class="btn btn-ghost btn-lg">대시보드로</a>
+  </div>
+</div>
+{% endblock %}

--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -32,11 +32,13 @@
     {% endfor %}
   </div>
 
-  <div class="alert alert-light border d-flex gap-2 align-items-start mb-4" role="note">
+  <div class="alert alert-light border d-flex gap-2 align-items-center mb-4" role="note">
     <i class="bi bi-shield-lock text-primary"></i>
     <div class="small mb-0">
-      입력한 키는 <strong>암호화되어 저장</strong>됩니다(서버에 <code>MARKET_CRED_ENC_KEY</code> 설정 시).
-      <strong>연결 테스트</strong>는 실제 마켓에 읽기/안전한 빈 쓰기만 시도하며 상품을 등록하지 않습니다.
+      🔒 입력한 키는 <strong>안전하게 암호화</strong>되어 보관돼요.
+      <span class="pc-help" tabindex="0" role="button" aria-label="자세히"
+            data-bs-toggle="tooltip" data-bs-html="true"
+            data-bs-title="서버에 <code>MARKET_CRED_ENC_KEY</code> 설정 시 키를 암호화 저장합니다. ‘연결 테스트’는 실제 마켓에 읽기/안전한 빈 쓰기만 시도하며 상품을 등록하지 않습니다.">?</span>
     </div>
   </div>
 

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -3614,6 +3614,12 @@ def markets_guide():
     return render_template("markets_guide.html", page="markets", guide=get_guide())
 
 
+@bp.get("/about")
+def about_page():
+    """소개 — '코고가네란?' (애플 톤, v5). 로그인 없이도 볼 수 있음."""
+    return render_template("about.html")
+
+
 @bp.get("/start")
 def onboarding_wizard():
     """For Beginners 키노트형 온보딩 위저드 (v5).

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -322,6 +322,16 @@ a:hover {
   margin-top: -2px;
 }
 
+/* "?" 도움말 토글 — 개발자/내부 문구를 본문에서 숨기고 팝오버로만(v5) */
+.pc-help {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--pc-color-surface-muted); color: var(--pc-color-text-muted);
+  border: 1px solid var(--pc-color-border);
+  font-size: 11px; font-weight: 700; cursor: help; vertical-align: middle; line-height: 1;
+}
+.pc-help:hover, .pc-help:focus { background: var(--pc-color-primary); color: #fff; border-color: var(--pc-color-primary); outline: none; }
+
 .text-teal { color: #0d9488 !important; }
 .bg-teal { background-color: #0d9488 !important; }
 .badge-get { background: #22c55e; color: #fff; }

--- a/src/templates/landing.html
+++ b/src/templates/landing.html
@@ -111,6 +111,7 @@
     <hr>
     <span>Phase {{ current_phase }}</span> &nbsp;·&nbsp;
     <span>{{ version }}</span> &nbsp;·&nbsp;
+    <a href="/seller/about">코고가네란?</a> &nbsp;·&nbsp;
     <a href="/privacy">개인정보처리방침</a> &nbsp;·&nbsp;
     <a href="/terms">이용약관</a> &nbsp;·&nbsp;
     <a href="https://github.com/Kohgane/proxy-commerce" target="_blank" rel="noopener">

--- a/tests/test_about_and_help.py
+++ b/tests/test_about_and_help.py
@@ -1,0 +1,43 @@
+"""tests/test_about_and_help.py — About 소개 + '?' 개발자문구 숨김 (Phase 254, v5)."""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_about_page_renders(client):
+    html = client.get("/seller/about").get_data(as_text=True)
+    assert "코고가네" in html
+    assert "수집" in html and "등록" in html
+    assert "/seller/start" in html  # 시작하기 CTA
+
+
+def test_about_linked_from_landing(client, monkeypatch):
+    monkeypatch.setenv("ROOT_REDIRECT", "landing")
+    from src.order_webhook import app
+    with app.test_client() as c:
+        html = c.get("/").get_data(as_text=True)
+    assert "/seller/about" in html
+
+
+def test_markets_connect_dev_text_hidden_behind_help(client):
+    """기술 문구(MARKET_CRED_ENC_KEY 등)는 본문 노출 대신 '?' 툴팁 안으로."""
+    html = client.get("/seller/markets/connect").get_data(as_text=True)
+    # 친절한 한 줄은 본문에, 기술 디테일은 tooltip data-bs-title 안에
+    assert "안전하게 암호화" in html
+    assert 'class="pc-help"' in html
+    assert "MARKET_CRED_ENC_KEY" in html  # 툴팁 속성 안에 존재
+    # 본문 단락에 길게 노출되던 '읽기/안전한 빈 쓰기' 설명이 평문 <strong>로 남지 않음
+    assert "<strong>연결 테스트</strong>는 실제 마켓에 읽기" not in html


### PR DESCRIPTION
오너 v5 — **개발자 문구 "?" 숨김 + About 소개**입니다.

## 변경
### "?" 도움말 토글 (개발자/내부 용어 숨김)
- `app.css` **`.pc-help`**(작은 원형 "?") + `_base.html` **전역 Bootstrap 툴팁 초기화**.
- **마켓 연결 페이지**의 기술 문구(`MARKET_CRED_ENC_KEY`·연결 테스트 원리)를 본문에서 빼고 → **‘🔒 입력한 키는 안전하게 암호화돼요’ 한 줄** + **"?"**(상세는 클릭/hover 시에만). 비기너 본문엔 짧은 카피만.

### About 소개 (애플 톤)
- 신설 **`/seller/about`** — “코고가네란?”: 수집 / 다듬기 / 등록 3카드 + “누구를 위한 건가요?” + **‘시작하기’ 주황 CTA**.
- **랜딩 푸터 ‘코고가네란?’** 링크 + 고급 nav ‘소개’ 링크. For Beginners 1단계와 톤 공유.

## 테스트
- 신규 3케이스(About 렌더 · 랜딩 링크 · 기술 문구 "?" 숨김 검증).
- 전체 `pytest` **10091 passed**.

## v5 진행
✅ 네비 간소화 + 주황 토큰 · ✅ For Beginners 키노트 온보딩 · ✅ "?" 숨김 + About.
남은 잔여: 주황 CTA 추가 적용(로그인 구글 버튼 등), For Beginners 서버측 진행 저장(현재 localStorage). 구글 계정 선택 화면은 오너 콘솔 ‘프로덕션 게시’ 사안.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_