### PR TITLE
test(guard): 죽은 버튼/링크 0 자동 가드 (Phase 260, v6 P0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@
   - ✅ v6 P0 마켓 원클릭 연동(Phase 259): markets_connect 각 카드에 발급 페이지 딥링크(주황 btn-cta 새탭,
     market_guide.guide_map — 네이버 apicenter/11번가 openapi URL 갱신) + 서버 아웃바운드 IP 복사 블록
     (SERVER_OUTBOUND_IP env 또는 ipify 1회조회·캐시, 쿠팡/네이버 허용IP용) + '?' 툴팁.
+  - ✅ v6 P0 죽은 버튼 가드(Phase 260): `tests/test_no_dead_buttons.py` — 시드 핵심페이지(대시보드/수집이력/
+    마켓/연결/요금제/About/start/가이드/모바일) 크롤 → 내부 링크 404/500 0 + 핸들러 없는 빈 앵커 0 (CI 가드).
+    감사 결과 기존 죽은 버튼 0 확인(템플릿 href='#' 1건도 실 핸들러 보유).
 - **쉽고 간편 결제(Phase 258):** 신설 `billing_store.py`(셀러 plan free/plus/pro + token_balance) +
   `/seller/billing`(요금제·충전 페이지, 깔끔 카드 + 1버튼 주황 CTA). free=즉시 전환, 유료=토스 결제
   (TOSS_CLIENT_KEY/SECRET_KEY) 설정 시에만 활성(가짜 활성 금지, 미설정 시 정직 안내). 활성 Plus/Pro면

--- a/tests/test_no_dead_buttons.py
+++ b/tests/test_no_dead_buttons.py
@@ -1,0 +1,91 @@
+"""tests/test_no_dead_buttons.py — 죽은 버튼/링크 가드 (Phase 260, v6 P0).
+
+오너 v6 P0: "클릭 가능한 모든 것이 실제로 무언가를 한다. 죽은 버튼 0."
+주요 화면을 렌더 → 내부 링크(href)를 추출 → 각 링크가 404/500이 아님을 보장(회귀 가드, CI 포함).
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# 크롤 시작점(셀러 핵심 화면 + 풀스크린 진입)
+SEED_PAGES = [
+    "/seller/dashboard",
+    "/seller/collect/history",
+    "/seller/markets",
+    "/seller/markets/connect",
+    "/seller/billing",
+    "/seller/about",
+    "/seller/start",
+    "/seller/guide/business",
+    "/seller/m",
+]
+
+# 내부 링크 패턴(앵커·동적 라우트 제외용)
+_HREF_RE = re.compile(r'href="(/[^"#?]*)"')
+# 동적/외부/특수 경로는 가드에서 제외(파라미터 필요 등)
+_SKIP_PREFIXES = ("/seller/collect/preview/", "/seller/static/", "/static/", "/auth/logout")
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _internal_links(html):
+    links = set()
+    for href in _HREF_RE.findall(html):
+        if any(href.startswith(p) for p in _SKIP_PREFIXES):
+            continue
+        if href.startswith("/seller/") or href in ("/privacy", "/terms"):
+            links.add(href)
+    return links
+
+
+def test_seed_pages_render(client):
+    for path in SEED_PAGES:
+        resp = client.get(path)
+        assert resp.status_code in (200, 302), f"{path} → {resp.status_code}"
+
+
+def test_no_dead_internal_links(client):
+    """시드 페이지의 모든 내부 링크가 404/500이 아님(죽은 링크 0)."""
+    seen = set()
+    dead = []
+    for path in SEED_PAGES:
+        resp = client.get(path)
+        if resp.status_code != 200:
+            continue
+        for link in _internal_links(resp.get_data(as_text=True)):
+            if link in seen:
+                continue
+            seen.add(link)
+            r = client.get(link)
+            # 404(없는 라우트)·500(서버오류)만 실패로 간주. 200/302/400/401/405는 정상.
+            if r.status_code in (404, 500):
+                dead.append(f"{link} → {r.status_code} (on {path})")
+    assert not dead, "죽은 링크 발견:\n" + "\n".join(dead)
+
+
+def test_no_empty_anchor_without_handler(client):
+    """href='#' 인데 onclick(핸들러)도 없는 죽은 앵커가 핵심 페이지에 없어야 한다."""
+    bad = []
+    for path in SEED_PAGES:
+        resp = client.get(path)
+        if resp.status_code != 200:
+            continue
+        html = resp.get_data(as_text=True)
+        # href="#" 직후 같은 태그에 onclick/data-bs-* 가 없으면 의심
+        for m in re.finditer(r'<a[^>]*href="#"[^>]*>', html):
+            tag = m.group(0)
+            if "onclick=" not in tag and "data-bs-" not in tag and "data-act" not in tag:
+                bad.append(f"{path}: {tag[:80]}")
+    assert not bad, "핸들러 없는 빈 앵커:\n" + "\n".join(bad)


### PR DESCRIPTION
v6 마스터 브리프 **P0 — 죽은/가짜 버튼 0 (자동 가드)** 입니다.

## 감사 결과
전 셀러 템플릿을 훑은 결과 **기존 죽은 버튼은 0**이었습니다:
- `href="#"`은 1곳뿐이고 그것도 실제 클립보드 복사 핸들러를 가짐.
- alert/console만 찍는 버튼·빈 onclick 없음.
(그간 Phase 215 등에서 죽은 버튼을 꾸준히 잡아온 결과)

## 추가 — 회귀 가드 (CI 포함)
- **`tests/test_no_dead_buttons.py`** — 시드 핵심 페이지(대시보드/수집 이력/마켓/마켓 연결/요금제/About/온보딩 start/사업자 가이드/모바일)를 렌더 → **모든 내부 링크를 GET → 404/500이면 실패**(죽은 링크 0 보장). 핸들러 없는 빈 앵커(`href="#"` + onclick/data-* 없음)도 0 가드.
- 앞으로 누가 죽은 링크/버튼을 추가하면 **CI가 막습니다.**

## 테스트
- 신규 3케이스 통과(시드 렌더 · 죽은 링크 0 · 빈 앵커 0).
- 전체 `pytest` **10106 passed**.

## v6 진행
✅ 로그인 · ✅ 결제 · ✅ 마켓 원클릭 연동 · ✅ 죽은 버튼 가드. 다음: 모바일 설치형 PWA → 애플홈 감성 랜딩.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_