### PR TITLE
feat(pwa): 모바일 설치형 PWA — '앱 설치' 버튼 + 코고가네 매니페스트 (Phase 261, v6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@
   - ✅ v6 P0 죽은 버튼 가드(Phase 260): `tests/test_no_dead_buttons.py` — 시드 핵심페이지(대시보드/수집이력/
     마켓/연결/요금제/About/start/가이드/모바일) 크롤 → 내부 링크 404/500 0 + 핸들러 없는 빈 앵커 0 (CI 가드).
     감사 결과 기존 죽은 버튼 0 확인(템플릿 href='#' 1건도 실 핸들러 보유).
+  - ✅ v6 모바일 설치형 PWA(Phase 261): manifest(webmanifest+json) short_name 코고가네, 색 순흑#020010→먹#1a1714,
+    start_url /seller/m, 상품수집/수집이력 shortcut. mobile_home에 '📲 앱 설치' 버튼(beforeinstallprompt, 안드로이드)
+    + SW 등록. iOS는 더보기의 '홈 화면에 추가' 안내. 테스트 갱신(short_name/color).
 - **쉽고 간편 결제(Phase 258):** 신설 `billing_store.py`(셀러 plan free/plus/pro + token_balance) +
   `/seller/billing`(요금제·충전 페이지, 깔끔 카드 + 1버튼 주황 CTA). free=즉시 전환, 유료=토스 결제
   (TOSS_CLIENT_KEY/SECRET_KEY) 설정 시에만 활성(가짜 활성 금지, 미설정 시 정직 안내). 활성 Plus/Pro면

--- a/src/seller_console/static/manifest.json
+++ b/src/seller_console/static/manifest.json
@@ -1,12 +1,12 @@
 {
   "name": "KOHgogane",
-  "short_name": "Percentiii",
+  "short_name": "코고가네",
   "description": "kohganepercentiii.com 셀러 콘솔 — 옴니채널 상품 관리 플랫폼",
-  "start_url": "/seller/dashboard",
+  "start_url": "/seller/m",
   "scope": "/seller/",
   "display": "standalone",
-  "background_color": "#020010",
-  "theme_color": "#020010",
+  "background_color": "#1a1714",
+  "theme_color": "#1a1714",
   "lang": "ko",
   "orientation": "portrait-primary",
   "icons": [
@@ -23,7 +23,10 @@
       "purpose": "any maskable"
     }
   ],
-  "categories": ["business", "shopping"],
+  "categories": [
+    "business",
+    "shopping"
+  ],
   "share_target": {
     "action": "/seller/collect/quick",
     "method": "GET",
@@ -34,6 +37,16 @@
     }
   },
   "shortcuts": [
+    {
+      "name": "상품 수집",
+      "url": "/seller/m",
+      "description": "링크 붙여넣어 바로 수집"
+    },
+    {
+      "name": "수집 이력",
+      "url": "/seller/collect/history",
+      "description": "수집한 상품"
+    },
     {
       "name": "주문 관리",
       "url": "/seller/orders",

--- a/src/seller_console/static/manifest.webmanifest
+++ b/src/seller_console/static/manifest.webmanifest
@@ -1,12 +1,12 @@
 {
   "name": "KOHgogane",
-  "short_name": "Percentiii",
+  "short_name": "코고가네",
   "description": "kohganepercentiii.com 셀러 콘솔 — 옴니채널 상품 관리 플랫폼",
-  "start_url": "/seller/dashboard",
+  "start_url": "/seller/m",
   "scope": "/seller/",
   "display": "standalone",
-  "background_color": "#020010",
-  "theme_color": "#020010",
+  "background_color": "#1a1714",
+  "theme_color": "#1a1714",
   "lang": "ko",
   "orientation": "portrait-primary",
   "icons": [
@@ -23,7 +23,10 @@
       "purpose": "any maskable"
     }
   ],
-  "categories": ["business", "shopping"],
+  "categories": [
+    "business",
+    "shopping"
+  ],
   "share_target": {
     "action": "/seller/collect/quick",
     "method": "GET",
@@ -34,6 +37,16 @@
     }
   },
   "shortcuts": [
+    {
+      "name": "상품 수집",
+      "url": "/seller/m",
+      "description": "링크 붙여넣어 바로 수집"
+    },
+    {
+      "name": "수집 이력",
+      "url": "/seller/collect/history",
+      "description": "수집한 상품"
+    },
     {
       "name": "주문 관리",
       "url": "/seller/orders",

--- a/src/seller_console/templates/mobile_home.html
+++ b/src/seller_console/templates/mobile_home.html
@@ -95,6 +95,7 @@
 <!-- 더보기 탭 -->
 <section class="m-tabpane" id="pane-more">
   <h2 class="h5 fw-bold mb-3">더보기</h2>
+  <button id="installBtn" class="btn btn-cta w-100 mb-2 d-none" onclick="installApp()">📲 코고가네 앱 설치</button>
   <div class="vstack gap-2">
     <a href="/seller/start" class="m-card p-3 text-decoration-none text-dark">✨ For Beginners · 시작 가이드</a>
     <a href="/seller/markets/connect" class="m-card p-3 text-decoration-none text-dark">🛍️ 마켓 연동</a>
@@ -115,6 +116,27 @@
 </nav>
 
 <script>
+// 설치형 PWA — 안드로이드: beforeinstallprompt로 '앱 설치' 버튼 노출. iOS: 공유→홈 화면에 추가 안내(더보기).
+let _deferredPrompt = null;
+window.addEventListener('beforeinstallprompt', function (e) {
+  e.preventDefault();
+  _deferredPrompt = e;
+  var b = document.getElementById('installBtn');
+  if (b) b.classList.remove('d-none');
+});
+function installApp() {
+  if (!_deferredPrompt) return;
+  _deferredPrompt.prompt();
+  _deferredPrompt.userChoice.finally(function () {
+    _deferredPrompt = null;
+    var b = document.getElementById('installBtn'); if (b) b.classList.add('d-none');
+  });
+}
+// 서비스워커 등록(설치 가능 조건)
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/seller/static/sw.js', { scope: '/seller/' }).catch(function () {});
+}
+
 document.querySelectorAll('.m-tab').forEach(function (t) {
   t.addEventListener('click', function () {
     var pane = t.getAttribute('data-pane');

--- a/tests/test_mobile_home.py
+++ b/tests/test_mobile_home.py
@@ -46,6 +46,13 @@ def test_mobile_home_shows_recent_collect(client):
     assert "https://i/a.jpg" in html
 
 
+def test_mobile_home_has_install_pwa(client):
+    """설치형 PWA — '앱 설치' 버튼 + beforeinstallprompt + manifest 링크."""
+    html = client.get("/seller/m").get_data(as_text=True)
+    assert "installBtn" in html and "beforeinstallprompt" in html
+    assert "manifest.webmanifest" in html
+
+
 def test_mobile_home_orders_kpi_real(client):
     fake = {"today_new": 4, "pending_ship": 2, "shipped": 9, "returned_exchanged": 1}
     with patch("src.seller_console.orders.sync_service.OrderSyncService") as MockSvc:

--- a/tests/test_pwa_manifest.py
+++ b/tests/test_pwa_manifest.py
@@ -17,10 +17,10 @@ def test_manifest_has_name():
 
 
 def test_manifest_has_short_name():
-    """manifest.webmanifest에 short_name 필드가 있어야 한다 (Percentiii)."""
+    """manifest.webmanifest에 short_name 필드가 있어야 한다 (코고가네)."""
     with open("src/seller_console/static/manifest.webmanifest", encoding="utf-8") as f:
         manifest = json.load(f)
-    assert manifest.get("short_name") == "Percentiii"
+    assert manifest.get("short_name") == "코고가네"
 
 
 def test_manifest_has_icons():
@@ -41,14 +41,14 @@ def test_manifest_has_theme_color():
     """manifest.webmanifest에 theme_color가 있어야 한다."""
     with open("src/seller_console/static/manifest.webmanifest", encoding="utf-8") as f:
         manifest = json.load(f)
-    assert manifest.get("theme_color") == "#020010"
+    assert manifest.get("theme_color") == "#1a1714"
 
 
 def test_manifest_has_background_color():
     """manifest.webmanifest에 background_color가 있어야 한다."""
     with open("src/seller_console/static/manifest.webmanifest", encoding="utf-8") as f:
         manifest = json.load(f)
-    assert manifest.get("background_color") == "#020010"
+    assert manifest.get("background_color") == "#1a1714"
 
 
 def test_manifest_display_standalone():


### PR DESCRIPTION
오너 **"모바일 앱도 만들거니까 준비해보자"** → PWA를 **설치형 앱**으로 마감했습니다.

## 변경
- **매니페스트**(webmanifest + json) 갱신:
  - `short_name` **‘코고가네’**, 색 순흑 `#020010` → **먹 `#1a1714`**(브랜드 토큰).
  - `start_url` **`/seller/m`**(모바일 앱 셸) — 설치 후 앱 아이콘으로 열면 모바일 앱 화면으로.
  - 바로가기(shortcuts)에 **상품 수집 / 수집 이력** 추가. (`display: standalone`, `share_target`은 기존)
- **모바일 홈**에 **📲 코고가네 앱 설치** 버튼 — 안드로이드 `beforeinstallprompt` 발생 시 노출 → 누르면 설치 프롬프트. 서비스워커 등록.
- iOS는 `beforeinstallprompt` 미지원 → 더보기의 **‘홈 화면에 추가’** 안내 유지.

## 테스트
- 설치 버튼/매니페스트 케이스 추가 + theme/short_name 테스트 갱신.
- 전체 `pytest` **10107 passed**.

## 참고
- 네이티브 빌드(TWA/Capacitor)는 후속 — 지금은 **설치형 PWA**로 충족(경량). 안드로이드는 ‘앱 설치’ 한 번, iOS는 공유 → 홈 화면 추가로 앱처럼 사용.

## v6 진행
✅ 로그인 · ✅ 결제 · ✅ 마켓 원클릭 연동 · ✅ 죽은 버튼 가드 · ✅ 설치형 PWA. 남은 P1: **애플홈+퍼센티 감성 랜딩 리디자인**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_