### PR TITLE
feat(i18n): 외국인 전용 지역/언어 배너 + 실제 EN 전환 (Phase 268, v9 P1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,10 @@
   clamp(40px,6vw,72px) 자간 좁게, 한 줄 회색 서브, 큰 비주얼(이모지), 알약 CTA(주황 채움/청록 라인) 헤드라인
   바로 아래 중앙, IntersectionObserver 등장 페이드(prefers-reduced-motion 존중). 4-타일 그리드 폐기→섹션별 1메시지.
   보존: privacy/terms/seller/about/start·privacy-policy meta·For Beginners.
-- **v9 남음:** P1 외국인 지역/언어 배너(Accept-Language 외국인만, i18n 실전환, 쿠키 기억, 한국인 미노출).
+- **P1 외국인 지역/언어 배너(Phase 268):** order_webhook `_show_region_banner()`(Accept-Language 첫 언어가 ko가
+  아니고 미선택·미닫힘일 때만), `_visitor_lang()`(kgp_lang 쿠키=en이면 en, 아니면 ko 기본). `/i18n/set?lang=`·
+  `/i18n/dismiss` 라우트(쿠키 1년 기억). 랜딩 상단 슬림 배너(English/한국어/✕) — 외국인만, 한국인 미노출.
+  랜딩 카피 EN/KO 실전환(가짜 드롭다운 아님 — 고른 값이 실제 EN 카피로 반영). → v9 완료(수집추적·애플홈·지역배너).
 
 ## 🟦 v7/v8 추가 브리프 (오너 2026-06-21 — "렌더 env 다 했음, 나열순, v8 우선")
 - **v8(우선):** ①속도(타이밍 측정→시트 캐시/배치, gunicorn gthread/gzip/에셋) ②마켓호출 Bluehost 릴레이

--- a/src/order_webhook.py
+++ b/src/order_webhook.py
@@ -1184,6 +1184,63 @@ _EXTERNAL_SHOP_URL = os.getenv("EXTERNAL_SHOP_URL", "https://kohganemultishop.or
 # Phase 123 — 루트 라우트 + 에러 핸들러
 # ---------------------------------------------------------------------------
 
+def _visitor_lang() -> str:
+    """방문자 언어 — kgp_lang 쿠키로 명시 선택했으면 그 값, 아니면 한국어(기본)."""
+    try:
+        return "en" if request.cookies.get("kgp_lang") == "en" else "ko"
+    except Exception:
+        return "ko"
+
+
+def _show_region_banner() -> bool:
+    """외국인 방문자에게만 지역/언어 배너 노출(한국인 미노출).
+
+    조건: 닫지 않았고 + 언어 미선택 + Accept-Language 첫 언어가 한국어가 아님.
+    """
+    try:
+        if request.cookies.get("kgp_region_dismissed") == "1":
+            return False
+        if request.cookies.get("kgp_lang"):
+            return False
+        al = (request.headers.get("Accept-Language", "") or "").strip().lower()
+        return bool(al) and not al.startswith("ko")
+    except Exception:
+        return False
+
+
+def _render_landing():
+    from src.version import get_current_phase
+    version = os.getenv('APP_VERSION', 'dev')
+    return render_template('landing.html', version=version, current_phase=get_current_phase(),
+                           lang=_visitor_lang(), show_region_banner=_show_region_banner())
+
+
+@app.get('/i18n/set')
+def i18n_set():
+    """언어 선택 적용(쿠키 기억) — 외국인 지역 배너의 'Continue'/드롭다운. 가짜 아님."""
+    lang = (request.args.get("lang") or "ko").strip().lower()
+    if lang not in ("ko", "en"):
+        lang = "ko"
+    nxt = request.args.get("next", "/")
+    if not nxt.startswith("/"):
+        nxt = "/"
+    resp = redirect(nxt, code=302)
+    resp.set_cookie("kgp_lang", lang, max_age=60 * 60 * 24 * 365, samesite="Lax")
+    resp.set_cookie("kgp_region_dismissed", "1", max_age=60 * 60 * 24 * 365, samesite="Lax")
+    return resp
+
+
+@app.get('/i18n/dismiss')
+def i18n_dismiss():
+    """지역 배너 닫기(쿠키 기억)."""
+    nxt = request.args.get("next", "/")
+    if not nxt.startswith("/"):
+        nxt = "/"
+    resp = redirect(nxt, code=302)
+    resp.set_cookie("kgp_region_dismissed", "1", max_age=60 * 60 * 24 * 365, samesite="Lax")
+    return resp
+
+
 @app.get('/')
 def root():
     """루트 라우트 — ROOT_REDIRECT 환경변수로 동작 제어 (Phase 132).
@@ -1212,9 +1269,7 @@ def root():
         return redirect(_EXTERNAL_SHOP_URL, code=302)
 
     if redirect_target == "landing":
-        from src.version import get_current_phase
-        version = os.getenv('APP_VERSION', 'dev')
-        return render_template('landing.html', version=version, current_phase=get_current_phase())
+        return _render_landing()
 
     # 기본: "seller" (백워드 호환)
     # 단, 미로그인 방문자에게는 랜딩 페이지(개인정보처리방침 링크 포함)를 직접 렌더한다.
@@ -1227,9 +1282,7 @@ def root():
             return redirect('/seller/', code=302)
         except Exception:
             pass
-    from src.version import get_current_phase
-    version = os.getenv('APP_VERSION', 'dev')
-    return render_template('landing.html', version=version, current_phase=get_current_phase())
+    return _render_landing()
 
 
 @app.route("/shop")

--- a/src/templates/landing.html
+++ b/src/templates/landing.html
@@ -43,13 +43,23 @@
 {% endblock %}
 
 {% block content %}
+{% set EN = (lang == 'en') %}
+{% if show_region_banner %}
+<!-- 외국인 전용 지역/언어 배너 (한국인 미노출) -->
+<div style="background:#1a1714;color:#f5efe3;font-size:.85rem;padding:.5rem 1rem;display:flex;align-items:center;justify-content:center;gap:.8rem;flex-wrap:wrap;">
+  <span>🌏 Shopping from outside Korea? Choose your language.</span>
+  <a href="/i18n/set?lang=en&next=/" style="color:#1a1714;background:#c9a24b;border-radius:999px;padding:.15rem .8rem;text-decoration:none;font-weight:700;">English</a>
+  <a href="/i18n/set?lang=ko&next=/" style="color:#f5efe3;border:1px solid #57503f;border-radius:999px;padding:.15rem .8rem;text-decoration:none;">한국어</a>
+  <a href="/i18n/dismiss?next=/" aria-label="close" style="color:#c9bda6;text-decoration:none;">✕</a>
+</div>
+{% endif %}
 <nav class="lpnav">
   <div class="inner">
     <a href="/" class="logo">🛒 코고가네</a>
     <div class="ms-auto d-flex align-items-center gap-3">
-      <a href="/seller/about" class="navlink d-none d-sm-inline">소개</a>
-      <a href="/seller/" class="navlink d-none d-sm-inline">둘러보기</a>
-      <a href="/seller/start" class="pill pill-fill" style="padding:.45rem 1.1rem;font-size:.9rem;">시작하기</a>
+      <a href="/seller/about" class="navlink d-none d-sm-inline">{{ 'About' if EN else '소개' }}</a>
+      <a href="/seller/" class="navlink d-none d-sm-inline">{{ 'Explore' if EN else '둘러보기' }}</a>
+      <a href="/seller/start" class="pill pill-fill" style="padding:.45rem 1.1rem;font-size:.9rem;">{{ 'Get started' if EN else '시작하기' }}</a>
     </div>
   </div>
 </nav>
@@ -57,12 +67,21 @@
 <!-- 1. 히어로 (어두움) -->
 <section class="scene dark">
   <div class="wrap reveal">
+    {% if EN %}
+    <h1>From sourcing<br>to listing<span class="beta">Beta</span></h1>
+    <p class="sub">Source overseas products, polish them in Korean, and list to marketplaces — in a few clicks.</p>
+    <div class="d-flex flex-wrap gap-2 justify-content-center">
+      <a href="/seller/start" class="pill pill-fill">New here?</a>
+      <a href="/seller/" class="pill pill-line">Explore</a>
+    </div>
+    {% else %}
     <h1>수 집 부 터<br>등 록 까 지<span class="beta">Beta</span></h1>
     <p class="sub">해외 상품을 수집하고, 한국어로 다듬고, 우리 마켓에 등록까지. 클릭 몇 번이면 끝.</p>
     <div class="d-flex flex-wrap gap-2 justify-content-center">
       <a href="/seller/start" class="pill pill-fill">처음이신가요?</a>
       <a href="/seller/" class="pill pill-line">둘러보기</a>
     </div>
+    {% endif %}
   </div>
 </section>
 
@@ -70,10 +89,13 @@
 <section class="scene cream">
   <div class="wrap reveal">
     <div class="visual">🔎</div>
-    <div class="eyebrow">수집</div>
-    <h2>버튼 한 번이면<br>담깁니다</h2>
+    <div class="eyebrow">{{ 'Collect' if EN else '수집' }}</div>
+    {% if EN %}<h2>One click<br>to collect</h2>
+    <p class="sub">Taobao, Amazon, AliExpress… any product. Chrome extension, mobile share, or paste.</p>
+    <a href="/seller/start" class="pill pill-fill">Start collecting</a>
+    {% else %}<h2>버튼 한 번이면<br>담깁니다</h2>
     <p class="sub">타오바오·아마존·알리… 어떤 상품이든. 크롬 확장·모바일 공유·붙여넣기까지.</p>
-    <a href="/seller/start" class="pill pill-fill">수집 시작하기</a>
+    <a href="/seller/start" class="pill pill-fill">수집 시작하기</a>{% endif %}
   </div>
 </section>
 
@@ -81,10 +103,13 @@
 <section class="scene dark">
   <div class="wrap reveal">
     <div class="visual">🌐</div>
-    <div class="eyebrow">다듬기</div>
-    <h2>한국어로,<br>깔끔하게</h2>
+    <div class="eyebrow">{{ 'Polish' if EN else '다듬기' }}</div>
+    {% if EN %}<h2>Clean,<br>in Korean</h2>
+    <p class="sub">Translate titles/descriptions, filter banned words, set prices/margins, remove watermarks.</p>
+    <a href="/seller/about" class="pill pill-line">Learn more</a>
+    {% else %}<h2>한국어로,<br>깔끔하게</h2>
     <p class="sub">제목·설명 번역, 금지어 정리, 가격·마진 일괄. 이미지 워터마크 제거까지.</p>
-    <a href="/seller/about" class="pill pill-line">자세히 보기</a>
+    <a href="/seller/about" class="pill pill-line">자세히 보기</a>{% endif %}
   </div>
 </section>
 
@@ -92,10 +117,13 @@
 <section class="scene cream">
   <div class="wrap reveal">
     <div class="visual">🚀</div>
-    <div class="eyebrow">등록</div>
-    <h2>여러 마켓에<br>한 번에</h2>
+    <div class="eyebrow">{{ 'List' if EN else '등록' }}</div>
+    {% if EN %}<h2>Many markets,<br>at once</h2>
+    <p class="sub">Coupang, SmartStore, 11st… from key issuance to connect and list, all by click.</p>
+    <a href="/seller/markets/connect" class="pill pill-fill">Connect markets</a>
+    {% else %}<h2>여러 마켓에<br>한 번에</h2>
     <p class="sub">쿠팡·스마트스토어·11번가… 발급부터 연결, 등록까지 클릭으로.</p>
-    <a href="/seller/markets/connect" class="pill pill-fill">마켓 연동하기</a>
+    <a href="/seller/markets/connect" class="pill pill-fill">마켓 연동하기</a>{% endif %}
   </div>
 </section>
 
@@ -103,15 +131,18 @@
 <section class="scene dark">
   <div class="wrap reveal">
     <div class="visual">✨</div>
-    <h2>처음이어도<br>괜찮아요</h2>
+    {% if EN %}<h2>New?<br>No problem</h2>
+    <p class="sub">Just follow the big buttons — from sign-in to your first listing.</p>
+    <a href="/seller/start" class="pill pill-fill">For Beginners · Start</a>
+    {% else %}<h2>처음이어도<br>괜찮아요</h2>
     <p class="sub">큰 버튼을 따라 누르기만 하면, 로그인부터 첫 등록까지 끝납니다.</p>
-    <a href="/seller/start" class="pill pill-fill">For Beginners · 시작하기</a>
+    <a href="/seller/start" class="pill pill-fill">For Beginners · 시작하기</a>{% endif %}
   </div>
 </section>
 
 <footer class="lpfoot">
   <span>Phase {{ current_phase }} · {{ version }}</span> &nbsp;·&nbsp;
-  <a href="/seller/about">코고가네란?</a> &nbsp;·&nbsp;
+  <a href="/seller/about">{{ "About KOHgogane" if EN else "코고가네란?" }}</a> &nbsp;·&nbsp;
   <a href="/privacy">개인정보처리방침</a> &nbsp;·&nbsp;
   <a href="/terms">이용약관</a> &nbsp;·&nbsp;
   <a href="https://github.com/Kohgane/proxy-commerce" target="_blank" rel="noopener"><i class="bi bi-github"></i> GitHub</a>

--- a/tests/test_region_banner_i18n.py
+++ b/tests/test_region_banner_i18n.py
@@ -1,0 +1,52 @@
+"""tests/test_region_banner_i18n.py — 외국인 지역/언어 배너 (Phase 268, v9 P1)."""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("ROOT_REDIRECT", "landing")
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_banner_shown_for_foreign_visitor(client):
+    html = client.get("/", headers={"Accept-Language": "en-US,en;q=0.9"}).get_data(as_text=True)
+    assert "Choose your language" in html
+    assert "/i18n/set?lang=en" in html
+
+
+def test_banner_hidden_for_korean(client):
+    html = client.get("/", headers={"Accept-Language": "ko-KR,ko;q=0.9"}).get_data(as_text=True)
+    assert "Choose your language" not in html
+
+
+def test_set_lang_en_sets_cookie_and_redirects(client):
+    resp = client.get("/i18n/set?lang=en&next=/")
+    assert resp.status_code == 302
+    cookies = resp.headers.getlist("Set-Cookie")
+    assert any("kgp_lang=en" in c for c in cookies)
+    assert any("kgp_region_dismissed=1" in c for c in cookies)
+
+
+def test_landing_renders_english_when_lang_cookie_en(client):
+    client.set_cookie("kgp_lang", "en")
+    html = client.get("/").get_data(as_text=True)
+    assert "From sourcing" in html          # 실제 EN 카피로 전환(가짜 아님)
+    assert "Connect markets" in html
+    # 이미 선택 → 배너 안 뜸
+    assert "Choose your language" not in html
+
+
+def test_dismiss_hides_banner_for_foreign(client):
+    client.set_cookie("kgp_region_dismissed", "1")
+    html = client.get("/", headers={"Accept-Language": "en-US"}).get_data(as_text=True)
+    assert "Choose your language" not in html


### PR DESCRIPTION
v9 **마지막 — 외국인 전용 지역/언어 배너** (실제 EN 전환). 이걸로 v9 완료.

## 변경
- **외국인만 노출**: `_show_region_banner()` — Accept-Language 첫 언어가 한국어가 **아니고**, 닫지 않았고, 언어 미선택일 때만. **한국인(ko-KR)에겐 미노출.**
- **랜딩 상단 슬림 배너**: *"🌏 Shopping from outside Korea? Choose your language."* + **English / 한국어 / ✕**.
- **실제 언어 전환(가짜 드롭다운 금지)**: `/i18n/set?lang=en` → `kgp_lang` 쿠키(1년) → **랜딩이 실제 영어 카피로 렌더**(히어로·수집·다듬기·등록·For Beginners·내비·푸터). 닫기는 `/i18n/dismiss` 쿠키 기억.
- `_visitor_lang()`로 쿠키 기반 렌더. 토큰 단일소스 유지.

## 테스트
- 신규 5케이스(외국인 노출 · 한국인 미노출 · set 쿠키 · **EN 실전환**(‘From sourcing’/‘Connect markets’) · dismiss).
- 전체 `pytest` **10125 passed**.

## 정직/범위
- 선택한 언어가 **실제로 반영**됩니다(가짜 드롭다운 아님). 우선 **랜딩(외국 유입 진입점)** 부터 영어 전환 — 전 앱 i18n은 후속.

## v9 완료 🎉
✅ 수집-이력 추적+관용매칭+재현테스트 · ✅ 애플 홈 '제대로' · ✅ 외국인 지역/언어 배너.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_