### PR TITLE
feat(v14): P0 모바일 드로어 닫기 + 온보딩 정직 자동체크 (Phase 281)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,18 @@
   `/i18n/dismiss` 라우트(쿠키 1년 기억). 랜딩 상단 슬림 배너(English/한국어/✕) — 외국인만, 한국인 미노출.
   랜딩 카피 EN/KO 실전환(가짜 드롭다운 아님 — 고른 값이 실제 EN 카피로 반영). → v9 완료(수집추적·애플홈·지역배너).
 
+## ⬛ v14 브리프 (오너 2026-06-22 — "온보딩·마켓연동·확장설치 UX 정밀화+친절화, 퍼센티 전역제거")
+- 제0원칙: 일반 유저는 아무것도 모른다 가정, 하나하나 세세히. 버전 충돌 시 v14 우선.
+- ✅ **P0 모바일 드로어 닫기(Phase 281):** `.sidebar-overlay`에 base 규칙 없어(위치/배경 X) 바깥 탭이 안 먹던 버그
+  → seller.css에 `position:fixed;inset:0;background;z-index:1040` + `body.kgp-drawer-open{overflow:hidden}`(스크롤 잠금).
+  _base.html JS: openSidebar/closeSidebar 분리 + 오버레이 onclick 닫기 + ESC 닫기 + 왼쪽 스와이프 닫기.
+- ✅ **P0 온보딩 정직화(Phase 281):** onboarding_wizard 이미 in-place(스텝퍼 고정·#panel 교체)였음. 버그 수정:
+  ①새 탭(window.open _blank) 제거 → 같은 탭 이동 ②링크 클릭만으로 가짜 완료(markDone) 제거 → 완료는 실제 상태
+  (autoDone: LOGGED_IN / MARKETS>0)로만 자동 체크 ③localStorage KEY v2로 옛 가짜-완료 폐기 ④intro에 '마켓 연동이란?'
+  쉬운 설명 추가. 가드 test_v14_onboarding_drawer(5). 전체 10165 passed.
+- ⏳ 남은 v14: 소셜 로그인 4종(구글·네이버·카카오·애플) · 마켓연동 순차 스테퍼+키발급안내(쿠팡 출고지 스코프) ·
+  확장 설치 단계별+빨간문구/복사버튼 · For Beginners 고정/토글/확대 · 친절카피+CTA · 아이콘표시 · 퍼센티/개발문구 전역제거.
+
 ## ⬛ v13 브리프 (오너 2026-06-22 — "관리자전용·재로그인버그·속도·모바일앱·글로벌·프로디자인·파비콘")
 - 버전 충돌 시 v13 우선. 디자인 최우선('학교 과제물'→프로). 정직 데이터·회귀 금지.
 - ✅ **P0 관리자 전용 게이팅(Phase 278):** admin_views.py에 `@admin_panel_bp.before_request` 단일 게이트 —

--- a/src/seller_console/static/seller.css
+++ b/src/seller_console/static/seller.css
@@ -117,6 +117,15 @@ input[type="tel"] {
 
 /* Phase 147: 모바일 반응형 */
 @media (max-width: 768px) {
+  /* v14 P0: 드로어 오버레이 — 바깥 영역을 실제로 덮어 탭하면 닫히게(기존엔 위치/배경 없어 클릭 안 먹힘) */
+  .sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, .45);
+    z-index: 1040;
+    display: none;
+  }
+  body.kgp-drawer-open { overflow: hidden; }   /* 드로어 열림 시 배경 스크롤 잠금 */
   /* 모바일 사이드바 drawer */
   .sidebar {
     position: fixed !important;

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -197,10 +197,17 @@
 <script>
 function toggleSidebar() {
   var drawer = document.getElementById('sidebarDrawer');
+  if (!drawer) return;
+  if (drawer.classList.contains('show')) { closeSidebar(); } else { openSidebar(); }
+}
+
+function openSidebar() {
+  var drawer = document.getElementById('sidebarDrawer');
   var overlay = document.getElementById('sidebarOverlay');
   if (!drawer) return;
-  drawer.classList.toggle('show');
-  if (overlay) overlay.style.display = drawer.classList.contains('show') ? 'block' : 'none';
+  drawer.classList.add('show');
+  if (overlay) overlay.style.display = 'block';
+  document.body.classList.add('kgp-drawer-open');   // 배경 스크롤 잠금
 }
 
 function closeSidebar() {
@@ -208,7 +215,27 @@ function closeSidebar() {
   var overlay = document.getElementById('sidebarOverlay');
   if (drawer) drawer.classList.remove('show');
   if (overlay) overlay.style.display = 'none';
+  document.body.classList.remove('kgp-drawer-open');
 }
+
+// v14 P0: ESC + 왼쪽 스와이프로도 드로어 닫기(바깥 탭은 오버레이 onclick으로 처리).
+document.addEventListener('keydown', function (e) {
+  if (e.key === 'Escape') closeSidebar();
+});
+(function () {
+  var sx = 0, sy = 0;
+  document.addEventListener('touchstart', function (e) {
+    if (!e.touches || !e.touches[0]) return;
+    sx = e.touches[0].clientX; sy = e.touches[0].clientY;
+  }, { passive: true });
+  document.addEventListener('touchend', function (e) {
+    var drawer = document.getElementById('sidebarDrawer');
+    if (!drawer || !drawer.classList.contains('show')) return;
+    var t = (e.changedTouches && e.changedTouches[0]); if (!t) return;
+    var dx = t.clientX - sx, dy = t.clientY - sy;
+    if (dx < -45 && Math.abs(dx) > Math.abs(dy)) closeSidebar();   // 왼쪽 스와이프
+  }, { passive: true });
+})();
 
 // 고급 기능: 현재 페이지가 안에 있으면 자동으로 펼친다(현재 위치 보이게).
 (function () {

--- a/src/seller_console/templates/onboarding_wizard.html
+++ b/src/seller_console/templates/onboarding_wizard.html
@@ -54,11 +54,13 @@ const LOGGED_IN = {{ _logged_in }};
 const MARKETS = {{ _markets }};
 const STEPS = [
   { key: 'intro', title: '코고가네에 오신 걸 환영해요', emoji: '👋',
-    lead: '해외 상품을 수집하고, 번역하고, 우리 마켓에 등록까지 — 한 곳에서. 클릭 몇 번이면 됩니다.',
+    lead: '해외 상품을 <b>수집</b> → 한국어로 <b>다듬기</b> → 쿠팡·스마트스토어 같은 우리 마켓에 <b>등록</b>까지 한 곳에서 해요.<br><br>' +
+          '<b>‘마켓 연동’이란?</b> 내가 파는 쇼핑몰(쿠팡·네이버 등)에 코고가네를 연결하는 거예요. 연결해 두면 수집한 상품을 ' +
+          '그 쇼핑몰에 <b>자동으로 올릴 수</b> 있어요. 그래서 꼭 한 번은 연결이 필요해요 — 차근차근 같이 해봐요.',
     primary: { label: '시작하기', cls: 'btn-cta', act: 'next' } },
   { key: 'business', title: '사업자 등록부터', emoji: '🪪',
     lead: '구매대행은 보통 사업자등록 → 통신판매업 신고가 필요해요. 가이드를 보고 천천히 준비하세요.',
-    primary: { label: '사업자 가이드 열기', cls: 'btn-primary', href: '/seller/guide/business', blank: true, markDone: true },
+    primary: { label: '사업자 가이드 보기', cls: 'btn-primary', href: '/seller/guide/business' },
     secondary: { label: '나중에 · 다음', cls: 'btn-ghost', act: 'next' } },
   { key: 'google', title: '구글로 시작하기', emoji: '🔑',
     lead: '구글 계정으로 1초 만에 로그인하세요. 내 수집·마켓·주문이 안전하게 개인화됩니다.',
@@ -67,21 +69,21 @@ const STEPS = [
       : { label: '구글로 시작', cls: 'btn-cta', href: '/auth/google/start?next=/seller/start' },
     autoDone: LOGGED_IN },
   { key: 'market', title: '마켓 연동하기', emoji: '🛍️',
-    lead: '쿠팡·스마트스토어·11번가 등 판매할 마켓을 연결하세요. 키를 붙여넣고 연결 테스트까지 한 번에.',
-    primary: { label: '마켓 연결하기', cls: 'btn-cta', href: '/seller/markets/connect', blank: true, markDone: true },
+    lead: '쿠팡·스마트스토어·11번가 등 판매할 마켓을 연결하세요. 키를 붙여넣고 연결 테스트까지 한 번에. <b>연결을 마치면 이 단계가 자동으로 체크됩니다.</b>',
+    primary: { label: '마켓 연결하러 가기', cls: 'btn-cta', href: '/seller/markets/connect' },
     secondary: { label: '다음', cls: 'btn-ghost', act: 'next' },
     autoDone: MARKETS > 0 },
   { key: 'extension', title: '크롬 확장 설치', emoji: '🧩',
     lead: '상품 페이지에서 버튼 한 번으로 수집되는 확장을 설치하세요. 모바일은 공유로 수집해요.',
-    primary: { label: '확장 설치 안내', cls: 'btn-primary', href: '/seller/extension', blank: true, markDone: true },
+    primary: { label: '확장 설치 안내 보기', cls: 'btn-primary', href: '/seller/extension' },
     secondary: { label: '다음', cls: 'btn-ghost', act: 'next' } },
   { key: 'first', title: '첫 상품 수집하기 🎉', emoji: '🚀',
     lead: '이제 상품을 수집해 보세요. 수집 → 편집 → 마켓 등록까지, 여기서 다 됩니다.',
-    primary: { label: '상품 수집 시작', cls: 'btn-cta', href: '/seller/manual-collect', markDone: true },
+    primary: { label: '상품 수집 시작', cls: 'btn-cta', href: '/seller/manual-collect' },
     secondary: { label: '대시보드로', cls: 'btn-ghost', href: '/seller/dashboard' } },
 ];
 
-const KEY = 'kgp_onboarding_done';
+const KEY = 'kgp_onboarding_done_v2';   // v14: 옛 가짜-완료(localStorage) 폐기 → 정직 상태로 초기화
 let done = {};
 try { done = JSON.parse(localStorage.getItem(KEY) || '{}'); } catch (e) {}
 STEPS.forEach(s => { if (s.autoDone) done[s.key] = true; });
@@ -123,12 +125,9 @@ function renderPanel() {
 }
 
 function handleBtn(step, b) {
-  if (b.markDone) saveDone(step.key);
-  if (b.href) {
-    if (b.blank) { window.open(b.href, '_blank'); saveDone(step.key); render(); }
-    else { window.location.href = b.href; }
-    return;
-  }
+  // v14: 같은 탭 이동(새 창/새 탭 금지). 링크 클릭만으로 '완료' 처리하지 않음(가짜 완료 금지) —
+  //      완료는 실제 상태(로그인/마켓연결)로 자동 체크되거나, 사용자가 '다음'을 눌러 진행할 때만.
+  if (b.href) { window.location.href = b.href; return; }
   if (b.act === 'next') { saveDone(step.key); next(); }
 }
 

--- a/tests/test_v14_onboarding_drawer.py
+++ b/tests/test_v14_onboarding_drawer.py
@@ -1,0 +1,56 @@
+"""tests/test_v14_onboarding_drawer.py — v14 P0 가드: 모바일 드로어 닫기 + 온보딩 정직 자동체크."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+BASE = Path("src/seller_console/templates/_base.html").read_text(encoding="utf-8")
+CSS = Path("src/seller_console/static/seller.css").read_text(encoding="utf-8")
+WIZ = Path("src/seller_console/templates/onboarding_wizard.html").read_text(encoding="utf-8")
+
+
+def test_drawer_overlay_closes_outside_tap():
+    # 오버레이가 실제로 화면을 덮도록 base 규칙(position:fixed) + onclick 닫기
+    assert "sidebar-overlay" in BASE
+    assert 'onclick="closeSidebar()"' in BASE
+    assert "position: fixed" in CSS and ".sidebar-overlay" in CSS
+    # 스크롤 잠금 + ESC + 스와이프 닫기
+    assert "kgp-drawer-open" in BASE and "kgp-drawer-open" in CSS
+    assert "Escape" in BASE
+    assert "touchend" in BASE and "closeSidebar()" in BASE
+
+
+def test_onboarding_no_new_tab_inplace():
+    # v14: 새 탭/새 창 금지 — window.open(_blank) 제거
+    assert "window.open" not in WIZ
+    assert "_blank" not in WIZ
+
+
+def test_onboarding_no_fake_completion():
+    # 링크 클릭만으로 완료 처리(markDone) 금지 — 실제 상태로만 자동 체크
+    assert "markDone" not in WIZ
+    assert "autoDone: LOGGED_IN" in WIZ          # 구글 로그인 실제 완료 반영
+    assert "autoDone: MARKETS > 0" in WIZ         # 마켓 연결 실제 완료 반영
+
+
+def test_onboarding_intro_explains_market_connect():
+    assert "‘마켓 연동’이란" in WIZ or "마켓 연동’이란" in WIZ
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("SELLER_CONSOLE_AUTH", "0")
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_wizard_renders(client):
+    html = client.get("/seller/start").get_data(as_text=True)
+    assert "마켓 연동" in html and "/auth/google/start" in html


### PR DESCRIPTION
v14 **P0 — 모바일 드로어 + 온보딩**(나머지 v14는 후속 PR).

## ① 모바일 좌측 메뉴 바깥 탭하면 닫기 ★
- 원인: `.sidebar-overlay`에 **base 규칙(위치/배경/z-index)이 없어** 화면을 안 덮음 → 바깥 영역 탭이 안 먹었음.
- 수정: `seller.css`에 `position:fixed; inset:0; background; z-index:1040` 추가 → **오버레이가 실제로 덮고 탭하면 닫힘**.
- 추가: **ESC 닫기 + 왼쪽 스와이프 닫기 + 배경 스크롤 잠금**(`body.kgp-drawer-open{overflow:hidden}`). `openSidebar/closeSidebar` 분리.

## ② For Beginners 온보딩: 고정 스테퍼 + in-place + 실제 자동 체크 ★
- 스테퍼는 좌측 고정, 우측 `#panel`만 교체(이미 SPA식 in-place — 새로고침 없음).
- **가짜 완료 제거(image3)**: 링크만 클릭해도 완료 처리하던 `markDone` 삭제. 완료는 **실제 상태로만 자동 체크** — 구글 로그인(`LOGGED_IN`) / 마켓 연결(`MARKETS>0`). localStorage 키를 v2로 올려 **옛 가짜-완료 상태 폐기**.
- **새 탭/새 창 금지**: `window.open(_blank)` 제거 → 같은 탭 이동.
- 첫 단계 "환영해요"에 **‘마켓 연동이란? 왜 필요한가’** 쉬운 설명 추가.

## 테스트
- 신규 `test_v14_onboarding_drawer`(5: 오버레이 닫기/ESC/스와이프/스크롤락 · 새탭 없음 · 가짜완료 없음 · intro 설명 · 렌더). 전체 `pytest` **10165 passed**.

> 남은 v14: 소셜 로그인 4종 · 마켓연동 순차 스테퍼+키발급 안내(쿠팡 출고지 스코프) · 확장 설치 단계별+복사버튼 · For Beginners 고정/토글/확대 · 친절 카피·CTA · 아이콘 표시 · "퍼센티"/개발문구 전역 제거 — 후속 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_