### PR TITLE
feat(markets): 원클릭 마켓 연동 — 발급 딥링크(주황) + 서버 IP 복사 (Phase 259, v6 P0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,12 @@
 - 진행: 위에서부터 순서대로. 계획 짜서 실행.
 - **계획(2026-06-21):** ①로그인 튕김(✅ Phase 257) → ②쉽고 간편 결제·버튼(✅ Phase 258 요금제·충전) →
   ③모바일 앱 준비(설치형 PWA + 모바일 주문 액션).
+- **v6 마스터 브리프(2026-06-21):** "쉽고 편함 최우선"(3클릭 이내·화면당 버튼 1~2). P0=①모든 버튼 실동작 감사
+  (죽은/가짜 버튼 0, 테스트 가드) ②일반유저 실제 API연동(발급 URL 딥링크 새탭+서버 IP 복사+실연결테스트)
+  ③실 구글 로그인. P1=애플홈+퍼센티 디자인, For Beginners(✅v5), "?"숨김/네비간소화/About(✅v5).
+  - ✅ v6 P0 마켓 원클릭 연동(Phase 259): markets_connect 각 카드에 발급 페이지 딥링크(주황 btn-cta 새탭,
+    market_guide.guide_map — 네이버 apicenter/11번가 openapi URL 갱신) + 서버 아웃바운드 IP 복사 블록
+    (SERVER_OUTBOUND_IP env 또는 ipify 1회조회·캐시, 쿠팡/네이버 허용IP용) + '?' 툴팁.
 - **쉽고 간편 결제(Phase 258):** 신설 `billing_store.py`(셀러 plan free/plus/pro + token_balance) +
   `/seller/billing`(요금제·충전 페이지, 깔끔 카드 + 1버튼 주황 CTA). free=즉시 전환, 유료=토스 결제
   (TOSS_CLIENT_KEY/SECRET_KEY) 설정 시에만 활성(가짜 활성 금지, 미설정 시 정직 안내). 활성 Plus/Pro면

--- a/src/seller_console/market_guide.py
+++ b/src/seller_console/market_guide.py
@@ -79,7 +79,7 @@ MARKET_GUIDE: List[Dict[str, Any]] = [
         "key": "smartstore",
         "label": "스마트스토어 (네이버)",
         "icon": "🟢",
-        "official_url": "https://commerce.naver.com",
+        "official_url": "https://apicenter.commerce.naver.com/ko/basic/main",
         "official_label": "네이버 커머스 API센터 열기",
         "flow": ["커머스 API센터 로그인", "애플리케이션 등록", "ID/Secret 발급", "여기에 붙여넣기"],
         "steps": [
@@ -104,7 +104,7 @@ MARKET_GUIDE: List[Dict[str, Any]] = [
         "key": "elevenst",
         "label": "11번가",
         "icon": "🔴",
-        "official_url": "https://soffice.11st.co.kr",
+        "official_url": "https://openapi.11st.co.kr/",
         "official_label": "11번가 셀러오피스 열기",
         "flow": ["셀러오피스 로그인", "오픈API 신청", "API Key 발급", "여기에 붙여넣기"],
         "steps": [
@@ -247,3 +247,10 @@ MARKET_GUIDE: List[Dict[str, Any]] = [
 
 def get_guide() -> List[Dict[str, Any]]:
     return MARKET_GUIDE
+
+
+def guide_map():
+    """key → {official_url, official_label} 빠른 조회(연동 카드 딥링크용)."""
+    return {g.get("key"): {"official_url": g.get("official_url", ""),
+                            "official_label": g.get("official_label", "발급 페이지 열기")}
+            for g in MARKET_GUIDE}

--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -32,6 +32,16 @@
     {% endfor %}
   </div>
 
+  {% if server_ip %}
+  <div class="alert alert-warning d-flex flex-wrap gap-2 align-items-center mb-3" role="note">
+    <i class="bi bi-hdd-network"></i>
+    <span class="small mb-0">쿠팡·네이버는 <strong>서버 IP를 허용 목록에 등록</strong>해야 연결돼요. 이 IP를 복사해 넣으세요:</span>
+    <code id="serverIp" class="ms-1">{{ server_ip }}</code>
+    <button type="button" class="btn btn-gold btn-sm py-0" onclick="copyServerIp(this)">복사</button>
+    <span class="pc-help" data-bs-toggle="tooltip" data-bs-title="마켓의 'API 호출 허용 IP'(쿠팡 Wing)/'호출 IP 등록'(네이버, 최대 3개)에 이 IP를 추가하세요.">?</span>
+  </div>
+  {% endif %}
+
   <div class="alert alert-light border d-flex gap-2 align-items-center mb-4" role="note">
     <i class="bi bi-shield-lock text-primary"></i>
     <div class="small mb-0">
@@ -66,13 +76,19 @@
     <div class="{{ 'col-12' if single_market else 'col-12 col-lg-6' }}">
       <div class="card console-card h-100" data-market="{{ m.market }}">
         <div class="card-body">
-          <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
+          <div class="d-flex align-items-center justify-content-between gap-2 mb-2">
             <h2 class="h6 mb-0">{{ m.label }}</h2>
             <span class="badge rounded-pill {{ 'text-bg-success' if m.connected else 'text-bg-secondary' }}"
                   data-role="status-badge">
               {{ '✅ 연결됨' if m.connected else '🪪 미연결' }}
             </span>
           </div>
+          {% set _g = (guide_map or {}).get(m.market) %}
+          {% if _g and _g.official_url %}
+          <a href="{{ _g.official_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-cta btn-sm w-100 mb-3">
+            🔗 {{ _g.official_label or '발급 페이지 열기' }} <span class="small">(새 탭)</span>
+          </a>
+          {% endif %}
 
           <form class="market-connect-form" data-market="{{ m.market }}" autocomplete="off">
             {% for f in m.fields %}
@@ -128,6 +144,14 @@
 
 {% block extra_js %}
 <script>
+function copyServerIp(btn) {
+  var ip = (document.getElementById('serverIp') || {}).textContent || '';
+  if (!ip) return;
+  navigator.clipboard.writeText(ip.trim()).then(function () {
+    if (window.pcToast) pcToast('서버 IP를 복사했어요. 마켓 허용 IP에 붙여넣으세요.', 'success');
+    if (btn) { var o = btn.textContent; btn.textContent = '복사됨 ✓'; setTimeout(function(){ btn.textContent = o; }, 1500); }
+  });
+}
 function collectValues(form) {
   const values = {};
   form.querySelectorAll('input[name]').forEach(input => {

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -3579,6 +3579,7 @@ def markets_connect():
     if not _check_auth():
         return redirect(url_for("auth.login", next=request.url))
     from . import market_credentials as mc
+    from .market_guide import guide_map
 
     seller = _seller_id()
     statuses = mc.all_status(seller)
@@ -3586,7 +3587,40 @@ def markets_connect():
     return render_template(
         "markets_connect.html", page="markets",
         market_statuses=statuses, market_chips=chips, single_market=None, guide_entry=None,
+        guide_map=guide_map(), server_ip=_server_outbound_ip(),
     )
+
+
+# 서버 아웃바운드 IP 캐시(쿠팡/네이버 허용 IP 등록용 — 화면에 복사 제공)
+_SERVER_IP_CACHE = {"ip": None, "tried": False}
+
+
+def _server_outbound_ip() -> str:
+    """서버 아웃바운드 IP. env SERVER_OUTBOUND_IP 우선, 없으면 1회 조회·캐시(실패 시 '')."""
+    env_ip = (os.getenv("SERVER_OUTBOUND_IP") or "").strip()
+    if env_ip:
+        return env_ip
+    if _SERVER_IP_CACHE["ip"] is not None:
+        return _SERVER_IP_CACHE["ip"]
+    if _SERVER_IP_CACHE["tried"]:
+        return ""
+    _SERVER_IP_CACHE["tried"] = True
+    ip = ""
+    try:
+        import urllib.request
+        for svc in ("https://api.ipify.org", "https://checkip.amazonaws.com"):
+            try:
+                with urllib.request.urlopen(svc, timeout=3) as r:
+                    cand = (r.read().decode("utf-8") or "").strip()
+                    if cand and len(cand) <= 45:
+                        ip = cand
+                        break
+            except Exception:
+                continue
+    except Exception:
+        ip = ""
+    _SERVER_IP_CACHE["ip"] = ip
+    return ip
 
 
 @bp.get("/markets/connect/<market>")
@@ -3595,7 +3629,7 @@ def markets_connect_one(market):
     if not _check_auth():
         return redirect(url_for("auth.login", next=request.url))
     from . import market_credentials as mc
-    from .market_guide import get_guide
+    from .market_guide import get_guide, guide_map
 
     market = _connect_market_key(market)
     if market not in mc.MARKET_CRED_FIELDS:
@@ -3608,6 +3642,7 @@ def markets_connect_one(market):
         "markets_connect.html", page="markets",
         market_statuses=[mc.status(seller, market)], market_chips=chips,
         single_market=market, guide_entry=guide_entry,
+        guide_map=guide_map(), server_ip=_server_outbound_ip(),
     )
 
 

--- a/tests/test_markets_connect_deeplink.py
+++ b/tests/test_markets_connect_deeplink.py
@@ -1,0 +1,44 @@
+"""tests/test_markets_connect_deeplink.py — 마켓 연동 발급 딥링크 + 서버 IP (Phase 259, v6 P0)."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_connect_page_has_issuance_deeplinks(client):
+    html = client.get("/seller/markets/connect").get_data(as_text=True)
+    # 각 카드에 발급 페이지 딥링크(주황 btn-cta, 새 탭)
+    assert "btn-cta" in html
+    assert 'target="_blank"' in html
+    # v6 표의 핵심 발급 URL
+    assert "wing.coupang.com" in html
+    assert "apicenter.commerce.naver.com" in html
+
+
+def test_server_ip_block_shown_when_known(client, monkeypatch):
+    monkeypatch.setenv("SERVER_OUTBOUND_IP", "203.0.113.7")
+    # 캐시 무시: env 우선이라 바로 노출
+    html = client.get("/seller/markets/connect").get_data(as_text=True)
+    assert "203.0.113.7" in html
+    assert "copyServerIp" in html
+    assert "허용 목록에 등록" in html
+
+
+def test_guide_map_has_markets():
+    from src.seller_console.market_guide import guide_map
+    gm = guide_map()
+    assert gm["coupang"]["official_url"].startswith("https://wing.coupang.com")
+    assert "openapi.11st.co.kr" in gm["elevenst"]["official_url"] or "11st" in gm.get("elevenst", {}).get("official_url", "11st")


### PR DESCRIPTION
v6 마스터 브리프 **P0 — 일반 유저가 클릭만으로 마켓 실연동**입니다. ("마켓 연동 쉽게")

## 변경
- **마켓 연결 카드마다 ‘🔗 발급 페이지 열기’(주황 CTA, 새 탭)** 추가 — `market_guide.guide_map`에서 마켓별 공식 발급 URL 연결. 발급 → 키 붙여넣기 → 연결 3스텝이 한 카드에서.
  - 발급 URL 정확도 갱신(v6 표): 네이버 `apicenter.commerce.naver.com/ko/basic/main`, 11번가 `openapi.11st.co.kr`.
- **서버 아웃바운드 IP 복사 블록** — 쿠팡·네이버는 ‘API 호출 허용 IP’에 서버 IP를 등록해야 연결됩니다. 그 IP를 화면에 표시 + **복사 버튼** + "?" 안내. 소스: `SERVER_OUTBOUND_IP` env 우선, 없으면 ipify/checkip로 1회 조회·캐시, **확인 불가 시 미표시(가짜 IP 금지)**.
- 기존 **연결 테스트/저장(실 연결 검증)** + "?" 암호화 문구 숨김(v5)과 합쳐 완성.

## 테스트
- 신규 3케이스(발급 딥링크 · 서버 IP 블록 · guide_map URL).
- 전체 `pytest` **10103 passed**.

## 오너 액션 (선택)
- `SERVER_OUTBOUND_IP`를 Render에 설정하면 IP가 확실히 표시됩니다(자동 조회가 막힐 때 대비). 마켓별 허용 IP 등록은 각 마켓 콘솔에서 1회.

## v6 진행
✅ 로그인 튕김 · ✅ 쉽고 결제 · ✅ 마켓 원클릭 연동. 다음: 모바일 앱 준비(설치형 PWA) → 죽은/가짜 버튼 전수 감사(테스트 가드) → 애플홈 랜딩.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_