### PR TITLE
feat(billing): 쉽고 간편 요금제·충전 + 번역 무제한 연동 (Phase 258, v6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,12 @@
 - 결제·버튼·모든 UX가 쉽고 간편·간결·직관적이어야 함. 복잡/개발자틱 금지.
 - 로그인 튕김은 절대 안 됨(아래 P0). 모바일 앱도 만들 예정 — 준비.
 - 진행: 위에서부터 순서대로. 계획 짜서 실행.
+- **계획(2026-06-21):** ①로그인 튕김(✅ Phase 257) → ②쉽고 간편 결제·버튼(✅ Phase 258 요금제·충전) →
+  ③모바일 앱 준비(설치형 PWA + 모바일 주문 액션).
+- **쉽고 간편 결제(Phase 258):** 신설 `billing_store.py`(셀러 plan free/plus/pro + token_balance) +
+  `/seller/billing`(요금제·충전 페이지, 깔끔 카드 + 1버튼 주황 CTA). free=즉시 전환, 유료=토스 결제
+  (TOSS_CLIENT_KEY/SECRET_KEY) 설정 시에만 활성(가짜 활성 금지, 미설정 시 정직 안내). 활성 Plus/Pro면
+  번역 무제한(bulk-translate가 billing_store.is_unlimited 확인). nav '요금제·충전' 추가.
 - **로그인 튕김 근본해결(Phase 257):** SECRET_KEY 미설정 시 세션 서명 키가 워커/재시작마다 바뀌어 튕김.
   → 키 영속 우선순위 = ①SECRET_KEY env ②**Google Sheets `app_config`(GOOGLE_SHEET_ID 있으면 재시작에도
   동일 키 — 오너 추가설정 불필요)** ③컨테이너 /tmp 공유. Sheets 있으면 재배포해도 세션 유지 → 튕김 해결.

--- a/src/seller_console/billing_store.py
+++ b/src/seller_console/billing_store.py
@@ -1,0 +1,109 @@
+"""src/seller_console/billing_store.py — 셀러 요금제/토큰 잔액 (Phase 258, v6 쉽고 간편 결제).
+
+셀러별 plan(free/plus/pro) + token_balance를 저장한다. 유료 활성은 실제 결제 확인 시에만
+(가짜 활성 금지 — 결제 미설정 시 free 유지 + 정직 안내).
+
+저장: GOOGLE_SHEET_ID 있으면 `billing` 워크시트, 없으면 인메모리.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
+_WS_NAME = "billing"
+_HEADERS = ["seller_id", "plan", "token_balance"]
+
+_in_memory: dict[str, dict] = {}
+
+PLANS = {
+    "free": {"label": "Free", "price_krw": 0, "translate_unlimited": False,
+             "desc": "기본 수집·편집·등록. 무료 번역 20회."},
+    "plus": {"label": "Plus", "price_krw": 19000, "translate_unlimited": True,
+             "desc": "번역 무제한 · 대량 수집 · 자동 등록."},
+    "pro": {"label": "Pro", "price_krw": 49000, "translate_unlimited": True,
+            "desc": "Plus + 소싱 모니터링 · 우선 지원."},
+}
+
+
+def _get_worksheet():
+    from src.utils.sheets import open_sheet
+    ws = open_sheet(_SHEET_ID, _WS_NAME)
+    try:
+        first = ws.row_values(1)
+        if not first or first[0] != "seller_id":
+            ws.insert_row(_HEADERS, index=1)
+    except Exception:
+        pass
+    return ws
+
+
+def get_account(seller_id: Optional[str]) -> dict:
+    """셀러 결제 상태 {plan, token_balance}."""
+    sid = str(seller_id or "")
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            for row in ws.get_all_records():
+                if str(row.get("seller_id", "") or "") == sid:
+                    plan = str(row.get("plan", "free") or "free")
+                    try:
+                        bal = int(row.get("token_balance", 0) or 0)
+                    except (TypeError, ValueError):
+                        bal = 0
+                    return {"plan": plan if plan in PLANS else "free", "token_balance": max(0, bal)}
+            return {"plan": "free", "token_balance": 0}
+        except Exception as exc:
+            logger.warning("billing 조회 실패(인메모리 폴백): %s", exc)
+    acc = _in_memory.get(sid) or {}
+    return {"plan": acc.get("plan", "free"), "token_balance": max(0, int(acc.get("token_balance", 0)))}
+
+
+def is_unlimited(seller_id: Optional[str]) -> bool:
+    """현재 플랜이 번역 무제한인지."""
+    plan = get_account(seller_id).get("plan", "free")
+    return bool(PLANS.get(plan, {}).get("translate_unlimited"))
+
+
+def set_plan(seller_id: Optional[str], plan: str) -> dict:
+    """플랜 설정(실제 결제 확인 후/무료). 잘못된 plan은 free."""
+    sid = str(seller_id or "")
+    plan = plan if plan in PLANS else "free"
+    cur = get_account(sid)
+    cur["plan"] = plan
+    _save(sid, cur)
+    return cur
+
+
+def add_tokens(seller_id: Optional[str], amount: int) -> dict:
+    sid = str(seller_id or "")
+    cur = get_account(sid)
+    cur["token_balance"] = max(0, cur["token_balance"] + int(amount or 0))
+    _save(sid, cur)
+    return cur
+
+
+def _save(sid: str, acc: dict) -> None:
+    if _SHEET_ID:
+        try:
+            ws = _get_worksheet()
+            values = ws.get_all_values()
+            header = values[0] if values else _HEADERS
+            col = {h: i for i, h in enumerate(header)}
+            for r, row in enumerate(values[1:], start=2):
+                if col.get("seller_id", 0) < len(row) and str(row[col["seller_id"]] or "") == sid:
+                    ws.update_cell(r, col.get("plan", 1) + 1, acc["plan"])
+                    ws.update_cell(r, col.get("token_balance", 2) + 1, str(acc["token_balance"]))
+                    return
+            new_row = [""] * len(header)
+            new_row[col.get("seller_id", 0)] = sid
+            new_row[col.get("plan", 1)] = acc["plan"]
+            new_row[col.get("token_balance", 2)] = str(acc["token_balance"])
+            ws.append_row(new_row)
+            return
+        except Exception as exc:
+            logger.warning("billing 저장 실패(인메모리 폴백): %s", exc)
+    _in_memory[sid] = {"plan": acc["plan"], "token_balance": acc["token_balance"]}

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -101,6 +101,7 @@
       <li><a class="console-nav-link {% if _path.startswith('/seller/api/tokens') or _path.startswith('/seller/me/tokens') %}active{% endif %}" href="/seller/api/tokens"><i class="bi bi-shield-lock"></i><span>API 토큰</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/bookmarklet') %}active{% endif %}" href="/seller/bookmarklet"><i class="bi bi-bookmark"></i><span>북마클릿</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/discovery') %}active{% endif %}" href="/seller/discovery"><i class="bi bi-compass"></i><span>Discovery</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/billing') %}active{% endif %}" href="/seller/billing"><i class="bi bi-credit-card"></i><span>요금제·충전</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/subscriptions') %}active{% endif %}" href="/seller/subscriptions"><i class="bi bi-arrow-repeat"></i><span>정기구독 관리</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/me/subscriptions') %}active{% endif %}" href="/seller/me/subscriptions"><i class="bi bi-person-check"></i><span>내 구독</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/wholesale/tiers') %}active{% endif %}" href="/seller/wholesale/tiers"><i class="bi bi-building"></i><span>도매 등급</span></a></li>

--- a/src/seller_console/templates/billing.html
+++ b/src/seller_console/templates/billing.html
@@ -1,0 +1,59 @@
+{% extends "_base.html" %}
+{% block title %}요금제·충전{% endblock %}
+{% block content %}
+<div class="container py-4" style="max-width: 880px;">
+  <h1 class="h3 mb-1">💳 요금제 · 충전</h1>
+  <p class="text-muted">쉽고 간편하게. 지금 플랜: <strong>{{ plans[account.plan].label }}</strong>
+    · 무료 번역 <strong>{{ free_remaining }}</strong>/{{ free_limit }}회 남음
+    {% if account.token_balance %}· 토큰 <strong>{{ account.token_balance }}</strong>{% endif %}</p>
+
+  {% if not pay_ready %}
+  <div class="alert alert-light border small">🔒 결제 연동(토스페이먼츠)이 아직 켜지지 않았어요. Free는 바로 쓰실 수 있고,
+    유료 플랜은 결제가 열리면 한 번에 결제됩니다. <span class="pc-help" data-bs-toggle="tooltip" data-bs-title="Render에 TOSS_CLIENT_KEY/TOSS_SECRET_KEY 설정 시 결제가 활성화됩니다.">?</span></div>
+  {% endif %}
+
+  <div class="row g-3 mt-1">
+    {% for code, p in plans.items() %}
+    <div class="col-md-4">
+      <div class="card h-100 {{ 'border-primary' if account.plan == code else '' }}">
+        <div class="card-body d-flex flex-column text-center">
+          {% if account.plan == code %}<span class="badge text-bg-primary mb-2 align-self-center">현재 플랜</span>{% endif %}
+          <h4 class="fw-bold">{{ p.label }}</h4>
+          <div class="display-6 fw-bold mb-1">{% if p.price_krw %}₩{{ '{:,}'.format(p.price_krw) }}{% else %}무료{% endif %}</div>
+          {% if p.price_krw %}<div class="small text-muted mb-2">/월</div>{% endif %}
+          <p class="text-muted small flex-grow-1">{{ p.desc }}</p>
+          {% if account.plan == code %}
+          <button class="btn btn-outline-secondary" disabled>이용 중</button>
+          {% elif code == 'free' %}
+          <button class="btn btn-ghost" onclick="selectPlan('free')">무료로 전환</button>
+          {% else %}
+          <button class="btn btn-cta" onclick="selectPlan('{{ code }}')">{{ p.label }} 시작하기</button>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <p class="text-muted small mt-3">결제·환불은 관련 법규를 따릅니다. 구독은 언제든 해지할 수 있어요.</p>
+</div>
+
+<script>
+async function selectPlan(plan) {
+  if (plan !== 'free' && !confirm(plan.toUpperCase() + ' 플랜을 시작할까요?')) return;
+  try {
+    const resp = await fetch('/seller/billing/select', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({plan: plan}),
+    });
+    const data = await resp.json();
+    if (data.pay_unconfigured) { pcToast(data.error, 'warning'); return; }
+    if (!data.ok) { pcToast(data.error || '처리 실패', 'error'); return; }
+    pcToast(data.message || '완료', 'success');
+    setTimeout(() => location.reload(), 800);
+  } catch (err) {
+    pcToast('요청 실패: ' + err.message, 'error');
+  }
+}
+</script>
+{% endblock %}

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1864,7 +1864,14 @@ def collect_bulk_translate():
     _limit = translation_usage.free_limit()
     _used_before = translation_usage.get_used(sid)
     _remaining = max(0, _limit - _used_before)
-    _unlimited = os.getenv("TRANSLATION_UNLIMITED", "0") == "1"  # 구독/무제한 훅(추후 구독 연동)
+    # 무제한 = env 훅 또는 활성 유료 플랜(Plus/Pro). 유료 활성은 실제 결제 시에만(가짜 금지).
+    _unlimited = os.getenv("TRANSLATION_UNLIMITED", "0") == "1"
+    try:
+        from . import billing_store
+        if billing_store.is_unlimited(sid):
+            _unlimited = True
+    except Exception:
+        pass
 
     updated = 0
     translated = 0
@@ -3655,6 +3662,44 @@ def mobile_home():
         logger.debug("모바일 주문 조회 실패: %s", exc)
 
     return render_template("mobile_home.html", recent=recent, kpi=kpi, orders=orders)
+
+
+@bp.get("/billing")
+def billing_page():
+    """요금제·충전 — 쉽고 간편(v6). 무료/Plus/Pro 카드 + 토큰 잔액."""
+    if not _check_auth():
+        return redirect(url_for("auth.login", next=request.url))
+    from . import billing_store, translation_usage
+    sid = _seller_id()
+    acc = billing_store.get_account(sid)
+    pay_ready = bool(os.getenv("TOSS_CLIENT_KEY")) and bool(os.getenv("TOSS_SECRET_KEY"))
+    return render_template("billing.html", account=acc, plans=billing_store.PLANS,
+                           pay_ready=pay_ready,
+                           free_remaining=translation_usage.remaining(sid),
+                           free_limit=translation_usage.free_limit())
+
+
+@bp.post("/billing/select")
+def billing_select():
+    """플랜 선택. free=즉시 적용. 유료=결제 연동 시에만 활성(가짜 활성 금지)."""
+    if not _check_auth():
+        return jsonify({"ok": False, "error": "로그인이 필요합니다."}), 401
+    data = request.get_json(force=True, silent=True) or {}
+    plan = str(data.get("plan") or "").strip()
+    from . import billing_store
+    if plan not in billing_store.PLANS:
+        return jsonify({"ok": False, "error": "알 수 없는 플랜입니다."}), 400
+    if plan == "free":
+        billing_store.set_plan(_seller_id(), "free")
+        return jsonify({"ok": True, "plan": "free", "message": "무료 플랜으로 전환했습니다."})
+    # 유료: 결제 연동 필요 — 미설정이면 정직 안내(활성 안 함)
+    pay_ready = bool(os.getenv("TOSS_CLIENT_KEY")) and bool(os.getenv("TOSS_SECRET_KEY"))
+    if not pay_ready:
+        return jsonify({"ok": False, "pay_unconfigured": True,
+                        "error": "결제 연동(토스페이먼츠)이 준비 중입니다. 운영자에게 문의하면 바로 열어드려요."}), 200
+    # 결제 설정됨 — 결제창 연결(자리). 실제 승인 후 set_plan은 결제 콜백에서.
+    return jsonify({"ok": True, "checkout": True, "plan": plan,
+                    "message": "결제창으로 이동합니다."})
 
 
 @bp.get("/about")

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,0 +1,69 @@
+"""tests/test_billing.py — 요금제·충전(쉽고 간편 결제) (Phase 258, v6)."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    from src.seller_console import billing_store as bs
+    bs._in_memory.clear()
+    yield
+    bs._in_memory.clear()
+
+
+def test_billing_page_shows_plans(client):
+    html = client.get("/seller/billing").get_data(as_text=True)
+    assert "요금제" in html
+    for label in ("Free", "Plus", "Pro"):
+        assert label in html
+    assert "무료 번역" in html
+
+
+def test_select_free_activates(client):
+    from src.seller_console import billing_store as bs
+    r = client.post("/seller/billing/select", json={"plan": "free"})
+    assert r.get_json()["ok"] is True
+    assert bs.get_account("default")["plan"] == "free"
+
+
+def test_select_paid_without_payment_is_honest(client, monkeypatch):
+    """결제 미설정 시 유료 활성 금지 — 정직 안내(가짜 활성 없음)."""
+    from src.seller_console import billing_store as bs
+    monkeypatch.delenv("TOSS_CLIENT_KEY", raising=False)
+    monkeypatch.delenv("TOSS_SECRET_KEY", raising=False)
+    r = client.post("/seller/billing/select", json={"plan": "plus"})
+    data = r.get_json()
+    assert data.get("pay_unconfigured") is True
+    assert bs.get_account("default")["plan"] == "free"  # 활성 안 됨
+
+
+def test_paid_plan_unlocks_unlimited_translation():
+    """활성 유료 플랜이면 번역 무제한(billing_store.is_unlimited)."""
+    from src.seller_console import billing_store as bs
+    bs.set_plan("s1", "plus")
+    assert bs.is_unlimited("s1") is True
+    assert bs.is_unlimited("nobody") is False
+
+
+def test_select_rejects_unknown_plan(client):
+    assert client.post("/seller/billing/select", json={"plan": "ultra"}).status_code == 400
+
+
+def test_billing_in_nav(client):
+    html = client.get("/seller/dashboard").get_data(as_text=True)
+    assert "/seller/billing" in html


### PR DESCRIPTION
오너 v6 계획 **2순위 — 쉽고·간편 결제(요금제·충전)**입니다. "결제도 편하고 버튼도 편하고."

## 변경
- **신설 `billing_store.py`** — 셀러별 plan(free/plus/pro) + token_balance(Sheets + 인메모리). `is_unlimited`.
- **`/seller/billing` 요금제·충전 페이지** — Free/Plus/Pro **카드(가격·혜택 한눈에)** + **큰 주황 CTA 1버튼**. 현재 플랜 · 무료 번역 잔여 · 토큰 잔액 표시. 깔끔·직관.
- **`POST /seller/billing/select`** — free=즉시 전환. 유료=`TOSS_CLIENT_KEY/TOSS_SECRET_KEY` 설정 시에만 결제(활성은 실제 결제 콜백에서). **미설정이면 ‘결제 준비 중 · 문의’로 정직 안내**(가짜 활성 금지).
- **번역 무제한 연동** — `bulk-translate`가 `billing_store.is_unlimited`(활성 Plus/Pro)를 확인 → 무료 20회 외에 유료 플랜이면 무제한. 단, 유료 활성은 **실제 결제 시에만**(가짜 없음).
- nav ‘요금제·충전’ 추가.

## 테스트
- 신규 6케이스(카드 · 무료 전환 · 유료 정직 차단 · 무제한 연동 · 검증 · nav).
- 전체 `pytest` **10100 passed**.

## 오너 액션 (결제 켜기)
- Render에 **`TOSS_CLIENT_KEY` / `TOSS_SECRET_KEY`** 설정 시 결제가 활성화됩니다. 그 전엔 Free는 바로 쓰고, 유료는 정직하게 ‘준비 중’ 안내.

## 다음 (v6 계획 3순위)
**모바일 앱 준비** — 설치형 PWA(앱 아이콘/스플래시/standalone/‘앱 설치’ 버튼) + 모바일 주문 액션(운송장 입력/송장 복사).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_