### PR TITLE
feat(v11): 정확 수집 + 페이지별 버튼 + 단일 아이콘 + 깔끔 뷰 + 업로드 정직 진단 (Phase 273–275)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,17 @@
   (보수적: `<select>` + 라벨 키워드(색상/사이즈/수량/color/size…) 스와치 그룹, 값 2+일 때만, 확신 없으면 빈값=정직)
   → parse_html 후처리로 options 비었으면 보강. extension_api extra에 `options` 저장(편집 프리필). ③가격 — merge가
   price 0/빈값일 때 스크래퍼 추출가로 보강(기존). 가드 `tests/test_collect_accuracy_v11.py` 4.
-- ⏳ **P0 버튼 자동 전환:** 목록=중앙 바만/상세=우측 FAB만(동시노출 0, URL패턴 dp·item.htm·g-·offer/detail + 단일제품 휴리스틱).
-- ⏳ **P0 지구본 제거·단일 아이콘:** 북마클릿 일반플로우 완전 제거(v10서 강등됨), 확장 글러브 단일아이콘(v8③ 적용됨) 확인.
-- ⏳ **P1 깔끔 유저뷰 + 업로드 실패 정직 진단:** 편집뷰 이미지·가격·상세·옵션만(raw URL 고급숨김), 업로드 프리플라이트
-  (가격0 차단·앱 마켓키 미입력 안내·쿠팡/네이버 릴레이IP·필수필드·실 API에러 패스스루, env키 vs 앱키 구분).
+- ✅ **P0 버튼 자동 전환(Phase 274):** content_script kgpRefresh를 모드 오케스트레이터로 — kgpFindCards 카드 3+면
+  목록(중앙 바만, kgpRemoveFab으로 FAB 숨김), 아니면 상세(kgpRemoveListing으로 바/배지 숨김, FAB만). 동시노출 0.
+  kgpIsDetailUrl(/dp//gp/product/item.htm/offer/detail/g-/product/)로 메타없는 상세도 FAB. 4초 인터벌이 kgpRefresh로
+  모드 재평가. manifest 1.5.0→1.5.1. ※지구본: 북마클릿 일반플로우서 제거됨(v10P1)+드래그아이콘 🧤(v8③), 확장 글러브
+  단일아이콘(v8③) → 지구본 노출 0. 가드 test_extension_button_switch_v11(4).
+- ✅ **P1 깔끔 유저뷰 + 업로드 정직 진단(Phase 275):** collect_preview에 깔끔 갤러리(#imageGallery 대표+썸네일, renderGallery)
+  + raw 이미지 URL 편집은 `<details>고급`으로 숨김(옵션 표시 유지). 업로드 진단: token_missing 메시지를 '내 마켓 키를
+  마켓연동 화면에 입력'(env MARKET_CRED_ENC_KEY와 구분 명시)로, 가격0 메시지 정직+원화환산 유도, collect_upload
+  except가 실 사유 패스스루(가짜 일반실패 폐기). markets_connect에 '내 마켓 키 vs env' 안내 배너. dispatch는 이미
+  per-market 실 API에러 패스스루(e2e가 핀). 가드 test_upload_diag_v11(4). 전체 10143 passed.
+- → v11 완료(수집정확도·버튼전환·지구본0·깔끔뷰·업로드 정직진단).
 
 ## 🟪 v10 브리프 (오너 2026-06-22 — "지정 소싱처에서만·실제 제품만·선택정상화·개발자 노출 제거")
 - 제0원칙: 일반 유저는 코드/북마클릿/env 몰라도 됨. "쓰기 편한가/보기 좋은가"만. 보이는 게 전부.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,20 @@
   `/i18n/dismiss` 라우트(쿠키 1년 기억). 랜딩 상단 슬림 배너(English/한국어/✕) — 외국인만, 한국인 미노출.
   랜딩 카피 EN/KO 실전환(가짜 드롭다운 아님 — 고른 값이 실제 EN 카피로 반영). → v9 완료(수집추적·애플홈·지역배너).
 
+## 🟩 v11 브리프 (오너 2026-06-22 — "아이콘 단일화·페이지별 버튼·정확 수집·업로드 실패 진단")
+- 절대원칙: 거짓 성공 금지(특히 업로드)·정직 데이터·회귀 금지·경량. 일반유저는 코드/URL/env 몰라도 됨.
+- ✅ **P0 수집 정확도(Phase 273):** ①무관 이미지 제거 — universal_scraper `_NON_PRODUCT_IMG_RE` 확장
+  (flags/openingemail/supplier-public-tag/`.slim.`/pdf/doc/arrow/chevron/tracking/beacon/1x1 등) + `is_product_image`/
+  `filter_product_images` 헬퍼 + width/height<100 아이콘 제외. content_script `_isProductImg` 동일 블랙리스트.
+  extension_api 최종 이미지에 `filter_product_images` 적용(어떤 소스든 정제, 첫=대표). ②옵션 전부 — `_collect_dom_options`
+  (보수적: `<select>` + 라벨 키워드(색상/사이즈/수량/color/size…) 스와치 그룹, 값 2+일 때만, 확신 없으면 빈값=정직)
+  → parse_html 후처리로 options 비었으면 보강. extension_api extra에 `options` 저장(편집 프리필). ③가격 — merge가
+  price 0/빈값일 때 스크래퍼 추출가로 보강(기존). 가드 `tests/test_collect_accuracy_v11.py` 4.
+- ⏳ **P0 버튼 자동 전환:** 목록=중앙 바만/상세=우측 FAB만(동시노출 0, URL패턴 dp·item.htm·g-·offer/detail + 단일제품 휴리스틱).
+- ⏳ **P0 지구본 제거·단일 아이콘:** 북마클릿 일반플로우 완전 제거(v10서 강등됨), 확장 글러브 단일아이콘(v8③ 적용됨) 확인.
+- ⏳ **P1 깔끔 유저뷰 + 업로드 실패 정직 진단:** 편집뷰 이미지·가격·상세·옵션만(raw URL 고급숨김), 업로드 프리플라이트
+  (가격0 차단·앱 마켓키 미입력 안내·쿠팡/네이버 릴레이IP·필수필드·실 API에러 패스스루, env키 vs 앱키 구분).
+
 ## 🟪 v10 브리프 (오너 2026-06-22 — "지정 소싱처에서만·실제 제품만·선택정상화·개발자 노출 제거")
 - 제0원칙: 일반 유저는 코드/북마클릿/env 몰라도 됨. "쓰기 편한가/보기 좋은가"만. 보이는 게 전부.
 - ✅ **P0 지정 소싱처에서만 노출 + 실제 제품만 + 선택 정상화(Phase 271):** content_script.js —

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -29,9 +29,10 @@ function extractProductMeta() {
 
   // 이미지: og:image 우선 + 페이지의 모든 상품 이미지(로고/배너/아이콘/작은 이미지 제외)
   const ogImage = getMeta("og:image") || getMeta("og:image:url") || "";
+  // v11 P0: 무관 이미지(플래그·태그·픽셀·문서아이콘·화살표 등) 제외 — 서버 블랙리스트와 동일.
   const _isProductImg = (s) =>
     s && s.indexOf("data:") !== 0 &&
-    !/(logo|sprite|icon|favicon|avatar|placeholder|loading|blank|pixel|banner|badge|rating|star_|flag_|emoji)/i.test(s);
+    !/(logo|sprite|icon|favicon|avatar|placeholder|loading|blank|pixel|spinner|banner|badge|button|arrow|chevron|caret|rating|star_|flags?|emoji|openingemail|supplier-public-tag|public-tag|\.slim\.|tracking|beacon|watermark|qr[-_]?code|coupon|nav_|\/pdf|pdf[-_]|\.pdf|\.doc|doc[-_]icon|\/doc\/|1x1|transparent\.|spacer)/i.test(s);
   const images = [];
   const _seenImg = new Set();
   const _pushImg = (s) => { if (_isProductImg(s) && !_seenImg.has(s)) { _seenImg.add(s); images.push(s); } };

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -322,7 +322,7 @@ function injectCollectButton() {
   if (document.getElementById(KGP_BTN_ID)) return;
   if (window.top !== window.self) return;       // iframe 안에서는 표시 안 함
   if (!document.body) return;
-  if (!looksLikeProductPage()) return;
+  if (!looksLikeProductPage() && !kgpIsDetailUrl()) return;   // 상세 페이지(메타 또는 URL 패턴)
 
   const btn = document.createElement("button");
   btn.id = KGP_BTN_ID;
@@ -784,11 +784,35 @@ function kgpTeardown() {
   } catch (e) { /* noop */ }
 }
 
-// SPA 대응: 최초 + URL 변경 시 재시도 (단일 상품 FAB + 리스팅 다중수집)
+// 상세 페이지로 보이는 URL 패턴(아마존 /dp//gp/product, 타오바오 item.htm, 1688 offer/detail, Temu g-, 일반 /product//goods/).
+function kgpIsDetailUrl() {
+  return /(\/dp\/|\/gp\/product\/|item\.htm|offer\/detail|\/g-?\d|\/goods\/|\/product\/)/i.test(location.href);
+}
+
+// FAB(우측)만 제거 / 리스팅(중앙 바·배지·구석배지)만 제거 — 모드 전환 시 상호배타.
+function kgpRemoveFab() {
+  const fab = document.getElementById(KGP_BTN_ID);
+  if (fab) fab.remove();
+}
+function kgpRemoveListing() {
+  const bar = document.getElementById(KGP_TOOLBAR_ID); if (bar) bar.remove();
+  const pill = document.getElementById(KGP_REOPEN_ID); if (pill) pill.remove();
+  document.querySelectorAll(".kgp-card-chk").forEach((b) => b.remove());
+  document.querySelectorAll('[data-kgp-outline="1"]').forEach((e) => { e.style.outline = ""; e.removeAttribute("data-kgp-outline"); });
+}
+
+// SPA 대응 + v11 P0: 페이지 종류에 따라 버튼 자동 전환(목록=중앙 바만, 상세=우측 FAB만 — 동시 노출 0).
 function kgpRefresh() {
   if (!kgpHostAllowed()) { kgpTeardown(); return; }   // 지정 소싱처에서만 노출(v10 P0)
-  injectCollectButton();
-  kgpInjectListing();
+  const cards = kgpFindCards();
+  const isList = cards.length >= 3;                   // 제품 그리드(여러 제품) = 목록
+  if (isList) {
+    kgpRemoveFab();                                   // 목록: 우측 FAB 숨김
+    kgpInjectListing();                               // 중앙 바만
+  } else {
+    kgpRemoveListing();                               // 상세: 중앙 바/배지 숨김
+    injectCollectButton();                            // 우측 FAB만(looksLikeProductPage/디테일 URL 가드)
+  }
 }
 
 // 설정 로드 후 첫 렌더. 설정 바뀌면(소싱처 추가/삭제·토글) 즉시 반영.
@@ -824,5 +848,5 @@ setInterval(() => {
     setTimeout(kgpRefresh, 900);
   }
 }, 1500);
-// 동적 로딩(무한 스크롤) 대응: 주기적으로 리스팅 재스캔(지정 소싱처에서만).
-setInterval(() => { if (kgpHostAllowed()) kgpInjectListing(); }, 4000);
+// 동적 로딩(무한 스크롤)·지연 렌더 대응: 주기적으로 모드 재평가(목록↔상세 자동 전환).
+setInterval(() => { if (kgpHostAllowed()) kgpRefresh(); }, 4000);

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "코고가네 수집기",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "지정 소싱처(타오바오·아마존 등)에서 한 클릭에 코고가네로 수집 (인페이지 수집 + 리스팅 다중 선택 수집 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/src/api/extension_api.py
+++ b/src/api/extension_api.py
@@ -216,11 +216,16 @@ def collect_from_extension():
 
     product_id = _upsert_catalog(payload, source=source)
 
-    # 이미지 목록 정규화 (편집 페이지에서 바로 쓰도록)
+    # 이미지 목록 정규화 + 무관 이미지 제거 (편집 페이지에서 바로 쓰도록)
+    # v11 P0: 어떤 소스(확장/서버파싱)든 최종 단계에서 플래그·태그·픽셀·문서 등 무관 이미지 제거.
     images = payload.get("images")
     if not isinstance(images, list):
         images = [payload.get("image")] if payload.get("image") else []
-    images = [str(i).strip() for i in images if str(i or "").strip()]
+    try:
+        from src.collectors.universal_scraper import filter_product_images
+        images = filter_product_images(images)
+    except Exception:
+        images = [str(i).strip() for i in images if str(i or "").strip()]
 
     # 수집 이력 기록 (편집 페이지가 바로 프리필되도록 상세 필드 보관)
     # v4 P0: 저장 자기검증 — append 직후 같은 seller_id로 재조회해 실제 저장됐을 때만 성공.
@@ -250,6 +255,7 @@ def collect_from_extension():
                 "price_original": payload.get("price", ""),
                 "currency": payload.get("currency", "USD"),
                 "brand": payload.get("brand", ""),
+                "options": payload.get("options", []),
                 "translation_provider": tr.get("provider", "none"),
             },
             seller_id=seller_id_val,

--- a/src/collectors/universal_scraper.py
+++ b/src/collectors/universal_scraper.py
@@ -180,19 +180,46 @@ def _extract_domain(url: str) -> str:
         return ""
 
 
-# 상품 이미지가 아닌 것으로 보이는 URL 패턴(로고/아이콘/배너/플레이스홀더 등)
+# 상품 이미지가 아닌 것으로 보이는 URL 패턴(로고/아이콘/배너/플래그/추적픽셀/문서아이콘 등)
+# v11 P0: 무관 이미지(태극기 flags·openingemail·supplier-public-tag·*.slim.png·pdf/doc·화살표 등) 제외.
 _NON_PRODUCT_IMG_RE = re.compile(
     r"(logo|sprite|icon|favicon|avatar|placeholder|loading|blank|pixel|spinner|"
-    r"banner|badge|button|arrow|star_|rating|flag_|emoji)",
+    r"banner|badge|button|arrow|chevron|caret|star_|rating|flags?|emoji|"
+    r"openingemail|supplier-public-tag|public-tag|\.slim\.|tracking|beacon|"
+    r"watermark|qr[-_]?code|coupon|thumb_nav|nav_|/pdf|pdf[-_]|\.pdf|"
+    r"\.doc|doc[-_]icon|/doc/|/document/|1x1|transparent\.|spacer)",
     re.IGNORECASE,
 )
+
+
+def is_product_image(url: str) -> bool:
+    """상품 이미지로 보이는 URL인가? (data:/빈값/블랙리스트 패턴 제외)"""
+    s = (url or "").strip()
+    if not s or s.startswith("data:"):
+        return False
+    if not s.startswith("http") and not s.startswith("//"):
+        return False
+    return not _NON_PRODUCT_IMG_RE.search(s)
+
+
+def filter_product_images(urls) -> list:
+    """이미지 URL 목록에서 무관 이미지를 제거하고 순서 유지·중복 제거(첫 번째=대표)."""
+    out, seen = [], set()
+    for u in (urls or []):
+        s = str(u or "").strip()
+        if not s or s in seen or not is_product_image(s):
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
 
 
 def _collect_dom_images(soup, base_url: str) -> list:
     """페이지 DOM에서 상품 이미지를 최대한 수집한다.
 
     - src + lazy-load 속성(data-src/data-original/data-lazy/data-srcset) + srcset(최대 해상도)
-    - data: URI, 로고/아이콘/배너/플레이스홀더 패턴 제외
+    - data: URI, 로고/아이콘/배너/플레이스홀더/플래그/추적픽셀/문서 패턴 제외
+    - width/height 속성이 명시돼 있고 작으면(아이콘/픽셀) 제외
     - 상대경로 절대화, 순서 유지 중복 제거
     """
     out: list = []
@@ -217,6 +244,17 @@ def _collect_dom_images(soup, base_url: str) -> list:
                 best = cand
         return best
 
+    def _too_small(img) -> bool:
+        # width/height 속성이 명시돼 있고 둘 중 하나가 작으면 아이콘/픽셀로 보고 제외.
+        for attr in ("width", "height"):
+            v = (img.get(attr) or "").strip().replace("px", "")
+            try:
+                if v and float(v) < 100:
+                    return True
+            except (TypeError, ValueError):
+                pass
+        return False
+
     for img in soup.find_all("img"):
         cand = ""
         for attr in ("src", "data-src", "data-original", "data-lazy",
@@ -234,6 +272,8 @@ def _collect_dom_images(soup, base_url: str) -> list:
             continue
         if _NON_PRODUCT_IMG_RE.search(url):
             continue
+        if _too_small(img):
+            continue
         seen.add(url)
         out.append(url)
 
@@ -246,6 +286,88 @@ def _collect_dom_images(soup, base_url: str) -> list:
             out.append(url)
 
     return out
+
+
+# 옵션 그룹 라벨로 인정할 키워드(한/영) — 색상·사이즈·수량·규격·스타일·변형 등.
+_OPTION_LABEL_RE = re.compile(
+    r"(색상|컬러|색깔|사이즈|크기|치수|규격|용량|수량|개수|스타일|종류|타입|모델|구성|"
+    r"옵션|선택|color|colour|size|quantity|qty|variant|variation|style|type|model|spec)",
+    re.IGNORECASE,
+)
+# 옵션 값으로 보기 어려운 잡텍스트(가격/안내문 등) — 너무 길거나 가격 문자열은 제외.
+_OPTION_VALUE_BAD_RE = re.compile(r"(원|₩|\$|¥|€|£|장바구니|구매|cart|add to|배송|리뷰|review)", re.IGNORECASE)
+
+
+def _collect_dom_options(soup) -> list:
+    """렌더된 DOM에서 옵션(색상/사이즈/수량 등)을 보수적으로 수집.
+
+    1) <select> 드롭다운 → {name, values}(placeholder 제외).
+    2) 라벨 텍스트가 옵션 키워드인 그룹의 클릭 가능 자식(버튼/스와치/li/img[alt]) 값.
+    확신 없으면 비움(거짓 데이터 금지). 값은 짧은 텍스트만, 캡 적용.
+    """
+    options: list = []
+    seen_names = set()
+
+    def _clean(v: str) -> str:
+        return re.sub(r"\s+", " ", (v or "")).strip()
+
+    def _add(name: str, values: list) -> None:
+        name = _clean(name)[:40] or "옵션"
+        vals, seenv = [], set()
+        for v in values:
+            cv = _clean(v)
+            if not cv or len(cv) > 40 or _OPTION_VALUE_BAD_RE.search(cv):
+                continue
+            if cv in seenv:
+                continue
+            seenv.add(cv)
+            vals.append(cv)
+            if len(vals) >= 40:
+                break
+        key = name.lower()
+        if len(vals) >= 2 and key not in seen_names:   # 값이 2개 이상일 때만 옵션으로 인정
+            seen_names.add(key)
+            options.append({"name": name, "values": vals})
+
+    # 1) <select>
+    try:
+        for sel in soup.find_all("select"):
+            opts = [o.get_text() for o in sel.find_all("option")
+                    if (o.get_text() or "").strip() and not o.get("disabled")]
+            # placeholder("선택하세요" 류) 첫 항목 제거 추정
+            if opts and re.search(r"(선택|choose|select|please)", opts[0], re.IGNORECASE):
+                opts = opts[1:]
+            name = sel.get("aria-label") or sel.get("name") or sel.get("id") or "옵션"
+            _add(name, opts)
+    except Exception:
+        pass
+
+    # 2) 라벨된 스와치 그룹
+    try:
+        for lab in soup.find_all(["label", "h2", "h3", "h4", "span", "div", "dt"]):
+            txt = _clean(lab.get_text())
+            if not txt or len(txt) > 24 or not _OPTION_LABEL_RE.search(txt):
+                continue
+            # 라벨 다음 형제/부모 내에서 클릭 가능 후보 텍스트 수집
+            group = lab.find_next_sibling() or lab.parent
+            if not group:
+                continue
+            cands = group.find_all(["button", "li", "a"], limit=60)
+            values = []
+            for c in cands:
+                v = _clean(c.get_text()) or _clean(c.get("aria-label") or "")
+                if not v:
+                    img = c.find("img")
+                    if img:
+                        v = _clean(img.get("alt") or "")
+                if v:
+                    values.append(v)
+            if values:
+                _add(txt, values)
+    except Exception:
+        pass
+
+    return options[:8]   # 옵션 그룹 과다 방지
 
 
 class UniversalScraper:
@@ -284,23 +406,28 @@ class UniversalScraper:
             logger.warning("beautifulsoup4 미설치 — 범용 수집기 제한 모드")
             return empty
 
-        # 1. JSON-LD
-        result = self._parse_jsonld(soup, url, domain)
-        if result:
-            return result
+        # 1~4: JSON-LD → OG → Microdata → Heuristic (순서대로 첫 성공 사용)
+        result = (
+            self._parse_jsonld(soup, url, domain)
+            or self._parse_opengraph(soup, url, domain)
+            or self._parse_microdata(soup, url, domain)
+            or self._heuristic(soup, url, domain)
+        )
 
-        # 2. Open Graph
-        result = self._parse_opengraph(soup, url, domain)
-        if result:
-            return result
-
-        # 3. Microdata
-        result = self._parse_microdata(soup, url, domain)
-        if result:
-            return result
-
-        # 4. Heuristic
-        return self._heuristic(soup, url, domain)
+        # v11 P0 후처리: 옵션이 비었으면 렌더된 DOM에서 보수적으로 보강(색상/사이즈/수량 등),
+        #               이미지는 무관 패턴을 한 번 더 필터(첫 번째=대표 유지).
+        if result is not None:
+            try:
+                if not getattr(result, "options", None):
+                    result.options = _collect_dom_options(soup)
+            except Exception:
+                pass
+            try:
+                if getattr(result, "images", None):
+                    result.images = filter_product_images(result.images)
+            except Exception:
+                pass
+        return result
 
     def _parse_jsonld(self, soup, url: str, domain: str) -> Optional[ScrapedProduct]:
         """JSON-LD schema.org Product 파싱."""

--- a/src/seller_console/templates/collect_preview.html
+++ b/src/seller_console/templates/collect_preview.html
@@ -79,11 +79,17 @@
 
       <!-- 이미지 목록 -->
       <div class="mb-3">
-        <div class="d-flex justify-content-between align-items-center mb-2">
-          <label class="form-label small fw-semibold mb-0">이미지 URL <span class="text-muted">(⭐ = 대표/썸네일, 맨 위가 대표)</span></label>
-          <button type="button" class="btn btn-outline-secondary btn-sm py-0" onclick="addImageRow()">+ 이미지 추가</button>
-        </div>
-        <div id="imageRows" class="vstack gap-2"></div>
+        <label class="form-label small fw-semibold mb-2 d-block">상품 이미지 <span class="text-muted">(맨 앞이 대표)</span></label>
+        <!-- v11 P1: 깔끔한 갤러리(대표+썸네일). raw URL 편집은 아래 '고급'으로 숨김. -->
+        <div id="imageGallery" class="d-flex flex-wrap gap-2 mb-2"></div>
+        <details class="small">
+          <summary class="text-muted" style="cursor:pointer">고급: 이미지 URL 직접 편집/추가</summary>
+          <div class="d-flex justify-content-end mb-2 mt-2">
+            <button type="button" class="btn btn-outline-secondary btn-sm py-0" onclick="addImageRow()">+ 이미지 추가</button>
+          </div>
+          <div id="imageRows" class="vstack gap-2"></div>
+          <div class="form-text">⭐ = 대표/썸네일(맨 위가 대표). 보통은 위 갤러리만 보면 됩니다.</div>
+        </details>
       </div>
 
       <!-- 옵션 목록 -->
@@ -359,12 +365,12 @@ function addImageRow(url) {
       b.disabled = false; b.textContent = old;
     }
   });
-  input.addEventListener('input', () => { syncThumb(); refreshPrimaryImage(); });
+  input.addEventListener('input', () => { syncThumb(); refreshPrimaryImage(); renderGallery(); });
   wrap.appendChild(row);
   refreshImageBadges();
 }
 
-// 첫 번째(맨 위) 이미지가 대표/썸네일 — 버튼 상태 갱신
+// 첫 번째(맨 위) 이미지가 대표/썸네일 — 버튼 상태 갱신 + 깔끔 갤러리 갱신
 function refreshImageBadges() {
   const rows = document.querySelectorAll('#imageRows .img-row');
   rows.forEach((row, i) => {
@@ -377,6 +383,32 @@ function refreshImageBadges() {
       btn.classList.add('btn-outline-warning'); btn.classList.remove('btn-warning');
       btn.textContent = '⭐'; btn.disabled = false; btn.title = '대표 이미지로 지정';
     }
+  });
+  renderGallery();
+}
+
+// v11 P1: 현재 이미지 URL들로 깔끔한 갤러리(대표 크게 + 썸네일) 렌더 — 클릭 시 원본 열기.
+function renderGallery() {
+  const g = document.getElementById('imageGallery');
+  if (!g) return;
+  const urls = Array.from(document.querySelectorAll('#imageRows .img-url'))
+    .map(i => (i.value || '').trim()).filter(Boolean);
+  g.innerHTML = '';
+  if (!urls.length) {
+    g.innerHTML = '<span class="text-muted small">이미지가 없습니다. 아래 ‘고급’에서 추가할 수 있어요.</span>';
+    return;
+  }
+  urls.forEach((u, i) => {
+    const a = document.createElement('a');
+    a.href = u; a.target = '_blank'; a.rel = 'noopener'; a.title = (i === 0 ? '대표 이미지' : '갤러리 이미지');
+    const sz = i === 0 ? 84 : 56;
+    a.style.cssText = 'display:inline-block;position:relative;border-radius:8px;overflow:hidden;border:' +
+      (i === 0 ? '2px solid #119a8e' : '1px solid #e3dac8') + ';flex-shrink:0';
+    a.innerHTML = '<img src="' + u.replace(/"/g, '&quot;') + '" alt="" loading="lazy" ' +
+      'style="width:' + sz + 'px;height:' + sz + 'px;object-fit:cover;display:block" ' +
+      'onerror="this.parentElement.style.display=\'none\'">' +
+      (i === 0 ? '<span style="position:absolute;left:0;bottom:0;background:#119a8e;color:#fff;font-size:9px;padding:1px 5px;border-top-right-radius:6px">대표</span>' : '');
+    g.appendChild(a);
   });
 }
 

--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -22,6 +22,13 @@
     </div>
   </div>
 
+  <div class="alert alert-light border small d-flex gap-2 align-items-start mb-3" role="note">
+    <span style="font-size:1.1rem">🔑</span>
+    <div>여기에 넣는 건 <strong>‘내 마켓 키’</strong>(쿠팡·네이버 등에서 발급받은 본인 API 키)예요.
+      서버 환경변수(<code>MARKET_CRED_ENC_KEY</code> 같은 인프라 키)와는 다릅니다 —
+      <strong>그건 운영자가 관리하고, 여기엔 입력하지 않아도 됩니다.</strong></div>
+  </div>
+
   <!-- 마켓 전환 칩 -->
   <div class="d-flex flex-wrap gap-2 mb-3">
     {% for chip in market_chips %}

--- a/src/seller_console/upload_dispatcher.py
+++ b/src/seller_console/upload_dispatcher.py
@@ -212,8 +212,10 @@ class UploadDispatcher:
                 market=market,
                 ok=False,
                 error_code="token_missing",
-                message=f"필수 환경변수 미설정: {', '.join(missing)}",
-                hint=_MARKET_TOKEN_HINTS.get(market, "관리자에게 문의하세요."),
+                message="이 마켓의 API 키(또는 배송정보)가 아직 입력되지 않았어요.",
+                hint=("‘마켓 연동’ 화면에서 이 마켓의 키를 입력하세요 (/seller/markets/connect/" + market + "). "
+                      "이 키는 앱에 입력하는 ‘내 마켓 키’이며, 서버 환경변수(MARKET_CRED_ENC_KEY 등 인프라 키)와는 다릅니다. "
+                      "누락: " + ", ".join(missing)),
             )
 
         # 필수 필드 검증
@@ -237,8 +239,8 @@ class UploadDispatcher:
                 market=market,
                 ok=False,
                 error_code="missing_field",
-                message="판매가(price)가 0 이하이거나 없습니다.",
-                hint="마진 계산기에서 권장 판매가를 계산 후 적용하세요.",
+                message="판매가가 0이거나 비어 있어 마켓이 등록을 거부합니다.",
+                hint="편집 화면에서 판매가를 입력하세요(외화면 ‘원화로 환산’ 버튼으로 원화 판매가를 채울 수 있어요).",
             )
 
         # 이미지 URL 접근성 (첫 번째 이미지만 HEAD 체크, 타임아웃 3초)

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1453,8 +1453,9 @@ def collect_upload():
             result = dispatcher.dispatch(product_data, markets)
         return jsonify({"ok": True, "result": result.to_dict()})
     except Exception as exc:
+        # v11 P0: 가짜 일반 실패 금지 — 실제 사유를 패스스루로 노출.
         logger.warning("업로드 디스패처 오류: %s", exc)
-        return jsonify({"ok": False, "error": "업로드 중 오류가 발생했습니다."}), 500
+        return jsonify({"ok": False, "error": f"업로드 중 오류: {exc}"}), 500
 
 
 @bp.post("/collect/prevalidate")

--- a/tests/test_collect_accuracy_v11.py
+++ b/tests/test_collect_accuracy_v11.py
@@ -1,0 +1,82 @@
+"""tests/test_collect_accuracy_v11.py — v11 P0 수집 정확도 가드.
+
+무관 이미지 제거 + 옵션(색상/사이즈/수량) 보수적 추출을 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.collectors.universal_scraper import (  # noqa: E402
+    UniversalScraper,
+    filter_product_images,
+    is_product_image,
+)
+
+
+def test_blacklisted_images_removed():
+    junk = [
+        "https://img.temu.com/openingemail/flags/kr.png",
+        "https://cdn.x.com/supplier-public-tag/v2.png",
+        "https://cdn.x.com/ui/arrow.slim.png",
+        "https://cdn.x.com/icons/pdf-icon.png",
+        "https://cdn.x.com/doc/manual.doc.png",
+        "https://t.x.com/1x1.gif",
+        "data:image/png;base64,AAAA",
+    ]
+    for u in junk:
+        assert not is_product_image(u), f"무관 이미지가 통과됨: {u}"
+
+
+def test_product_images_kept_and_deduped():
+    imgs = [
+        "https://img.temu.com/product/abc_800x800.jpg",
+        "https://img.temu.com/product/abc_800x800.jpg",   # 중복
+        "https://img.temu.com/material-put/detail1.jpg",
+        "https://cdn.x.com/openingemail/flags/kr.png",     # 제거 대상
+    ]
+    out = filter_product_images(imgs)
+    assert out == [
+        "https://img.temu.com/product/abc_800x800.jpg",
+        "https://img.temu.com/material-put/detail1.jpg",
+    ]
+    assert out[0].endswith("abc_800x800.jpg")   # 첫 번째 = 대표
+
+
+def test_parse_html_filters_images_and_extracts_select_options():
+    html = """
+    <html><head>
+      <meta property="og:title" content="테스트 상품">
+      <meta property="og:image" content="https://cdn.x.com/product/main.jpg">
+      <meta property="product:price:amount" content="19048">
+      <meta property="product:price:currency" content="KRW">
+    </head><body>
+      <img src="https://cdn.x.com/product/main.jpg" width="800" height="800">
+      <img src="https://cdn.x.com/openingemail/flags/kr.png" width="20" height="14">
+      <img src="https://cdn.x.com/ui/nav_arrow.png" width="12" height="12">
+      <label>색상</label>
+      <div>
+        <button>레드</button><button>블루</button><button>블랙</button>
+      </div>
+      <select name="사이즈">
+        <option>선택하세요</option><option>S</option><option>M</option><option>L</option>
+      </select>
+    </body></html>
+    """
+    res = UniversalScraper().parse_html(html, "https://temu.com/g-123.html")
+    # 무관 이미지(flags/arrow) 미수집
+    assert all("flags" not in i and "arrow" not in i for i in res.images)
+    assert any("product/main.jpg" in i for i in res.images)
+    # 옵션 추출(색상/사이즈)
+    names = {o["name"] for o in res.options}
+    assert any("색상" in n for n in names)
+    color = next(o for o in res.options if "색상" in o["name"])
+    assert "레드" in color["values"] and "블루" in color["values"]
+
+
+def test_options_empty_when_no_option_groups():
+    html = "<html><body><p>옵션 없는 단순 페이지</p></body></html>"
+    res = UniversalScraper().parse_html(html, "https://x.com/item")
+    assert res.options == []   # 확신 없으면 비움(거짓 데이터 금지)

--- a/tests/test_extension_button_switch_v11.py
+++ b/tests/test_extension_button_switch_v11.py
@@ -1,0 +1,36 @@
+"""tests/test_extension_button_switch_v11.py — v11 P0 버튼 자동 전환 가드(정적).
+
+목록=중앙 바만 / 상세=우측 FAB만(동시 노출 0) 로직과 단일 아이콘 잔재 제거를 핀으로 고정.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+CS = Path("extensions/chrome-collector/content_script.js").read_text(encoding="utf-8")
+
+
+def test_detail_vs_list_helpers_exist():
+    assert "function kgpIsDetailUrl" in CS
+    assert "function kgpRemoveFab" in CS
+    assert "function kgpRemoveListing" in CS
+
+
+def test_detail_url_patterns():
+    for pat in ["/dp/", "gp/product", "item.htm", "offer/detail", "g-?", "/product/"]:
+        assert pat in CS, f"상세 URL 패턴 {pat} 누락"
+
+
+def test_mutual_exclusion_in_refresh():
+    # kgpRefresh가 목록이면 FAB 제거, 상세면 리스팅 제거(동시 노출 0).
+    assert "const isList = cards.length >= 3" in CS
+    assert "kgpRemoveFab();" in CS
+    assert "kgpRemoveListing();" in CS
+    # FAB 가드가 상세 URL도 허용
+    assert "!looksLikeProductPage() && !kgpIsDetailUrl()" in CS
+
+
+def test_single_glove_icon_no_globe_image_in_bookmarklet_button():
+    bm = Path("src/seller_console/templates/bookmarklet.html").read_text(encoding="utf-8")
+    # 북마클릿 드래그 버튼은 🧤 한 글자(파비콘 글로브 이미지 미사용)
+    assert "🧤" in bm
+    assert "filename='favicon.svg'" not in bm and 'filename="favicon.svg"' not in bm

--- a/tests/test_upload_diag_v11.py
+++ b/tests/test_upload_diag_v11.py
@@ -1,0 +1,50 @@
+"""tests/test_upload_diag_v11.py — v11 P0/P1 업로드 정직 진단 + 깔끔 유저 뷰 가드."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_token_missing_message_distinguishes_app_vs_env(monkeypatch):
+    """키 미입력 시: 'env 미설정'이 아니라 '마켓 연동에 내 키 입력' 안내 + env 구분."""
+    for k in ("COUPANG_ACCESS_KEY", "COUPANG_SECRET_KEY", "COUPANG_VENDOR_ID"):
+        monkeypatch.delenv(k, raising=False)
+    from src.seller_console.upload_dispatcher import UploadDispatcher
+    res = UploadDispatcher().prevalidate(
+        {"title": "x", "price": 1000, "images": []}, ["coupang"]
+    )
+    r = res[0]
+    assert r.error_code == "token_missing"
+    assert "마켓 연동" in (r.hint or "") or "markets/connect" in (r.hint or "")
+    assert "환경변수" in (r.hint or "")          # env와 다름을 명시
+    assert "환경변수 미설정" not in r.message      # 개발자틱 메시지 폐기
+
+
+def test_price_zero_blocked_honestly(monkeypatch):
+    monkeypatch.setenv("SHOPIFY_SHOP", "x.myshopify.com")
+    monkeypatch.setenv("SHOPIFY_AUTO_TOKEN", "tok")
+    from src.seller_console.upload_dispatcher import UploadDispatcher
+    res = UploadDispatcher().prevalidate(
+        {"title": "상품", "price": 0, "images": []}, ["shopify"]
+    )
+    r = res[0]
+    assert r.error_code == "missing_field"
+    assert "판매가" in r.message
+    assert "원화" in (r.hint or "")
+
+
+def test_collect_preview_clean_gallery_and_advanced_raw_urls():
+    html = Path("src/seller_console/templates/collect_preview.html").read_text(encoding="utf-8")
+    assert "imageGallery" in html
+    assert "function renderGallery" in html
+    assert "고급: 이미지 URL" in html          # raw URL 편집은 '고급'으로 숨김
+    assert "optionRows" in html                # 옵션 표시 유지
+
+
+def test_markets_connect_clarifies_app_key_vs_env():
+    html = Path("src/seller_console/templates/markets_connect.html").read_text(encoding="utf-8")
+    assert "내 마켓 키" in html
+    assert "MARKET_CRED_ENC_KEY" in html       # env 인프라 키와 구분 설명


### PR DESCRIPTION
v11 전체 — 정확 수집 + 페이지별 버튼 + 단일 아이콘 + 깔끔 뷰 + **업로드 실패 정직 진단**. (3 커밋)

## ① 수집 정확도 (Phase 273)
- **무관 이미지 제거**: `universal_scraper` 블랙리스트 확장(flags·openingemail·supplier-public-tag·`.slim.`·pdf/doc·arrow/chevron·tracking·1x1…) + `is_product_image`/`filter_product_images` 헬퍼 + width/height<100 아이콘 제외. content_script `_isProductImg` 동일. extension_api 최종 이미지에 필터 적용(소스 불문, **첫 번째=대표**).
- **옵션 전부**: `_collect_dom_options`(보수적 — `<select>` + 라벨 키워드(색상/사이즈/수량/color/size…) 스와치 그룹, **값 2+일 때만**, 확신 없으면 빈값=정직) → `parse_html` 후처리. extension_api `extra.options` 저장(편집 프리필).
- **가격**: merge가 price 0/빈값일 때 스크래퍼 추출가로 보강.

## ② 버튼 자동 전환 + 단일 아이콘 (Phase 274)
- **목록=중앙 바만 / 상세=우측 FAB만 (동시 노출 0)**: `kgpRefresh`가 모드 오케스트레이터 — 카드 3+면 목록(FAB 숨김), 아니면 상세(바/배지 숨김). `kgpIsDetailUrl`(/dp//gp/product/item.htm/offer/detail/g-/product/)로 메타 없는 상세도 FAB. 4초 인터벌이 모드 재평가.
- **지구본 0**: 북마클릿은 일반 플로우에서 제거됨(v10 P1)·드래그 아이콘 🧤(v8③), 확장은 **글러브 단일 아이콘**(v8③). manifest 1.5.1.

## ③ 깔끔 유저 뷰 + 업로드 실패 정직 진단 (Phase 275)
- **깔끔 뷰**: 편집 화면에 **깔끔 갤러리**(대표+썸네일, `renderGallery`) + raw 이미지 URL 편집은 **`<details>`고급**으로 숨김. 옵션 표시 유지.
- **업로드 정직 진단(거짓 성공 금지)**: 키 미입력 → *“내 마켓 키를 ‘마켓 연동’ 화면에 입력”* (서버 env `MARKET_CRED_ENC_KEY` 인프라 키와 **다름** 명시). 가격 0 → 정직 차단 + 원화 환산 유도. `collect_upload` 예외가 **실제 사유 패스스루**. dispatch는 이미 per-market 실 API 에러 패스스루(e2e가 핀). `markets_connect`에 **‘내 마켓 키 vs env 키’ 구분 배너**.

## 테스트
- 신규 가드 12: `test_collect_accuracy_v11`(4)·`test_extension_button_switch_v11`(4)·`test_upload_diag_v11`(4).
- 전체 `pytest` **10143 passed**, `node --check` 통과.

## DoD
✅ 지구본/잔재 0·단일 아이콘 · ✅ 목록=바/상세=FAB 자동전환(동시 0) · ✅ 무관 이미지 미수집 · ✅ 가격≠0+옵션+상세+갤러리 · ✅ 유저뷰 raw URL 고급숨김 · ✅ 업로드 실패 실제 사유(가격0/키미입력/IP/필수필드)·env vs 앱키 구분 · ✅ CI/회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_