### PR TITLE
perf(v8): 수집이력 시트 왕복 감소 — 요청 범위 read 캐시 (Phase 264)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,10 @@
   이름(🧤만)+익스텐션/사이트 파비콘 코고가네 마크 교체.
   - ✅ v8 ①-a 응답 속도(Phase 263): gunicorn `gthread`+threads(I/O 동시성), gzip 응답 압축(after_request,
     텍스트류 600B↑, Accept-Encoding gzip시만 → 기존 테스트 안전), 정적 에셋 Cache-Control max-age=604800.
-    요청 타이밍 로그는 기존(request_logger elapsed_ms). ⏳ 다음: 시트 read 캐시(TTL)/배치.
+    요청 타이밍 로그는 기존(request_logger elapsed_ms).
+  - ✅ v8 ①-b 시트 왕복 감소(Phase 264): collect_history_store에 요청 범위 read 캐시(flask.g, has_request_context).
+    한 페이지에서 list+summary+distinct가 같은 시트 3회 읽던 걸 요청당 1회로. 쓰기(append/update/delete) 후
+    _invalidate_cache로 무효화(요청 내 스테일 방지). 요청 컨텍스트 밖/인메모리는 직접 read. ⏳ 다음: ②Bluehost 릴레이.
 - **v7:** 확장 상단바 토글/접힘 배지(끄면 구석 작게·청록/금 펄스·개수, 위치/상태 기억, 팝업 on/off), 단일 FAB
   우측 중앙 이동+드래그/기억, '전체 일괄수집' 코치마크 1회, 따라하기 재미(수집 도장/카운트업·위트카피·마일스톤).
 

--- a/src/seller_console/collect_history_store.py
+++ b/src/seller_console/collect_history_store.py
@@ -32,6 +32,37 @@ def _get_worksheet():
     return open_sheet(_SHEET_ID, _WS_NAME)
 
 
+def _read_sheet_records():
+    """시트 전체 records — 같은 요청 내 중복 read 제거(요청 범위 캐시, v8 속도).
+
+    한 페이지 렌더에서 list_items/summary/distinct_domains가 같은 시트를 3번 읽던 것을
+    요청당 1회로 줄인다. 요청 컨텍스트가 없으면(배치/테스트) 매번 직접 read(스테일 없음).
+    """
+    ws = _get_worksheet()
+    try:
+        from flask import g, has_request_context
+        if has_request_context():
+            cached = getattr(g, "_kgp_ch_rows", None)
+            if cached is not None:
+                return cached
+            recs = ws.get_all_records()
+            g._kgp_ch_rows = recs
+            return recs
+    except Exception:
+        pass
+    return ws.get_all_records()
+
+
+def _invalidate_cache():
+    """쓰기 후 요청 범위 캐시 무효화(같은 요청 내 후속 read가 최신을 보게)."""
+    try:
+        from flask import g, has_request_context
+        if has_request_context() and hasattr(g, "_kgp_ch_rows"):
+            delattr(g, "_kgp_ch_rows")
+    except Exception:
+        pass
+
+
 def _ensure_headers(ws) -> None:
     try:
         first_row = ws.row_values(1)
@@ -90,6 +121,7 @@ def append(
             ws = _get_worksheet()
             _ensure_headers(ws)
             ws.append_row([row_data[h] for h in _HEADERS])
+            _invalidate_cache()
             logger.info("수집 이력 저장: id=%s source=%s domain=%s", item_id, source, domain)
         except Exception as exc:
             logger.warning("수집 이력 Sheets 저장 실패: %s", exc)
@@ -116,9 +148,7 @@ def list_items(
 
     if _SHEET_ID:
         try:
-            ws = _get_worksheet()
-            records = ws.get_all_records()
-            rows = records
+            rows = _read_sheet_records()
         except Exception as exc:
             logger.warning("수집 이력 조회 실패: %s", exc)
             rows = list(_in_memory)
@@ -156,9 +186,7 @@ def get(item_id: str, seller_id: Optional[str] = None) -> Optional[dict]:
 
     if _SHEET_ID:
         try:
-            ws = _get_worksheet()
-            records = ws.get_all_records()
-            for row in records:
+            for row in _read_sheet_records():
                 if _match(row):
                     return dict(row)
         except Exception as exc:
@@ -205,6 +233,7 @@ def update(item_id: str, *, seller_id: Optional[str] = None, **fields) -> bool:
                         ci = col_idx.get(field)
                         if ci is not None:
                             ws.update_cell(r, ci + 1, val)
+                    _invalidate_cache()
                     logger.info("수집 이력 갱신: id=%s fields=%s", item_id, list(updates))
                     return True
         except Exception as exc:
@@ -256,6 +285,7 @@ def delete(item_ids, *, seller_id: Optional[str] = None) -> int:
                     ws.delete_rows(r)
                     deleted += 1
             if deleted:
+                _invalidate_cache()
                 logger.info("수집 이력 삭제: %d건", deleted)
             return deleted
         except Exception as exc:

--- a/tests/test_sheet_read_cache.py
+++ b/tests/test_sheet_read_cache.py
@@ -1,0 +1,54 @@
+"""tests/test_sheet_read_cache.py — v8 속도: 요청 범위 시트 read 캐시 (Phase 264)."""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class _FakeWS:
+    def __init__(self):
+        self.reads = 0
+
+    def get_all_records(self):
+        self.reads += 1
+        return [{"id": "a", "collected_at": "2026-06-20T00:00:00+00:00",
+                 "domain": "x", "source": "manual", "seller_id": "s1", "title": "t"}]
+
+
+def test_request_scoped_cache_dedupes_reads():
+    """같은 요청 안에서 list+list+get = 시트 read 1회(중복 제거)."""
+    from src.seller_console import collect_history_store as chs
+    from src.order_webhook import app
+    ws = _FakeWS()
+    with patch.object(chs, "_SHEET_ID", "sheet-x"), patch.object(chs, "_get_worksheet", return_value=ws):
+        with app.test_request_context("/seller/collect/history"):
+            from flask import g
+            if hasattr(g, "_kgp_ch_rows"): delattr(g, "_kgp_ch_rows")
+            chs.list_items(seller_id="s1")
+            chs.list_items(seller_id="s1", days=7)
+            chs.get("a", seller_id="s1")
+    assert ws.reads == 1
+
+
+def test_cache_invalidated_after_write():
+    """쓰기(update) 후 같은 요청 내 read가 최신을 다시 읽는다(스테일 방지)."""
+    from src.seller_console import collect_history_store as chs
+    from src.order_webhook import app
+    ws = _FakeWS()
+    # update는 get_all_values를 쓰므로 read 카운트와 무관 — 캐시 무효화만 확인.
+    ws.get_all_values = lambda: [["id", "seller_id", "title"], ["a", "s1", "t"]]
+    ws.update_cell = lambda *a, **k: None
+    ws.row_values = lambda *a, **k: ["id", "seller_id", "title"]
+    with patch.object(chs, "_SHEET_ID", "sheet-x"), patch.object(chs, "_get_worksheet", return_value=ws):
+        with app.test_request_context("/x"):
+            from flask import g
+            if hasattr(g, "_kgp_ch_rows"): delattr(g, "_kgp_ch_rows")
+            chs.list_items(seller_id="s1")          # read 1 (캐시 채움)
+            chs.update("a", seller_id="s1", title="new")  # 무효화
+            chs.get("a", seller_id="s1")            # read 2 (캐시 비었으므로 재read)
+    assert ws.reads == 2


### PR DESCRIPTION
v8 **①-b 속도 — Google Sheets 왕복 감소**(주범 1)입니다. "시트는 소스 오브 트루스 유지, 요청당 중복 read 제거."

## 변경
- **`collect_history_store`에 요청 범위 read 캐시** (`flask.g`, `has_request_context` 가드):
  - 수집 이력 페이지 한 번 렌더에 `list_items` + `summary`(→list) + `distinct_domains`(→list)가 **같은 시트를 3번** 읽던 것을 **요청당 1회**로. `list_items`/`get`이 공유.
- **쓰기(append/update/delete) 후 `_invalidate_cache`** → 같은 요청 내 후속 read가 최신을 봄(스테일 방지).
- **요청 컨텍스트 밖**(배치/테스트)·**인메모리 폴백**은 매번 직접 read → **크로스 요청 스테일 없음**(정직 데이터 보존).

## 안전
- 캐시는 **단일 요청 수명**만 — 다른 요청/사용자에 새지 않음. 쓰기 즉시 무효화.
- 신규 2케이스(요청 내 read 1회 · 쓰기 후 무효화 → 재read).
- 전체 `pytest` **10113 passed**.

## 다음 (v8)
② **쿠팡/네이버 Bluehost 고정 IP 릴레이**(IP 화이트리스트) → ③ 북마클릿 이모지 이름 + 코고가네 파비콘. 그 후 v7(확장 UX).

> 같은 요청 범위 캐시 패턴은 billing/groups/word_rules/pccc 등 다른 시트 스토어에도 후속 확대 가능(읽기 빈도 보고 측정 후).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_