### PR TITLE
feat(v8): 마켓 API 고정 IP 릴레이(쿠팡/네이버) — 플래그 폴백 (Phase 265)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,12 @@
     요청 타이밍 로그는 기존(request_logger elapsed_ms).
   - ✅ v8 ①-b 시트 왕복 감소(Phase 264): collect_history_store에 요청 범위 read 캐시(flask.g, has_request_context).
     한 페이지에서 list+summary+distinct가 같은 시트 3회 읽던 걸 요청당 1회로. 쓰기(append/update/delete) 후
-    _invalidate_cache로 무효화(요청 내 스테일 방지). 요청 컨텍스트 밖/인메모리는 직접 read. ⏳ 다음: ②Bluehost 릴레이.
+    _invalidate_cache로 무효화(요청 내 스테일 방지). 요청 컨텍스트 밖/인메모리는 직접 read.
+  - ✅ v8 ② 마켓 고정IP 릴레이(Phase 265): 신설 `src/market_relay.py`(relay_request — MARKET_RELAY_URL+TOKEN
+    설정+대상마켓일 때 Bluehost 릴레이로 POST, 미설정/비대상은 직접 호출 폴백. Bearer+HMAC). 쿠팡/네이버
+    uploader의 `requests.request`를 relay_request(market=coupang/smartstore)로 교체. 배포물 `relay/market_relay_server_v8.py`
+    (무상태 포워딩, host 화이트리스트, 키 미저장/미로깅) + README. 오너: Bluehost에 릴레이 올리고 그 IP를 쿠팡/네이버
+    허용IP+SERVER_OUTBOUND_IP에. ⏳ 다음: ③북마클릿 이모지+코고가네 파비콘.
 - **v7:** 확장 상단바 토글/접힘 배지(끄면 구석 작게·청록/금 펄스·개수, 위치/상태 기억, 팝업 on/off), 단일 FAB
   우측 중앙 이동+드래그/기억, '전체 일괄수집' 코치마크 1회, 따라하기 재미(수집 도장/카운트업·위트카피·마일스톤).
 

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,0 +1,34 @@
+# 코고가네 마켓 릴레이 (v8) — 쿠팡/네이버 고정 IP 경유
+
+Render는 아웃바운드 IP가 고정이 아니라 쿠팡·네이버 OpenAPI의 **호출 IP 화이트리스트**가 안 맞습니다.
+이 릴레이를 **고정 IP 호스트(Bluehost 등)** 에 올려, 서명까지 끝난 요청을 그 고정 IP에서 대신 호출합니다.
+
+## 1) Bluehost(고정 IP)에 릴레이 배포
+```bash
+pip install flask requests gunicorn
+export MARKET_RELAY_TOKEN="아주-긴-랜덤-토큰"     # Render 앱과 동일 값
+gunicorn -w 2 -b 0.0.0.0:8800 market_relay_server_v8:app
+# 또는 Bluehost Passenger/WSGI에 market_relay_server_v8:app 등록 + HTTPS 도메인 연결
+```
+- 공개 도메인 예: `https://relay.yourdomain.com` (HTTPS 필수)
+- 이 서버의 공인 IP 확인: `curl https://api.ipify.org`
+
+## 2) 쿠팡/네이버에 그 IP 등록
+- 위 IP를 **쿠팡 Wing(OPEN API 허용 IP, 최대 10개)** · **네이버 커머스API(호출 IP, 최대 3개)** 에 등록.
+
+## 3) Render 앱 환경변수
+| 변수 | 값 |
+|---|---|
+| `MARKET_RELAY_URL` | `https://relay.yourdomain.com` |
+| `MARKET_RELAY_TOKEN` | 릴레이와 동일한 긴 랜덤 토큰 |
+| `MARKET_RELAY_MARKETS` | (선택) 기본 `coupang,smartstore,naver` |
+| `SERVER_OUTBOUND_IP` | (선택) 위 Bluehost 공인 IP — 연동 화면 '복사' 버튼에 노출 |
+
+설정되면 쿠팡/네이버 호출(업로드·연결 테스트 동일)이 릴레이를 경유합니다.
+**미설정이면 기존처럼 직접 호출**(폴백 — 회귀 없음). Shopify/WooCommerce/Shopee는 IP 화이트리스트가
+없어 항상 직접 호출합니다.
+
+## 보안/정직
+- Bearer 토큰 + HMAC(timestamp+body) 검증, 5분 시계오차 허용(재전송 차단).
+- 허용 호스트(쿠팡/네이버)만 포워딩. 자격증명/페이로드 **미저장**, 키·바디 **로깅 금지**.
+- 실제 마켓 응답의 status/body만 패스스루 — **가짜 성공 없음**(IP 미등록이면 그 실패가 그대로 표시).

--- a/relay/market_relay_server_v8.py
+++ b/relay/market_relay_server_v8.py
@@ -1,0 +1,92 @@
+"""market_relay_server_v8.py — Bluehost 고정 IP 마켓 릴레이 (무상태).
+
+Render 앱이 보낸 '이미 서명된 요청'을 받아 고정 IP(Bluehost)에서 그대로 전달하고
+응답만 돌려준다. 쿠팡·네이버 OpenAPI의 호출 IP 화이트리스트 대응.
+
+배포(Bluehost / 모든 고정 IP 호스트):
+    pip install flask requests
+    export MARKET_RELAY_TOKEN="아주-긴-랜덤-토큰"      # Render 앱의 MARKET_RELAY_TOKEN과 동일
+    gunicorn -w 2 -b 0.0.0.0:8800 market_relay_server_v8:app   # 또는 호스트 WSGI/Passenger
+  → HTTPS 도메인(예: https://relay.yourdomain.com)을 Render 앱 MARKET_RELAY_URL 에 설정.
+  → 이 서버의 공인 IP(`curl https://api.ipify.org`)를 쿠팡/네이버 허용 IP에 등록.
+
+보안/정직:
+  - Bearer 토큰 + HMAC(timestamp+body) 검증, 5분 시계 오차 허용(재전송 차단).
+  - 허용 호스트(쿠팡/네이버)만 포워딩. 자격증명/페이로드 미저장, 키·바디 로깅 금지.
+  - 실제 마켓 응답의 status/body만 패스스루(가짜 성공 없음).
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import time
+from urllib.parse import urlparse
+
+import requests
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+_TOKEN = os.environ.get("MARKET_RELAY_TOKEN", "")
+_MAX_SKEW = int(os.environ.get("MARKET_RELAY_MAX_SKEW", "300"))
+# 허용 호스트(화이트리스트) — 쿠팡/네이버 OpenAPI 도메인만.
+_ALLOW_HOST_SUFFIXES = tuple(
+    h.strip() for h in (os.environ.get(
+        "MARKET_RELAY_ALLOW_HOSTS",
+        "coupang.com,api-gateway.coupang.com,commerce.naver.com,api.commerce.naver.com",
+    ).split(",")) if h.strip()
+)
+
+
+@app.get("/healthz")
+def healthz():
+    return jsonify(ok=True)
+
+
+@app.post("/relay")
+def relay():
+    if not _TOKEN:
+        return jsonify(error="relay not configured"), 503
+    if request.headers.get("Authorization", "") != f"Bearer {_TOKEN}":
+        return jsonify(error="unauthorized"), 401
+
+    ts = request.headers.get("X-Relay-Timestamp", "")
+    sig = request.headers.get("X-Relay-Signature", "")
+    raw = request.get_data() or b""
+    try:
+        if not ts or abs(time.time() - int(ts)) > _MAX_SKEW:
+            return jsonify(error="stale timestamp"), 401
+    except (TypeError, ValueError):
+        return jsonify(error="bad timestamp"), 401
+    expect = hmac.new(_TOKEN.encode(), (ts + raw.decode("utf-8")).encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expect, sig):
+        return jsonify(error="bad signature"), 401
+
+    try:
+        spec = json.loads(raw)
+    except ValueError:
+        return jsonify(error="bad json"), 400
+
+    url = spec.get("url", "")
+    host = urlparse(url).netloc.lower()
+    if not host or not any(host == h or host.endswith("." + h) or host.endswith(h) for h in _ALLOW_HOST_SUFFIXES):
+        return jsonify(error="host not allowed"), 403
+
+    try:
+        resp = requests.request(
+            spec.get("method", "GET"),
+            url,
+            headers=spec.get("headers") or {},
+            data=(spec.get("body") or None),
+            timeout=int(os.environ.get("MARKET_RELAY_TIMEOUT", "30")),
+        )
+        return jsonify(status=resp.status_code, body=resp.text)
+    except requests.RequestException as exc:
+        # 키/바디 로깅 금지 — 예외 타입만.
+        return jsonify(status=502, body=json.dumps({"relay_error": type(exc).__name__})), 200
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", "8800")))

--- a/src/market_relay.py
+++ b/src/market_relay.py
@@ -1,0 +1,89 @@
+"""src/market_relay.py — 마켓 API 호출을 고정 IP 릴레이로 경유 (v8 P0, Phase 265).
+
+쿠팡·네이버 OpenAPI는 호출 IP를 화이트리스트에 등록해야 한다. Render는 아웃바운드 IP가
+고정이 아니라서 화이트리스트가 안 맞는다. → 서명까지 끝난 요청을 Bluehost 고정 IP 릴레이로
+전달해 거기서 실제 호출(고정 IP)하고 결과만 돌려받는다.
+
+- `MARKET_RELAY_URL` + `MARKET_RELAY_TOKEN` 둘 다 설정 + market이 릴레이 대상일 때만 경유.
+  미설정이면 기존처럼 직접 호출(폴백 — 회귀 없음).
+- Bearer 토큰 + HMAC(timestamp+body) 서명으로 인증/재전송 차단.
+- 무상태: 릴레이는 자격증명/페이로드를 저장하지 않고 키도 로깅하지 않는다(릴레이 서버 책임).
+
+서명은 호출 앱(여기)에서 이미 끝났고, 릴레이는 단순 포워딩만 한다(마켓별 로직 없음).
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json as _json
+import logging
+import os
+import time
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _relay_markets() -> set:
+    raw = os.getenv("MARKET_RELAY_MARKETS") or "coupang,smartstore,naver"
+    return {m.strip().lower() for m in raw.split(",") if m.strip()}
+
+
+def relay_enabled(market: str = "") -> bool:
+    """릴레이 경유 조건: URL+TOKEN 설정 + market이 대상."""
+    if not (os.getenv("MARKET_RELAY_URL") and os.getenv("MARKET_RELAY_TOKEN")):
+        return False
+    m = (market or "").strip().lower()
+    return (not m) or (m in _relay_markets())
+
+
+class RelayResponse:
+    """requests.Response 호환 최소 shim (status_code/json()/text/raise_for_status)."""
+
+    def __init__(self, status_code: int, text: str = ""):
+        self.status_code = int(status_code)
+        self.text = text or ""
+
+    def json(self):
+        return _json.loads(self.text) if self.text else {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"{self.status_code} via relay", response=self)
+
+
+def relay_request(method, url, *, headers=None, json=None, data=None, timeout=30, market=""):
+    """릴레이 설정 시 고정 IP 경유, 아니면 직접 requests 호출(폴백).
+
+    Returns: requests.Response 또는 RelayResponse(호환).
+    """
+    if not relay_enabled(market):
+        return requests.request(method, url, headers=headers, json=json, data=data, timeout=timeout)
+
+    relay_url = os.getenv("MARKET_RELAY_URL", "").rstrip("/")
+    token = os.getenv("MARKET_RELAY_TOKEN", "")
+    body = None
+    if json is not None:
+        body = _json.dumps(json, ensure_ascii=False)
+    elif data is not None:
+        body = data if isinstance(data, str) else _json.dumps(data, ensure_ascii=False)
+
+    spec = {"method": str(method).upper(), "url": url, "headers": dict(headers or {}), "body": body}
+    payload = _json.dumps(spec, ensure_ascii=False)
+    ts = str(int(time.time()))
+    sig = hmac.new(token.encode(), (ts + payload).encode(), hashlib.sha256).hexdigest()
+    r = requests.post(
+        relay_url + "/relay",
+        data=payload.encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Relay-Timestamp": ts,
+            "X-Relay-Signature": sig,
+            "Content-Type": "application/json",
+        },
+        timeout=timeout + 10,
+    )
+    r.raise_for_status()
+    out = r.json()
+    return RelayResponse(int(out.get("status", 502)), out.get("body", ""))

--- a/src/uploaders/coupang_uploader.py
+++ b/src/uploaders/coupang_uploader.py
@@ -372,7 +372,10 @@ class CoupangUploader(BaseUploader):
         }
         for attempt in range(3):
             try:
-                resp = requests.request(method, url, json=data, headers=headers, timeout=30)
+                # 고정 IP 릴레이 경유(MARKET_RELAY_URL 설정 시) — 쿠팡 호출 IP 화이트리스트 대응(v8).
+                # 미설정이면 직접 호출(폴백). 서명은 위에서 이미 끝났고 릴레이는 포워딩만.
+                from src.market_relay import relay_request
+                resp = relay_request(method, url, json=data, headers=headers, timeout=30, market="coupang")
                 if resp.status_code == 429:
                     logger.warning('Coupang rate limit hit, retrying in %ds (attempt %d)', 5, attempt + 1)
                     time.sleep(5 * (attempt + 1))

--- a/src/uploaders/naver_uploader.py
+++ b/src/uploaders/naver_uploader.py
@@ -236,7 +236,9 @@ class NaverSmartStoreUploader(BaseUploader):
         }
         for attempt in range(3):
             try:
-                resp = requests.request(method, url, json=data, headers=headers, timeout=30)
+                # 고정 IP 릴레이 경유(MARKET_RELAY_URL 설정 시) — 네이버 호출 IP 화이트리스트 대응(v8).
+                from src.market_relay import relay_request
+                resp = relay_request(method, url, json=data, headers=headers, timeout=30, market="smartstore")
                 if resp.status_code == 429:
                     logger.warning('Naver rate limit hit, retrying in %ds (attempt %d)', 5, attempt + 1)
                     time.sleep(5 * (attempt + 1))

--- a/tests/test_market_relay.py
+++ b/tests/test_market_relay.py
@@ -1,0 +1,78 @@
+"""tests/test_market_relay.py — 마켓 고정 IP 릴레이 클라이언트 (Phase 265, v8 P0)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in ("MARKET_RELAY_URL", "MARKET_RELAY_TOKEN", "MARKET_RELAY_MARKETS"):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def test_direct_when_relay_unconfigured(monkeypatch):
+    """릴레이 미설정 → 직접 requests 호출(폴백, 회귀 없음)."""
+    from src import market_relay
+    assert market_relay.relay_enabled("coupang") is False
+    with patch("src.market_relay.requests.request") as mock_req:
+        mock_req.return_value = MagicMock(status_code=200)
+        market_relay.relay_request("GET", "https://api-gateway.coupang.com/x",
+                                   headers={"A": "1"}, market="coupang")
+    mock_req.assert_called_once()
+
+
+def test_relay_used_when_configured(monkeypatch):
+    """릴레이 설정 + 대상 마켓 → 릴레이로 POST, 응답 패스스루."""
+    monkeypatch.setenv("MARKET_RELAY_URL", "https://relay.example.com")
+    monkeypatch.setenv("MARKET_RELAY_TOKEN", "tok-123")
+    from src import market_relay
+    assert market_relay.relay_enabled("coupang") is True
+
+    relay_resp = MagicMock()
+    relay_resp.raise_for_status.return_value = None
+    relay_resp.json.return_value = {"status": 201, "body": json.dumps({"ok": True})}
+    with patch("src.market_relay.requests.post", return_value=relay_resp) as mock_post, \
+         patch("src.market_relay.requests.request") as mock_direct:
+        resp = market_relay.relay_request("POST", "https://api-gateway.coupang.com/v2/products",
+                                          json={"name": "x"}, headers={"Authorization": "CEA ..."},
+                                          market="coupang")
+    mock_post.assert_called_once()
+    mock_direct.assert_not_called()
+    assert resp.status_code == 201
+    assert resp.json() == {"ok": True}
+    # 릴레이로 보낸 스펙에 서명된 헤더/바디가 담김
+    sent = mock_post.call_args
+    assert "/relay" in sent.args[0]
+    assert sent.kwargs["headers"]["Authorization"] == "Bearer tok-123"
+    assert "X-Relay-Signature" in sent.kwargs["headers"]
+
+
+def test_non_relay_market_goes_direct(monkeypatch):
+    """릴레이 설정돼도 대상 아닌 마켓(shopify)은 직접 호출."""
+    monkeypatch.setenv("MARKET_RELAY_URL", "https://relay.example.com")
+    monkeypatch.setenv("MARKET_RELAY_TOKEN", "tok")
+    monkeypatch.setenv("MARKET_RELAY_MARKETS", "coupang,smartstore")
+    from src import market_relay
+    assert market_relay.relay_enabled("shopify") is False
+    with patch("src.market_relay.requests.request") as mock_req, \
+         patch("src.market_relay.requests.post") as mock_post:
+        mock_req.return_value = MagicMock(status_code=200)
+        market_relay.relay_request("GET", "https://shop.myshopify.com/x", market="shopify")
+    mock_req.assert_called_once()
+    mock_post.assert_not_called()
+
+
+def test_relay_response_raise_for_status():
+    from src.market_relay import RelayResponse
+    import requests
+    RelayResponse(200, "{}").raise_for_status()  # no raise
+    with pytest.raises(requests.exceptions.HTTPError):
+        RelayResponse(401, "").raise_for_status()


### PR DESCRIPTION
v8 **② 마켓 API 호출을 고정 IP 릴레이로 경유** (쿠팡/네이버 IP 화이트리스트). Render는 아웃바운드 IP가 고정이 아니라 화이트리스트가 안 맞으므로, 서명까지 끝난 요청을 **Bluehost 고정 IP 릴레이**에서 대신 호출합니다.

## 변경 (앱)
- **신설 `src/market_relay.py`** — `relay_request(method, url, …, market)`:
  - `MARKET_RELAY_URL` + `MARKET_RELAY_TOKEN` 설정 + **대상 마켓(coupang/smartstore/naver)**일 때만 릴레이 경유.
  - **미설정/비대상이면 기존처럼 직접 `requests` 호출**(플래그 폴백 — **회귀 없음**).
  - **Bearer + HMAC**(timestamp+body) 서명, 재전송 차단. `RelayResponse`(requests 호환 shim).
- 쿠팡·네이버 uploader의 `requests.request` → `relay_request(market=...)`로 교체. **연결 테스트도 같은 경로**(실제 IP 반영). Shopify/Woo/Shopee는 화이트리스트가 없어 **직접 호출 유지**.

## 배포물 (Bluehost)
- **`relay/market_relay_server_v8.py`** — 무상태 포워딩 Flask: **허용 호스트(쿠팡/네이버)만**, Bearer+HMAC 검증, **자격증명/바디 미저장·키 미로깅**, 실제 status/body만 패스스루(**가짜 성공 없음** — IP 미등록이면 그 실패가 그대로). `relay/README.md`에 배포·IP 등록·env 가이드.

## 테스트
- 신규 4케이스(미설정 직접 · 릴레이 경유+서명 · 비대상 직접 · RelayResponse). 업로드 테스트 471개 포함 전체 `pytest` **10117 passed**.

## 오너 액션
1. `relay/`를 Bluehost(고정 IP)에 배포(HTTPS).
2. 그 서버 공인 IP(`curl https://api.ipify.org`)를 **쿠팡/네이버 허용 IP**에 등록 + `SERVER_OUTBOUND_IP`에 입력(연동 화면 복사 버튼).
3. Render에 `MARKET_RELAY_URL` / `MARKET_RELAY_TOKEN` 설정. → 설정 즉시 경유, 미설정이면 기존 동작.

## 다음 (v8)
③ 북마클릿 이모지 이름(🧤) + 익스텐션/사이트 파비콘 코고가네 마크. 그 후 v7(확장 UX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_