### PR TITLE
fix(v9 P0): 수집-이력 불일치 추적 로그 + 식별자 관용 매칭 + 재현 테스트 (Phase 266)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,20 @@
 - 코드/문서/로그/실제 응답 등 **확인 가능한 근거**가 있을 때만 단정적으로 답한다.
 - 헛다리(추측 기반 단정) 반복 금지. 화면·응답 원문 등 증거를 우선한다.
 
+## 🟥 v9 브리프 (오너 2026-06-21 — "수집 성공인데 이력에 없음, 추적으로 끝장. 고친 척 금지")
+- **P0 수집 추적(Phase 266):** 거짓 성공/추측 금지 → 상관관계 ID로 한 건 끝까지 추적.
+  - 확장 `/api/v1/collect/extension`에 corr_id 로깅(수신 token_user_id·url → 저장 seller_id·item_id →
+    자기검증 saved → 실패 시 502). collect_history 뷰에 식별자/총건수 로그.
+  - **관용 식별자 매칭(핵심 수정):** 저장 seller_id가 user_id면 user_id로, email이면 email로 어긋나도 본인
+    이력에 보이게 — `_seller_identities()`={user_id,email,기본키}로 list_items/summary/distinct/get + KPI 필터
+    (collect_history_store에 seller_ids set 파라미터 추가). 타 셀러 누출 없음(전부 본인 값).
+  - **재현 테스트(가드):** 확장 수집(token user_id=u1) → 세션 user_id=u1 이력에 +1 노출 보장 +
+    email/user_id 별칭 관용 + 타셀러 미노출. 전체 10120 passed.
+  - ※ 원인 확정은 오너 다음 수집 시 corr_id 로그로 어느 홉인지 증거 확보(현재 코드상 GOOGLE_SHEET_ID 있으면
+    저장=조회 동일 시트, seller_id 별칭만이 유력 — 관용 매칭으로 방어). P1: 애플홈 '제대로'·외국인 지역배너.
+- **v9 남음:** P1 애플 홈 규격 재적용(거대 헤드라인 clamp(40,6vw,72)·알약 CTA·밝다/어둡다), P1 외국인 지역/언어 배너
+  (Accept-Language 외국인만, i18n 실전환, 쿠키 기억, 한국인 미노출).
+
 ## 🟦 v7/v8 추가 브리프 (오너 2026-06-21 — "렌더 env 다 했음, 나열순, v8 우선")
 - **v8(우선):** ①속도(타이밍 측정→시트 캐시/배치, gunicorn gthread/gzip/에셋) ②마켓호출 Bluehost 릴레이
   (쿠팡/네이버 고정IP 경유, MARKET_RELAY_URL/TOKEN, 연결테스트 동일경로, Shopify/Woo는 직접) ③북마클릿 이모지

--- a/src/api/extension_api.py
+++ b/src/api/extension_api.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import secrets
 import threading
 import time
 import uuid
@@ -179,12 +180,16 @@ def collect_from_extension():
     Response:
         {ok: true, preview_url: "/seller/collect/preview/<id>"}
     """
+    # v9 P0 — 수집 1건 끝까지 추적(상관관계 ID). 어느 홉에서 사라지는지 로그로 본다.
+    _corr = secrets.token_hex(4)
     user = _require_token(scopes=["collect.write"])
     if not user:
+        logger.warning("[collect %s] 인증 실패(토큰 없음/무효)", _corr)
         return jsonify({"ok": False, "error": "인증이 필요합니다. Personal Access Token을 설정해주세요."}), 401
 
     payload = request.get_json(force=True, silent=True) or {}
     url = (payload.get("url") or "").strip()
+    logger.info("[collect %s] 수신 token_user_id=%r url=%s", _corr, user.get("user_id"), url[:80])
     if not url:
         return jsonify({"ok": False, "error": "url 필드가 필요합니다."}), 400
 
@@ -249,16 +254,19 @@ def collect_from_extension():
             },
             seller_id=seller_id_val,
         )
+        logger.info("[collect %s] 저장 시도 seller_id=%r item_id=%s", _corr, seller_id_val, item_id)
         try:
             saved = history_get(item_id, seller_id=seller_id_val) is not None
         except Exception:
             saved = bool(item_id)
+        logger.info("[collect %s] 저장 자기검증 saved=%s (같은 seller_id=%r로 재조회)", _corr, saved, seller_id_val)
     except Exception as exc:
-        logger.warning("수집 이력 기록 실패: %s", exc)
+        logger.warning("[collect %s] 수집 이력 기록 실패: %s", _corr, exc)
 
     if not item_id or not saved:
         # 가짜 성공 금지(v4 P0): 실제 저장 안 됐으면 정직한 실패로 토스트가 사유를 표시하게.
-        logger.warning("확장 수집 저장 검증 실패: url=%s user=%s saved=%s", url[:80], seller_id_val, saved)
+        logger.warning("[collect %s] 저장 검증 실패 → 502 정직 실패: url=%s seller_id=%r saved=%s",
+                       _corr, url[:80], seller_id_val, saved)
         return jsonify({"ok": False, "error": "수집 항목을 저장하지 못했습니다. 잠시 후 다시 시도하세요."}), 502
 
     preview_url = f"/seller/collect/preview/{item_id}"

--- a/src/seller_console/collect_history_store.py
+++ b/src/seller_console/collect_history_store.py
@@ -133,7 +133,8 @@ def append(
 
 
 def list_items(
-    *, domain: str = "", source: str = "", days: int = 30, seller_id: Optional[str] = None
+    *, domain: str = "", source: str = "", days: int = 30, seller_id: Optional[str] = None,
+    seller_ids: Optional[set] = None,
 ) -> list[dict]:
     """수집 이력 목록 반환 (최신순).
 
@@ -163,7 +164,11 @@ def list_items(
             continue
         if source and row.get("source", "") != source:
             continue
-        if seller_id is not None and str(row.get("seller_id", "") or "") != str(seller_id):
+        _rsid = str(row.get("seller_id", "") or "")
+        if seller_ids is not None:
+            if _rsid not in seller_ids:
+                continue
+        elif seller_id is not None and _rsid != str(seller_id):
             continue
         result.append(dict(row))
 
@@ -171,16 +176,20 @@ def list_items(
     return result
 
 
-def get(item_id: str, seller_id: Optional[str] = None) -> Optional[dict]:
+def get(item_id: str, seller_id: Optional[str] = None, seller_ids: Optional[set] = None) -> Optional[dict]:
     """ID로 단건 조회.
 
     Args:
         seller_id: 지정 시 해당 셀러의 항목만 반환(타 셀러 항목 접근 차단). None이면 검사 안 함.
+        seller_ids: 사용자의 식별자 집합(user_id+email) — 별칭 불일치 대비 관용 매칭.
     """
     def _match(row: dict) -> bool:
         if row.get("id") != item_id:
             return False
-        if seller_id is not None and str(row.get("seller_id", "") or "") != str(seller_id):
+        _rsid = str(row.get("seller_id", "") or "")
+        if seller_ids is not None:
+            return _rsid in seller_ids
+        if seller_id is not None and _rsid != str(seller_id):
             return False
         return True
 
@@ -303,9 +312,9 @@ def delete(item_ids, *, seller_id: Optional[str] = None) -> int:
     return before - len(_in_memory)
 
 
-def summary(days: int = 30, seller_id: Optional[str] = None) -> dict:
+def summary(days: int = 30, seller_id: Optional[str] = None, seller_ids: Optional[set] = None) -> dict:
     """기간별 요약 통계."""
-    items = list_items(days=days, seller_id=seller_id)
+    items = list_items(days=days, seller_id=seller_id, seller_ids=seller_ids)
     by_source: dict[str, int] = {
         "extension": 0,
         "bookmarklet": 0,
@@ -341,8 +350,8 @@ def summary(days: int = 30, seller_id: Optional[str] = None) -> dict:
     }
 
 
-def distinct_domains(days: int = 90, seller_id: Optional[str] = None) -> list[str]:
+def distinct_domains(days: int = 90, seller_id: Optional[str] = None, seller_ids: Optional[set] = None) -> list[str]:
     """최근 N일 내 수집된 도메인 목록 (중복 제거, 알파벳순)."""
-    items = list_items(days=days, seller_id=seller_id)
+    items = list_items(days=days, seller_id=seller_id, seller_ids=seller_ids)
     domains = sorted({item.get("domain", "") for item in items if item.get("domain")})
     return domains

--- a/src/seller_console/data_aggregator.py
+++ b/src/seller_console/data_aggregator.py
@@ -32,7 +32,7 @@ def _safe_import(module_path: str, attr: str = None) -> Optional[Any]:
 # 오늘 KPI 데이터
 # ---------------------------------------------------------------------------
 
-def get_today_kpi(seller_id: Any = None) -> Dict[str, Any]:
+def get_today_kpi(seller_id: Any = None, seller_ids: Any = None) -> Dict[str, Any]:
     """오늘 KPI 카드 데이터 반환 (주문수, GMV, 마진, 신규 수집).
 
     실데이터 우선: 오늘 수집 건수는 collect_history_store(실 저장소)에서 집계.
@@ -56,7 +56,8 @@ def get_today_kpi(seller_id: Any = None) -> Dict[str, Any]:
     # 오늘 수집 건수 — 실 저장소(collect_history_store)에서 셀러별 집계(이력 리스트와 동일 필터)
     try:
         from .collect_history_store import summary as collect_summary
-        s = collect_summary(days=2, seller_id=seller_id)
+        # 이력 리스트와 동일 필터 — 식별자 집합(user_id+email)이 있으면 그걸로(관용 매칭, v9).
+        s = collect_summary(days=2, seller_id=seller_id, seller_ids=seller_ids)
         if isinstance(s, dict):
             data["new_products_collected"] = int(s.get("today", 0) or 0)
             has_real = True

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -146,11 +146,11 @@ def _find_cross_channel_messages(messages: list, identity: dict[str, str]) -> li
 # 헬퍼 — graceful import
 # ---------------------------------------------------------------------------
 
-def _get_widgets(seller_id=None) -> list:
-    """위젯 데이터 목록 조회 (graceful import). seller_id로 KPI 셀러 격리."""
+def _get_widgets(seller_id=None, seller_ids=None) -> list:
+    """위젯 데이터 목록 조회 (graceful import). seller_id/식별자집합으로 KPI 셀러 격리."""
     try:
         from .widgets import build_all_widgets
-        return build_all_widgets(seller_id)
+        return build_all_widgets(seller_id, seller_ids)
     except Exception as exc:
         logger.warning("위젯 로드 실패: %s", exc)
         return []
@@ -916,7 +916,7 @@ def _build_dashboard_home_context(widgets: list[dict[str, Any]], dismissed: bool
 
 
 def _render_dashboard_home():
-    widgets = _get_widgets(_seller_id())
+    widgets = _get_widgets(_seller_id(), _seller_identities())
     dismissed = request.cookies.get(_ONBOARDING_DISMISS_COOKIE) == "1"
     context = _build_dashboard_home_context(widgets, dismissed=dismissed)
     context["onboarding"]["dismiss_href"] = url_for("seller_console.dismiss_onboarding", next=request.path)
@@ -3562,6 +3562,22 @@ def _seller_id() -> str:
         return "default"
 
 
+def _seller_identities() -> set:
+    """현재 사용자의 식별자 집합(user_id + email + 기본키) — 수집 저장 seller_id와
+    이력 필터 seller_id가 별칭(user_id vs email)으로 어긋날 때도 본인 항목을 보이게
+    하는 관용 매칭용(v9 P0). 모두 '본인' 값이라 타 셀러 누출 없음.
+    """
+    ids = set()
+    try:
+        for v in (session.get("user_id"), session.get("user_email")):
+            if v:
+                ids.add(str(v))
+    except Exception:
+        pass
+    ids.add(_seller_id())
+    return ids
+
+
 def _diag_market_key(market: str) -> str:
     """자격증명 마켓 키 → 진단 서브시스템 키 (11번가만 상이)."""
     return "11st" if market == "elevenst" else market
@@ -4912,9 +4928,12 @@ def collect_history():
     try:
         from .collect_history_store import list_items, summary, distinct_domains
         _sid = _seller_id()
-        items = list_items(domain=domain, source=source, days=days, seller_id=_sid)
-        summ = summary(days=days, seller_id=_sid)
-        domains = distinct_domains(seller_id=_sid)
+        _ids = _seller_identities()
+        items = list_items(domain=domain, source=source, days=days, seller_ids=_ids)
+        summ = summary(days=days, seller_ids=_ids)
+        domains = distinct_domains(seller_ids=_ids)
+        # v9 P0 추적: 이력 필터 식별자 + 결과 건수(어느 seller_id로 조회하는지 증거).
+        logger.info("[collect-history] seller_id=%s identities=%s total=%s", _sid, sorted(_ids), summ.get("total"))
     except Exception as exc:
         logger.warning("수집 이력 조회 실패: %s", exc)
 

--- a/src/seller_console/widgets.py
+++ b/src/seller_console/widgets.py
@@ -52,9 +52,9 @@ def _safe_call(func, *args, **kwargs) -> Dict[str, Any]:
         return dict(_NOT_READY)
 
 
-def build_kpi_widget(seller_id: Any = None) -> Dict[str, Any]:
-    """오늘 KPI 카드 위젯 데이터 (seller_id로 '오늘 수집' 셀러 격리)."""
-    data = _safe_call(get_today_kpi, seller_id)
+def build_kpi_widget(seller_id: Any = None, seller_ids: Any = None) -> Dict[str, Any]:
+    """오늘 KPI 카드 위젯 데이터 (seller_id/식별자집합으로 '오늘 수집' 셀러 격리)."""
+    data = _safe_call(get_today_kpi, seller_id, seller_ids)
     return {
         "title": "오늘 KPI",
         "type": "kpi",
@@ -157,10 +157,10 @@ def build_orders_kpi_widget() -> Dict[str, Any]:
     }
 
 
-def build_all_widgets(seller_id: Any = None) -> List[Dict[str, Any]]:
-    """모든 대시보드 위젯 데이터 목록 반환 (seller_id로 셀러 격리 KPI)."""
+def build_all_widgets(seller_id: Any = None, seller_ids: Any = None) -> List[Dict[str, Any]]:
+    """모든 대시보드 위젯 데이터 목록 반환 (seller_id/식별자집합으로 셀러 격리 KPI)."""
     return [
-        build_kpi_widget(seller_id),
+        build_kpi_widget(seller_id, seller_ids),
         build_collect_queue_widget(),
         build_market_status_widget(),
         build_sourcing_alerts_widget(),

--- a/tests/test_collect_trace_v9.py
+++ b/tests/test_collect_trace_v9.py
@@ -1,0 +1,72 @@
+"""tests/test_collect_trace_v9.py — '수집 성공인데 이력에 없음' 재현/회귀 가드 (Phase 266, v9 P0).
+
+브리프 요구: 확장 수집 1건 → 같은 seller_id로 이력 조회 시 +1(즉시 노출) 보장.
++ user_id/email 별칭으로 저장돼도 본인 이력에 보이는 관용 매칭.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    from src.seller_console import collect_history_store as chs
+    chs._in_memory.clear()
+    yield
+    chs._in_memory.clear()
+
+
+def test_extension_collect_appears_in_history_same_seller(client):
+    """확장 수집(토큰 user_id=u1) → 세션 user_id=u1로 이력 조회 시 그 상품이 보인다."""
+    with patch("src.api.extension_api._require_token", return_value={"user_id": "u1", "scopes": ["collect.write"]}), \
+         patch("src.api.extension_api._upsert_catalog", return_value="cat1"), \
+         patch("src.api.extension_api._notify_telegram"):
+        r = client.post("/api/v1/collect/extension",
+                        data=json.dumps({"url": "https://shop/x", "title": "추적가방", "translate": False}),
+                        content_type="application/json",
+                        headers={"Authorization": "Bearer tok"})
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is True
+
+    # 같은 사용자로 이력 페이지 → 그 상품이 보여야 한다(저장 seller_id == 조회 seller_id)
+    with client.session_transaction() as sess:
+        sess["user_id"] = "u1"
+    html = client.get("/seller/collect/history").get_data(as_text=True)
+    assert "추적가방" in html
+
+
+def test_history_tolerant_identity_email_vs_userid(client):
+    """저장은 email seller_id, 조회는 user_id 세션이어도 본인 이력에 보인다(별칭 관용)."""
+    from src.seller_console import collect_history_store as chs
+    chs.append(source="extension", url="https://shop/y", title="별칭상품", seller_id="me@x.com")
+    with client.session_transaction() as sess:
+        sess["user_id"] = "uA"
+        sess["user_email"] = "me@x.com"
+    html = client.get("/seller/collect/history").get_data(as_text=True)
+    assert "별칭상품" in html
+
+
+def test_other_seller_item_not_visible(client):
+    """타 셀러 항목은 여전히 안 보인다(관용 매칭이 누출되지 않음)."""
+    from src.seller_console import collect_history_store as chs
+    chs.append(source="extension", url="https://shop/z", title="남의상품", seller_id="someone-else")
+    with client.session_transaction() as sess:
+        sess["user_id"] = "uA"
+        sess["user_email"] = "me@x.com"
+    html = client.get("/seller/collect/history").get_data(as_text=True)
+    assert "남의상품" not in html


### PR DESCRIPTION
v9 **P0 — "수집 성공인데 이력에 없음"을 추적으로 끝낸다.** 고친 척 금지 — 증거(로그) + 재현 테스트.

## 추적 (어느 홉에서 사라지는지 증거)
- 확장 `/api/v1/collect/extension`에 **상관관계 ID(corr_id)** 로깅:
  `수신 token_user_id·url` → `저장 seller_id·item_id` → `자기검증 saved(같은 seller_id로 즉시 재조회)` → 실패 시 502.
- `collect_history` 뷰: **조회 식별자 + 총건수** 로그.
→ 오너 다음 수집 1건이면 로그로 **정확한 홉**이 보입니다.

## 수정 (유력 원인 = seller_id 별칭 불일치 방어)
- `_seller_identities()` = {세션 `user_id`, `email`, 기본키}.
- `collect_history_store.list_items/summary/distinct_domains/get`에 **`seller_ids`(집합) 파라미터** 추가 → 저장 seller_id가 `user_id`든 `email`이든 **본인이면 이력/KPI에 보임**(관용 매칭). 전부 본인 값이라 **타 셀러 누출 없음**. 대시보드 KPI도 같은 식별자로 일치.

## 증명 (재현 테스트, CI 가드)
- 확장 수집(token `user_id=u1`) → 세션 `user_id=u1` 이력에 **+1 노출** 보장.
- `email`↔`user_id` 별칭 관용(저장은 email, 조회는 user_id 세션) + **타 셀러 항목 미노출**.
- 전체 `pytest` **10120 passed**.

## 정직
- `GOOGLE_SHEET_ID`가 설정되면 저장=조회 동일 시트이므로(자기검증 통과 = Sheets에 실제 존재), 남는 유력 원인은 **seller_id 별칭**뿐 — 이번 관용 매칭으로 방어합니다. **정확한 원인 홉은 오너의 다음 수집 corr_id 로그로 확정**합니다(추측 단정 안 함). 만약 로그가 다른 홉(쓰기≠읽기 탭 등)을 가리키면 그 증거로 다시 잡겠습니다.

## 다음 (v9)
P1 애플 홈 '제대로' 재적용 → P1 외국인 지역/언어 배너.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_