### PR TITLE
feat(landing): 애플홈+퍼센티 감성 랜딩 리디자인 (Phase 262, v6 P1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,11 @@
   - ✅ v6 모바일 설치형 PWA(Phase 261): manifest(webmanifest+json) short_name 코고가네, 색 순흑#020010→먹#1a1714,
     start_url /seller/m, 상품수집/수집이력 shortcut. mobile_home에 '📲 앱 설치' 버튼(beforeinstallprompt, 안드로이드)
     + SW 등록. iOS는 더보기의 '홈 화면에 추가' 안내. 테스트 갱신(short_name/color).
+  - ✅ v6 P1 애플홈 랜딩 리디자인(Phase 262): landing.html을 풀블리드 섹션(밝다 한지↔어둡다 먹 번갈아) +
+    큰 명조 히어로(띄어쓴 한글 "수 집 부 터/등 록 까 지")+서브+CTA2(처음이신가요 주황/둘러보기 청록라인) +
+    2열 기능 타일(수집/다듬기/등록/주문) + For Beginners 밴드 + 푸터. **개발자 카드(관리자/API/시스템) 제거**
+    (일반 유저 랜딩에서 숨김). 보존: /privacy·/terms·/seller/·/seller/about·/seller/start·privacy-policy meta.
+    → v6 큰 줄기 완료(로그인·결제·마켓연동·죽은버튼가드·설치형PWA·애플홈 랜딩).
 - **쉽고 간편 결제(Phase 258):** 신설 `billing_store.py`(셀러 plan free/plus/pro + token_balance) +
   `/seller/billing`(요금제·충전 페이지, 깔끔 카드 + 1버튼 주황 CTA). free=즉시 전환, 유료=토스 결제
   (TOSS_CLIENT_KEY/SECRET_KEY) 설정 시에만 활성(가짜 활성 금지, 미설정 시 정직 안내). 활성 Plus/Pro면

--- a/src/templates/landing.html
+++ b/src/templates/landing.html
@@ -1,122 +1,80 @@
-{# 랜딩 페이지 — 먹+금 다크 vault (KOHgogane 브리프 §2.2 / Phase 235) #}
+{# 랜딩 — 애플홈 + 퍼센티 감성 (KOHgogane 브리프 v6 P1 / Phase 262) #}
 {% extends "_base_app.html" %}
 
 {% block title %}{{ brand_name|default('KOHgogane', true) }} — 코고가네 셀러 SaaS{% endblock %}
 {% block head %}
 <link rel="privacy-policy" href="/privacy">
 <style>
-  /* 입구(랜딩)는 먹 다크 vault — 금빛 글로우 + 한지 텍스트 + 청록 CTA. 작업 화면은 한지 라이트. */
-  body.bg-light {
-    background:
-      radial-gradient(1100px 460px at 50% -6%, rgba(201,162,75,.18), transparent 60%),
-      linear-gradient(180deg, #1a1714 0%, #211c17 55%, #14110e 100%) fixed !important;
-    color: #f5efe3;
-  }
-  .vault-hero h1 { font-family: var(--pc-font-display, 'Noto Serif KR', serif); color: #ecdcb0; }
-  .vault-hero .lead { color: #c9bda6; }
-  .vault-rule { height: 1px; width: 120px; margin: 1.25rem auto; background: linear-gradient(90deg, transparent, #c9a24b, transparent); }
-  .vault-card {
-    background: #241f1a;
-    border: 1px solid rgba(201,162,75,.30) !important;
-    color: #f5efe3;
-    transition: border-color .18s ease, transform .18s ease, box-shadow .18s ease;
-  }
-  .vault-card:hover {
-    border-color: #0f9d8c !important;
-    transform: translateY(-3px);
-    box-shadow: 0 18px 40px rgba(0,0,0,.45);
-  }
-  .vault-card .card-title { color: #ecdcb0; }
-  .vault-card .card-text { color: #c0b49d !important; }
-  .vault-foot, .vault-foot a { color: #b7a98c !important; }
-  .vault-foot a:hover { color: #ecdcb0 !important; }
-  .vault-foot hr { border-color: rgba(201,162,75,.25); }
-  .vault-beta {
-    display: inline-block; font-size: .7rem; letter-spacing: .12em; text-transform: uppercase;
-    color: #1a1714; background: #c9a24b; border-radius: 999px; padding: .12rem .6rem; font-weight: 700;
-    vertical-align: middle; margin-left: .4rem;
-  }
+  body.bg-light { background: var(--pc-color-bg) !important; color: var(--pc-color-text); }
+  .lp { max-width: 980px; margin: 0 auto; padding: 0 1rem; }
+  /* 풀블리드 섹션 — 밝다(한지) ↔ 어둡다(먹) 번갈아 */
+  .lp-sec { padding: 5rem 0; }
+  .lp-dark { background:
+      radial-gradient(900px 380px at 50% -10%, rgba(201,162,75,.16), transparent 60%),
+      linear-gradient(180deg, #1a1714, #14110e); color: #f5efe3; }
+  .lp-cream { background: var(--pc-color-bg); color: var(--pc-color-text); }
+  .lp-hero h1 { font-family: var(--pc-font-display, serif); font-weight: 700; font-size: clamp(2.2rem, 6vw, 3.8rem); line-height: 1.1; letter-spacing: -.01em; }
+  .lp-hero .sub { color: #c9bda6; font-size: 1.15rem; max-width: 540px; margin: 1rem auto 2rem; }
+  .lp-beta { font-size:.66rem; letter-spacing:.14em; background:#c9a24b; color:#1a1714; border-radius:999px; padding:.15rem .55rem; font-weight:700; vertical-align: middle; }
+  .lp-eyebrow { font-size:.8rem; letter-spacing:.16em; text-transform:uppercase; color:#119a8e; font-weight:700; }
+  .lp-sec h2 { font-family: var(--pc-font-display, serif); font-weight:700; font-size: clamp(1.8rem,4vw,2.6rem); }
+  .lp-tile { background: var(--pc-color-surface); border:1px solid var(--pc-color-border); border-radius:18px; padding:2rem 1.6rem; height:100%; transition: transform .15s, box-shadow .15s; }
+  .lp-tile:hover { transform: translateY(-3px); box-shadow: var(--pc-shadow-md); }
+  .lp-tile .ico { font-size:2.4rem; }
+  .lp-cta-line { border:1.5px solid #119a8e; color:#9fe7df !important; background:transparent; }
+  .lp-foot a { color: var(--pc-color-text-muted); }
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="row justify-content-center mt-4 vault-hero">
-  <div class="col-lg-8 text-center">
-    <h1 class="display-5 fw-bold mb-2">
-      {{ brand_name|default('KOHgogane', true) }}<span class="vault-beta">Beta</span>
-    </h1>
-    <div class="vault-rule"></div>
-    <p class="lead mb-4">수집부터 등록까지 — 한 곳에서. 퍼센티 스타일 셀러 자동화 SaaS.</p>
-    <a href="/seller/start" class="btn btn-cta btn-lg mb-5">✨ For Beginners · 처음이신가요?</a>
+<!-- 히어로 (어두움) -->
+<section class="lp-sec lp-dark lp-hero text-center">
+  <div class="lp">
+    <div class="mb-3" style="font-size:2.6rem;">🛒 <span class="lp-beta">Beta</span></div>
+    <h1>수 집 부 터<br>등 록 까 지</h1>
+    <p class="sub">해외 상품을 수집하고, 한국어로 다듬고, 우리 마켓에 등록까지. 클릭 몇 번이면 끝.</p>
+    <div class="d-flex flex-wrap gap-2 justify-content-center">
+      <a href="/seller/start" class="btn btn-cta btn-lg">✨ 처음이신가요?</a>
+      <a href="/seller/" class="btn btn-lg lp-cta-line">둘러보기</a>
+    </div>
   </div>
-</div>
+</section>
 
-<div class="row justify-content-center g-4">
-  {# 셀러 콘솔 카드 #}
-  <div class="col-sm-6 col-lg-3">
-    <a href="/seller/" class="text-decoration-none">
-      <div class="card h-100 shadow-sm vault-card landing-card">
-        <div class="card-body text-center py-4">
-          <div class="fs-1 mb-3">🛒</div>
-          <h5 class="card-title fw-bold">셀러 콘솔</h5>
-          <p class="card-text small">상품 수집 · 마진 계산 · 마켓 업로드</p>
-        </div>
-      </div>
-    </a>
+<!-- 기능 타일 (밝음) -->
+<section class="lp-sec lp-cream">
+  <div class="lp text-center mb-5">
+    <div class="lp-eyebrow mb-2">한 곳에서, 한 번에</div>
+    <h2>반복 작업은 코고가네가</h2>
   </div>
-
-  {# 관리자 패널 카드 #}
-  <div class="col-sm-6 col-lg-3">
-    <a href="/admin/" class="text-decoration-none">
-      <div class="card h-100 shadow-sm vault-card landing-card">
-        <div class="card-body text-center py-4">
-          <div class="fs-1 mb-3">🛠</div>
-          <h5 class="card-title fw-bold">관리자 패널</h5>
-          <p class="card-text small">주문 · 재고 · 매출 대시보드</p>
-        </div>
-      </div>
-    </a>
+  <div class="lp">
+    <div class="row g-3">
+      <div class="col-md-6"><div class="lp-tile"><div class="ico mb-2">🔎</div><h5 class="fw-bold">수집</h5><p class="text-muted mb-0">타오바오·아마존·알리 등 어떤 상품이든 버튼 한 번. 크롬 확장·모바일 공유·붙여넣기까지.</p></div></div>
+      <div class="col-md-6"><div class="lp-tile"><div class="ico mb-2">🌐</div><h5 class="fw-bold">다듬기</h5><p class="text-muted mb-0">제목·설명 한국어 번역, 금지어 정리, 가격·마진 일괄 적용. 이미지 워터마크 제거까지.</p></div></div>
+      <div class="col-md-6"><div class="lp-tile"><div class="ico mb-2">🚀</div><h5 class="fw-bold">등록</h5><p class="text-muted mb-0">쿠팡·스마트스토어·11번가 등 여러 마켓에 한 번에. 발급부터 연결까지 클릭으로.</p></div></div>
+      <div class="col-md-6"><div class="lp-tile"><div class="ico mb-2">📦</div><h5 class="fw-bold">주문</h5><p class="text-muted mb-0">주문·배송·정산을 한 화면에서. 모바일 앱으로 어디서나 확인하고 처리.</p></div></div>
+    </div>
   </div>
+</section>
 
-  {# API 문서 카드 #}
-  <div class="col-sm-6 col-lg-3">
-    <a href="/api/docs" class="text-decoration-none">
-      <div class="card h-100 shadow-sm vault-card landing-card">
-        <div class="card-body text-center py-4">
-          <div class="fs-1 mb-3">📚</div>
-          <h5 class="card-title fw-bold">API 문서</h5>
-          <p class="card-text small">200+ 엔드포인트 · 검색 · 그룹화</p>
-        </div>
-      </div>
-    </a>
+<!-- For Beginners 밴드 (어두움) -->
+<section class="lp-sec lp-dark text-center">
+  <div class="lp">
+    <h2 class="mb-3">처음이어도 괜찮아요</h2>
+    <p class="sub mx-auto">큰 버튼을 따라 누르기만 하면, 로그인부터 첫 등록까지 끝납니다.</p>
+    <a href="/seller/start" class="btn btn-cta btn-lg">✨ For Beginners · 시작하기</a>
+    <div class="mt-3"><a href="/seller/about" class="text-decoration-none" style="color:#c9bda6">코고가네란? →</a></div>
   </div>
+</section>
 
-  {# 시스템 상태 카드 #}
-  <div class="col-sm-6 col-lg-3">
-    <a href="/health/deep" class="text-decoration-none">
-      <div class="card h-100 shadow-sm vault-card landing-card">
-        <div class="card-body text-center py-4">
-          <div class="fs-1 mb-3">💚</div>
-          <h5 class="card-title fw-bold">시스템 상태</h5>
-          <p class="card-text small">헬스체크 · 의존성 · 업타임</p>
-        </div>
-      </div>
-    </a>
-  </div>
-</div>
-
-{# 푸터 #}
-<div class="row mt-5 vault-foot">
-  <div class="col text-center small">
+<!-- 푸터 -->
+<section class="lp-sec lp-cream lp-foot" style="padding:2.5rem 0;">
+  <div class="lp text-center small">
     <hr>
-    <span>Phase {{ current_phase }}</span> &nbsp;·&nbsp;
-    <span>{{ version }}</span> &nbsp;·&nbsp;
+    <span class="text-muted">Phase {{ current_phase }} · {{ version }}</span> &nbsp;·&nbsp;
     <a href="/seller/about">코고가네란?</a> &nbsp;·&nbsp;
     <a href="/privacy">개인정보처리방침</a> &nbsp;·&nbsp;
     <a href="/terms">이용약관</a> &nbsp;·&nbsp;
-    <a href="https://github.com/Kohgane/proxy-commerce" target="_blank" rel="noopener">
-      <i class="bi bi-github"></i> GitHub
-    </a>
+    <a href="https://github.com/Kohgane/proxy-commerce" target="_blank" rel="noopener"><i class="bi bi-github"></i> GitHub</a>
   </div>
-</div>
+</section>
 {% endblock %}


### PR DESCRIPTION
v6 마스터 브리프 **P1 — 애플홈 + 퍼센티 감성 랜딩 리디자인**입니다. (v6 마지막 큰 조각)

## 변경 — `landing.html` 전면 리디자인
**애플 홈의 구조감 + 퍼센티 셀러 카피**를 코고가네 톤으로:
- **풀블리드 섹션** — 밝다(한지) ↔ 어둡다(먹) **번갈아**.
- **히어로(어두움):** 큰 명조 헤드라인(띄어쓴 한글 **‘수 집 부 터 / 등 록 까 지’**) + 짧은 서브 + **CTA 2개**(처음이신가요=주황 / 둘러보기=청록 라인) + Beta 배지.
- **기능 타일(밝음):** 2열 큰 타일 4개(🔎 수집 / 🌐 다듬기 / 🚀 등록 / 📦 주문) + 짧은 셀러 친화 카피, hover lift.
- **For Beginners 밴드(어두움)** + ‘코고가네란?’ 링크 · 푸터.
- **개발자 카드(관리자 패널 / API 문서 / 시스템 상태) 제거** — 일반 유저 랜딩에서 숨김(쉽고 편함·비기너 우선).

보존(테스트): `/privacy`·`/terms`·`/seller/`·`/seller/about`·`/seller/start`·‘For Beginners’·`privacy-policy` meta·`brand_name`.

## 테스트
- 전체 `pytest` **10107 passed**(랜딩 링크/온보딩/About/죽은버튼 가드 포함).

## v6 완료 🎉
✅ 로그인 튕김 · ✅ 쉽고 결제 · ✅ 마켓 원클릭 연동 · ✅ 죽은 버튼 0 가드 · ✅ 설치형 PWA · ✅ 애플홈 랜딩.
(구글 일반유저 로그인은 코드 준비됨 — 오너 콘솔 ‘프로덕션 게시’만 남음.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_