### PR TITLE
feat(v14): 소셜로그인4종+마켓순차화+확장설치단계화+For Beginners+퍼센티제거 (Phase 282)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,13 @@
   prev/next, '전체 보기' 토글, JS show/hide). 섹션(쿠팡 출고지 등)에 '이 항목은 {마켓}에만 필요' 스코프 명시(쿠팡 전용
   오해 해소). 개발 문서경로(LIVE_VERIFICATION_GUIDE) 노출 제거. 키 발급 딥링크·필드설명·필수표시는 기존 유지.
   가드 test_market_connect_stepper_v14(4). 전체 10175 passed.
-- ⏳ 남은 v14: 확장 설치 단계별+빨간문구/복사버튼 · For Beginners 고정/토글/확대 · 친절카피+CTA · 아이콘표시 ·
-  퍼센티/개발문구 전역제거.
+- ✅ **확장 설치 단계화 + 퍼센티 제거(Phase 282):** extension_install.html을 키노트식 단계 위저드로 재작성
+  (한 화면=한 단계, 단계당 버튼 1개, 이전/다음, 진행바). 복사 버튼 실동작(navigator.clipboard + pcToast 피드백,
+  실패 시 안내). 빨간 날것 표기(chrome://extensions/manifest는 안내에 최소화·'?'·details로). '퍼센티' 전역 제거
+  (collect_receiver/manual_collect/bookmarklet 카피 + woocommerce 운송장 노트 [코고가네]). manual_collect '기존 수집기
+  엔드포인트' 개발노트 → 사용자 카피. ※channels/percenty.py는 실제 퍼센티 채널 연동이라 유지.
+  가드 test_ext_install_wizard_v14(6). 전체 10180 passed.
+- ⏳ 남은 v14: For Beginners 고정/토글/확대 · 친절카피("상품 수집이란?")+CTA 강조 · 기본 마켓/소싱처 아이콘 표시.
 
 ## ⬛ v13 브리프 (오너 2026-06-22 — "관리자전용·재로그인버그·속도·모바일앱·글로벌·프로디자인·파비콘")
 - 버전 충돌 시 v13 우선. 디자인 최우선('학교 과제물'→프로). 정직 데이터·회귀 금지.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,15 @@
   ①새 탭(window.open _blank) 제거 → 같은 탭 이동 ②링크 클릭만으로 가짜 완료(markDone) 제거 → 완료는 실제 상태
   (autoDone: LOGGED_IN / MARKETS>0)로만 자동 체크 ③localStorage KEY v2로 옛 가짜-완료 폐기 ④intro에 '마켓 연동이란?'
   쉬운 설명 추가. 가드 test_v14_onboarding_drawer(5). 전체 10165 passed.
-- ⏳ 남은 v14: 소셜 로그인 4종(구글·네이버·카카오·애플) · 마켓연동 순차 스테퍼+키발급안내(쿠팡 출고지 스코프) ·
-  확장 설치 단계별+빨간문구/복사버튼 · For Beginners 고정/토글/확대 · 친절카피+CTA · 아이콘표시 · 퍼센티/개발문구 전역제거.
+- ✅ **소셜 로그인 4종(Phase 282):** 신설 apple.py(Sign in with Apple — ES256 JWT client_secret, form_post 콜백,
+  id_token 디코드; 키 미설정 시 비활성). views.py 4 provider 등록 + 콜백 GET+POST(request.values). login.html·온보딩에
+  구글·네이버·카카오·애플 4버튼. 오너: 네이버·카카오·애플 콘솔 OAuth 등록. 가드 test_social_login_v14(6).
+- ✅ **마켓연동 순차 스테퍼(Phase 282):** markets_connect에 '한 마켓씩' 순차 진행 스테퍼(연결되면 ✓ 자동체크,
+  prev/next, '전체 보기' 토글, JS show/hide). 섹션(쿠팡 출고지 등)에 '이 항목은 {마켓}에만 필요' 스코프 명시(쿠팡 전용
+  오해 해소). 개발 문서경로(LIVE_VERIFICATION_GUIDE) 노출 제거. 키 발급 딥링크·필드설명·필수표시는 기존 유지.
+  가드 test_market_connect_stepper_v14(4). 전체 10175 passed.
+- ⏳ 남은 v14: 확장 설치 단계별+빨간문구/복사버튼 · For Beginners 고정/토글/확대 · 친절카피+CTA · 아이콘표시 ·
+  퍼센티/개발문구 전역제거.
 
 ## ⬛ v13 브리프 (오너 2026-06-22 — "관리자전용·재로그인버그·속도·모바일앱·글로벌·프로디자인·파비콘")
 - 버전 충돌 시 v13 우선. 디자인 최우선('학교 과제물'→프로). 정직 데이터·회귀 금지.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,10 @@
   (collect_receiver/manual_collect/bookmarklet 카피 + woocommerce 운송장 노트 [코고가네]). manual_collect '기존 수집기
   엔드포인트' 개발노트 → 사용자 카피. ※channels/percenty.py는 실제 퍼센티 채널 연동이라 유지.
   가드 test_ext_install_wizard_v14(6). 전체 10180 passed.
-- ⏳ 남은 v14: For Beginners 고정/토글/확대 · 친절카피("상품 수집이란?")+CTA 강조 · 기본 마켓/소싱처 아이콘 표시.
+- ✅ **For Beginners 고정 버튼 + 친절 카피(Phase 282):** _base.html에 모든 페이지 우하단 고정 '✨ 처음이신가요?'
+  큰 알약(주황 btn-cta) + 바로 밑 작은 '가이드 버튼 숨기기' on/off(localStorage kgp_fb_hidden, 숨기면 작은 ✨ 재오픈
+  버튼). manual_collect에 '상품 수집이란?' 한 줄 풀이 + '?' 툴팁. 가드 test_for_beginners_v14(3). 전체 10183 passed.
+- ⏳ 남은 v14: 기본 마켓/소싱처 사이트 아이콘(로고) 표시(현재 이모지 아이콘) — 후속.
 
 ## ⬛ v13 브리프 (오너 2026-06-22 — "관리자전용·재로그인버그·속도·모바일앱·글로벌·프로디자인·파비콘")
 - 버전 충돌 시 v13 우선. 디자인 최우선('학교 과제물'→프로). 정직 데이터·회귀 금지.

--- a/src/auth/providers/__init__.py
+++ b/src/auth/providers/__init__.py
@@ -2,5 +2,6 @@
 from .kakao import KakaoProvider
 from .google import GoogleProvider
 from .naver import NaverProvider
+from .apple import AppleProvider
 
-__all__ = ["KakaoProvider", "GoogleProvider", "NaverProvider"]
+__all__ = ["KakaoProvider", "GoogleProvider", "NaverProvider", "AppleProvider"]

--- a/src/auth/providers/apple.py
+++ b/src/auth/providers/apple.py
@@ -1,0 +1,106 @@
+"""src/auth/providers/apple.py — Sign in with Apple OAuth 2.0 프로바이더 (v14).
+
+Apple은 client_secret을 .p8 키로 서명한 ES256 JWT로 만든다(짧은 만료). 콜백은 form_post(POST).
+응답의 id_token(JWT)에 sub/email이 들어 있어 별도 userinfo 엔드포인트가 없다.
+키 미설정/라이브러리 미설치 시 is_configured=False → 버튼 비노출(가짜 활성 금지).
+
+오너 액션: Apple Developer에서 Services ID(APPLE_CLIENT_ID), Team ID(APPLE_TEAM_ID),
+Key ID(APPLE_KEY_ID), .p8 개인키(APPLE_PRIVATE_KEY) 발급/설정. (또는 미리 만든 APPLE_CLIENT_SECRET.)
+"""
+from __future__ import annotations
+
+import os
+import time
+from urllib.parse import urlencode
+
+import requests
+
+
+class AppleProvider:
+    """Sign in with Apple 프로바이더."""
+
+    name = "apple"
+
+    _AUTH_URL = "https://appleid.apple.com/auth/authorize"
+    _TOKEN_URL = "https://appleid.apple.com/auth/token"
+
+    def __init__(self) -> None:
+        self.client_id = os.getenv("APPLE_CLIENT_ID", "").strip()          # Services ID
+        self.team_id = os.getenv("APPLE_TEAM_ID", "").strip()
+        self.key_id = os.getenv("APPLE_KEY_ID", "").strip()
+        # 개행이 \n 으로 인코딩돼 들어올 수 있어 복원
+        self.private_key = os.getenv("APPLE_PRIVATE_KEY", "").strip().replace("\\n", "\n")
+        # 미리 계산한 client_secret(JWT)을 직접 줄 수도 있음(선택)
+        self.client_secret_env = os.getenv("APPLE_CLIENT_SECRET", "").strip()
+
+    @property
+    def is_configured(self) -> bool:
+        if not self.client_id:
+            return False
+        if self.client_secret_env:
+            return True
+        return bool(self.team_id and self.key_id and self.private_key)
+
+    # 호환용 속성(_oauth_runtime이 client_secret을 읽음) — 실제 시크릿은 JWT라 노출 안 함
+    @property
+    def client_secret(self) -> str:
+        return self.client_secret_env or ("(.p8 키로 생성)" if (self.team_id and self.key_id and self.private_key) else "")
+
+    def _build_client_secret(self) -> str:
+        if self.client_secret_env:
+            return self.client_secret_env
+        import jwt  # PyJWT (ES256은 cryptography 필요)
+        now = int(time.time())
+        payload = {
+            "iss": self.team_id,
+            "iat": now,
+            "exp": now + 3600,
+            "aud": "https://appleid.apple.com",
+            "sub": self.client_id,
+        }
+        return jwt.encode(payload, self.private_key, algorithm="ES256", headers={"kid": self.key_id, "alg": "ES256"})
+
+    def get_authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "response_type": "code",
+            "response_mode": "form_post",   # Apple은 콜백을 POST로 보냄
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": "name email",
+        }
+        return f"{self._AUTH_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str, redirect_uri: str) -> dict:
+        """인가 코드 → 토큰. id_token(JWT)을 access_token 슬롯에 매핑(흐름 호환)."""
+        try:
+            data = {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": self.client_id,
+                "client_secret": self._build_client_secret(),
+            }
+            r = requests.post(self._TOKEN_URL, data=data, timeout=10)
+            r.raise_for_status()
+            js = r.json()
+            if isinstance(js, dict) and js.get("id_token") and not js.get("access_token"):
+                js["access_token"] = js["id_token"]
+            return js
+        except Exception as exc:
+            return {"error": str(exc)}
+
+    def get_user_info(self, access_token: str) -> dict:
+        """access_token == id_token(JWT) 디코드 → sub/email. (Apple 토큰엔드포인트가 발급한 토큰)"""
+        try:
+            import jwt
+            claims = jwt.decode(access_token, options={"verify_signature": False})
+            return {
+                "provider_user_id": claims.get("sub", ""),
+                "email": claims.get("email", ""),
+                "name": "",
+                "avatar_url": "",
+                "provider": "apple",
+            }
+        except Exception as exc:
+            return {"error": str(exc)}

--- a/src/auth/templates/auth/login.html
+++ b/src/auth/templates/auth/login.html
@@ -104,7 +104,19 @@
       <div class="small text-muted mb-2">{{ naver_status.reason }} <a href="{{ naver_status.setup_url }}">설정 경로</a></div>
       {% endif %}
 
-      {% if kakao_status.is_configured or google_status.is_configured or naver_status.is_configured %}
+      {% if apple_status.is_configured %}
+      <a href="/auth/apple/start?next={{ next_url }}" class="btn w-100 social-btn mb-2 social-login-link"
+         style="background:#000;color:#fff;border:none;">
+         Apple로 로그인
+      </a>
+      {% else %}
+      <button type="button" class="btn w-100 social-btn mb-1" style="background:#f0f0f0;color:#666;border:none;" disabled>
+        Apple 로그인 (설정 필요)
+      </button>
+      <div class="small text-muted mb-2">{{ apple_status.reason }} <a href="{{ apple_status.setup_url }}">설정 경로</a></div>
+      {% endif %}
+
+      {% if kakao_status.is_configured or google_status.is_configured or naver_status.is_configured or apple_status.is_configured %}
       <div class="divider">또는</div>
       {% endif %}
 

--- a/src/auth/views.py
+++ b/src/auth/views.py
@@ -205,6 +205,8 @@ def _oauth_default_next(provider: str) -> str:
         return os.getenv("GOOGLE_OAUTH_NEXT_DEFAULT", "/seller/dashboard").strip() or "/seller/dashboard"
     if provider == "naver":
         return os.getenv("NAVER_OAUTH_NEXT_DEFAULT", "/seller/dashboard").strip() or "/seller/dashboard"
+    if provider == "apple":
+        return os.getenv("APPLE_OAUTH_NEXT_DEFAULT", "/seller/dashboard").strip() or "/seller/dashboard"
     return "/seller/dashboard"
 
 
@@ -261,6 +263,7 @@ _PROVIDER_MAP = {
     "kakao": None,
     "google": None,
     "naver": None,
+    "apple": None,
 }
 
 
@@ -276,6 +279,9 @@ def _get_provider(provider: str):
         elif provider == "naver":
             from .providers.naver import NaverProvider
             return NaverProvider()
+        elif provider == "apple":
+            from .providers.apple import AppleProvider
+            return AppleProvider()
     except Exception as exc:
         logger.warning("프로바이더 로드 실패 (%s): %s", provider, exc)
     return None
@@ -366,6 +372,16 @@ _OAUTH_PROVIDER_ENV_SPECS = {
         "client_secret_envs": [
             ("NAVER_CLIENT_SECRET", "NAVER_CLIENT_SECRET"),
             ("NAVER_OAUTH_CLIENT_SECRET", "NAVER_OAUTH_CLIENT_SECRET (별칭 폴백)"),
+        ],
+    },
+    "apple": {
+        "display_name": "Apple",
+        "client_id_envs": [
+            ("APPLE_CLIENT_ID", "APPLE_CLIENT_ID (Services ID)"),
+        ],
+        "client_secret_envs": [
+            ("APPLE_CLIENT_SECRET", "APPLE_CLIENT_SECRET (또는 .p8: APPLE_TEAM_ID/KEY_ID/PRIVATE_KEY)"),
+            ("APPLE_PRIVATE_KEY", "APPLE_PRIVATE_KEY (.p8)"),
         ],
     },
 }
@@ -480,6 +496,7 @@ def login():
     kakao_status = _provider_status("kakao")
     google_status = _provider_status("google")
     naver_status = _provider_status("naver")
+    apple_status = _provider_status("apple")
     # 운영자용 OAuth 진단(콜백 URI/client_id)은 일반 사용자 첫 화면에 노출하지 않는다
     # (KOHgogane 브리프 §2.4). 관리자 세션이거나 ?diag=1 일 때만 렌더한다.
     show_diag = request.args.get("diag") == "1"
@@ -502,6 +519,7 @@ def login():
         kakao_status=kakao_status,
         google_status=google_status,
         naver_status=naver_status,
+        apple_status=apple_status,
         oauth_runtime=oauth_runtime,
     )
 
@@ -623,10 +641,13 @@ def login_post():
         return redirect(url_for("auth.login"))
 
 
+_OAUTH_PROVIDERS = ("kakao", "google", "naver", "apple")
+
+
 @auth_bp.get("/<provider>/start")
 def oauth_start(provider: str):
     """OAuth 시작 — state 생성 + 프로바이더로 리다이렉트."""
-    if provider not in ("kakao", "google", "naver"):
+    if provider not in _OAUTH_PROVIDERS:
         return jsonify({"error": "지원하지 않는 프로바이더입니다."}), 400
 
     p = _get_provider(provider)
@@ -648,22 +669,25 @@ def oauth_start(provider: str):
     return redirect(auth_url)
 
 
-@auth_bp.get("/<provider>/callback")
+@auth_bp.route("/<provider>/callback", methods=["GET", "POST"])
 def oauth_callback(provider: str):
-    """OAuth 콜백 — 코드 교환 + 사용자 생성/로그인."""
-    if provider not in ("kakao", "google", "naver"):
+    """OAuth 콜백 — 코드 교환 + 사용자 생성/로그인.
+
+    Apple은 response_mode=form_post로 콜백을 POST로 보낸다 → request.values(args+form)로 통일.
+    """
+    if provider not in _OAUTH_PROVIDERS:
         return jsonify({"error": "지원하지 않는 프로바이더입니다."}), 400
 
-    # CSRF 방어: state 파라미터 검증
-    state_param = request.args.get("state", "")
+    # CSRF 방어: state 파라미터 검증 (GET=query, POST(form_post)=form)
+    state_param = request.values.get("state", "")
     state_stored = session.pop(f"oauth_state_{provider}", "")
     if not state_param or not secrets.compare_digest(state_param, state_stored):
         flash("보안 오류가 발생했습니다. 다시 시도해주세요.", "auth_oauth")
         return redirect(url_for("auth.login"))
 
-    code = request.args.get("code", "")
+    code = request.values.get("code", "")
     if not code:
-        error = request.args.get("error", "알 수 없는 오류")
+        error = request.values.get("error", "알 수 없는 오류")
         flash(f"로그인 취소 또는 오류: {error}", "auth_oauth")
         return redirect(url_for("auth.login"))
 

--- a/src/seller_console/market_adapters/woocommerce_adapter.py
+++ b/src/seller_console/market_adapters/woocommerce_adapter.py
@@ -361,7 +361,7 @@ class WooCommerceAdapter(MarketAdapter):
 
         try:
             import requests
-            note = f"[퍼센티] 운송장 등록: {courier} / {tracking_no}"
+            note = f"[코고가네] 운송장 등록: {courier} / {tracking_no}"
             resp = requests.post(
                 f"{_api_url()}/orders/{order_id}/notes",
                 auth=_auth(),

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -192,6 +192,35 @@
   </div>
 </div>
 
+<!-- v14: For Beginners 진입 버튼 — 모든 페이지 고정 + 바로 밑 작은 on/off(상태 기억) -->
+<div id="fbWrap" style="position:fixed;right:18px;bottom:18px;z-index:1035;display:flex;flex-direction:column;align-items:flex-end;gap:3px">
+  <a href="/seller/start" id="fbBtn" class="btn btn-cta"
+     style="border-radius:999px;font-weight:800;font-size:1rem;padding:.7rem 1.4rem;box-shadow:0 8px 22px rgba(239,122,34,.35)">
+     ✨ 처음이신가요?
+  </a>
+  <button type="button" id="fbHide" class="btn btn-link p-0 text-muted" style="font-size:.68rem;text-decoration:none">가이드 버튼 숨기기</button>
+</div>
+<button type="button" id="fbReopen" class="btn btn-cta" title="처음이신가요? 가이드 열기"
+        style="display:none;position:fixed;right:18px;bottom:18px;z-index:1035;border-radius:999px;width:44px;height:44px;font-size:1.1rem;box-shadow:0 6px 18px rgba(239,122,34,.35)">✨</button>
+<script>
+(function () {
+  var wrap = document.getElementById('fbWrap');
+  var reopen = document.getElementById('fbReopen');
+  var hide = document.getElementById('fbHide');
+  if (!wrap || !reopen || !hide) return;
+  function get(k){ try { return localStorage.getItem(k); } catch(e){ return null; } }
+  function set(k,v){ try { localStorage.setItem(k,v); } catch(e){} }
+  function apply() {
+    var hidden = get('kgp_fb_hidden') === '1';
+    wrap.style.display = hidden ? 'none' : 'flex';
+    reopen.style.display = hidden ? 'flex' : 'none';
+  }
+  hide.addEventListener('click', function(){ set('kgp_fb_hidden','1'); apply(); });
+  reopen.addEventListener('click', function(){ set('kgp_fb_hidden','0'); apply(); });
+  apply();
+})();
+</script>
+
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ url_for('seller_console.static', filename='seller.js') }}"></script>
 <script>

--- a/src/seller_console/templates/bookmarklet.html
+++ b/src/seller_console/templates/bookmarklet.html
@@ -26,7 +26,7 @@
                 <strong>‘수집 완료’</strong>만 표시됩니다. 결과는 <strong>내 계정의 ‘수집 이력’</strong>에서 확인·편집하세요.</li>
           </ol>
           <div class="alert alert-success small mb-0">
-            ✅ <strong>토큰이 필요 없습니다.</strong> 새 탭이 고가네 퍼센티(로그인된 내 계정)로 열려 안전하게 수집됩니다.
+            ✅ <strong>토큰이 필요 없습니다.</strong> 새 탭이 코고가네(로그인된 내 계정)로 열려 안전하게 수집됩니다.
             (예전 토큰 방식은 일부 사이트의 보안정책(CSP)에 막혀 작동하지 않았어요 — 이 방식은 그 문제가 없습니다.)
           </div>
         </div>
@@ -80,7 +80,7 @@
         <div class="card-body small text-muted">
           <ol class="mb-2">
             <li>상품 페이지의 <strong>이미지·상세설명·리뷰·HTML</strong>을 읽습니다.</li>
-            <li><strong>새 탭으로 고가네 퍼센티(로그인된 내 계정)를 열어</strong> 그 데이터를 전달합니다.</li>
+            <li><strong>새 탭으로 코고가네(로그인된 내 계정)를 열어</strong> 그 데이터를 전달합니다.</li>
             <li>서버가 이미지·상세·리뷰를 정리하고(선택 시 번역) <strong>내 수집 이력에 저장</strong>합니다 — ‘수집 완료’만 표시됩니다.</li>
           </ol>
           <div>봇 차단이 강한 사이트는 <a href="/seller/markets/guide">크롬 확장(고가네 수집)</a>도 사용할 수 있어요.</div>

--- a/src/seller_console/templates/collect_receiver.html
+++ b/src/seller_console/templates/collect_receiver.html
@@ -54,7 +54,7 @@ function showLogin() {
   // 로그인 페이지로 튕기지 않고, 이 창 안에서 친절히 로그인 안내
   render(
     '<div class="display-6 mb-2">🔒</div>' +
-    '<h1 class="h5 mb-2">고가네 퍼센티 로그인이 필요해요</h1>' +
+    '<h1 class="h5 mb-2">코고가네 로그인이 필요해요</h1>' +
     '<p class="text-muted small mb-3">로그인 후 다시 상품 페이지에서 북마클릿을 누르면 바로 수집됩니다.</p>' +
     '<div class="d-flex gap-2 justify-content-center flex-wrap">' +
       '<a class="btn btn-primary btn-sm" href="/auth/login?next=/seller/collect/history">로그인하기</a>' +

--- a/src/seller_console/templates/extension_install.html
+++ b/src/seller_console/templates/extension_install.html
@@ -1,60 +1,107 @@
 {% extends "_base.html" %}
 {% block title %}크롬 확장 설치{% endblock %}
 {% block content %}
-<div class="container-fluid py-3" style="max-width:860px">
-  <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
-    <div>
-      <h1 class="h4 mb-1">🧩 고가네 수집 — 크롬 확장 설치</h1>
-      <p class="text-muted mb-0">설치하면 쇼핑몰 상품/검색 페이지에 <b>‘고가네 수집’ 버튼</b>이 떠서 클릭 한 번에 수집됩니다.</p>
-    </div>
-    <a href="/seller/extension/download" class="btn btn-primary">
-      <i class="bi bi-download"></i> 확장 다운로드 (v{{ version or '—' }})
-    </a>
+<div class="container-fluid py-3" style="max-width:720px">
+  <div class="text-center mb-3">
+    <h1 class="h4 mb-1">코고가네 수집 — 크롬 확장 설치</h1>
+    <p class="text-muted mb-0">설치하면 쇼핑몰에서 <b>버튼 한 번</b>으로 상품이 담겨요. 한 단계씩 따라오면 1~2분이면 끝나요.</p>
   </div>
 
-  <!-- 단계 가이드 -->
-  <div class="card console-card mb-3">
-    <div class="card-body">
-      <h2 class="h6 mb-3">설치 방법 (1~2분)</h2>
-      <ol class="mb-0">
-        <li class="mb-2">
-          위 <b>‘확장 다운로드’</b>를 눌러 <code>kohgane-collector-v{{ version }}.zip</code>을 받고
-          <b>압축을 풉니다</b> → <code>manifest.json</code>이 들어있는 폴더가 생깁니다.
-        </li>
-        <li class="mb-2">
-          크롬 주소창에 <code>chrome://extensions</code> 입력 → 엔터.
-          <a href="#" onclick="navigator.clipboard.writeText('chrome://extensions');return false;" class="small">📋 복사</a>
-        </li>
-        <li class="mb-2">오른쪽 위 <b>‘개발자 모드’</b>를 <b>켭니다</b>(토글 ON).</li>
-        <li class="mb-2">왼쪽 위 <b>‘압축해제된 확장 프로그램 로드’</b> 클릭 → 방금 <b>압축 푼 폴더</b>(안에 <code>manifest.json</code>이 보이는 그 폴더)를 선택.
-          <span class="text-muted small">※ ‘매니페스트 없음’ 오류가 나면 한 단계 안쪽 폴더(<code>manifest.json</code>이 바로 보이는 폴더)를 고르세요.</span></li>
-        <li class="mb-2"><b>‘코고가네 수집기’</b>가 확장 목록에 나타나면 설치 완료 ✅</li>
-        <li class="mb-2">
-          확장의 <b>옵션</b>에 <b>개인 토큰</b>을 넣습니다(딱 1회).
-          <a href="/seller/me/tokens" target="_blank">토큰 발급 →</a>
-          <div class="small text-muted">확장 아이콘 우클릭 → ‘옵션’ → 서버 URL <code>{{ request.host_url.rstrip('/') }}</code> + 토큰 붙여넣기</div>
-        </li>
-        <li>쇼핑몰 상품 페이지로 가면 우하단에 <b>고가네 수집</b> 버튼이, 검색/목록 페이지엔 카드마다 <b>수집 배지</b>가 뜹니다.</li>
-      </ol>
-    </div>
-  </div>
-
-  <div class="alert alert-light border small mb-3">
-    <i class="bi bi-info-circle text-primary"></i>
-    버튼이 안 보이면: ① 확장이 <b>켜져 있는지</b>(파란 토글) ② <code>chrome://extensions</code>에서 <b>새로고침(↻)</b>
-    ③ 상품 <b>상세 페이지</b>인지(목록 페이지는 카드 배지) ④ 옵션에 <b>토큰</b>이 들어갔는지 확인하세요.
-  </div>
-
-  <!-- 모바일 안내 -->
+  <!-- 키노트식 단계 카드: 한 화면에 한 단계, 버튼 1개 + 다음/이전 -->
   <div class="card console-card">
-    <div class="card-body">
-      <h2 class="h6 mb-2">📱 모바일에서 수집하기</h2>
-      <p class="small text-muted mb-2">모바일 브라우저는 크롬 확장을 지원하지 않습니다. 대신 두 가지 방법이 있어요.</p>
-      <ol class="small mb-0">
-        <li class="mb-2"><b>URL 붙여넣기</b>: 상품 페이지에서 주소 복사 → 고가네 <a href="/seller/collect">수집기</a>에 붙여넣고 <b>즉시 수집</b>.</li>
-        <li><b>공유하기(안드로이드)</b>: 고가네 퍼센티를 홈 화면에 추가(앱처럼 설치)하면, 쇼핑 앱에서 <b>공유 → 고가네 퍼센티</b>로 보내 바로 수집됩니다.</li>
-      </ol>
+    <div class="card-body text-center" style="min-height:340px">
+      <div class="small text-muted mb-2" id="extProgress"></div>
+      <div class="progress mb-4" style="height:6px;background:#eee">
+        <div class="progress-bar" id="extProgressBar" style="width:0%;background:var(--pc-color-primary)"></div>
+      </div>
+      <div id="extPanel"></div>
+    </div>
+    <div class="card-footer d-flex justify-content-between align-items-center bg-transparent">
+      <button type="button" class="btn btn-ghost btn-sm" id="extPrev">← 이전</button>
+      <span class="small text-muted" id="extStepNo"></span>
+      <button type="button" class="btn btn-ghost btn-sm" id="extNext">다음 →</button>
     </div>
   </div>
+
+  <details class="mt-3">
+    <summary class="text-muted small" style="cursor:pointer">잘 안 되나요? (자세한 도움말)</summary>
+    <div class="small text-muted mt-2">
+      버튼이 안 보이면: ① 확장이 <b>켜져 있는지</b> ② 확장 관리 화면에서 <b>새로고침(↻)</b>
+      ③ 지정 소싱처의 상품/목록 페이지인지 ④ 확장 <b>옵션</b>에 토큰이 들어갔는지 확인하세요.
+      모바일은 크롬 확장을 지원하지 않아요 — 상품 주소를 복사해 <a href="/seller/collect">수집기</a>에 붙여넣거나,
+      앱을 홈 화면에 추가한 뒤 쇼핑 앱에서 <b>공유 → 코고가네</b>로 보내면 됩니다.
+    </div>
+  </details>
 </div>
+
+<script>
+const HOST = "{{ request.host_url.rstrip('/') }}";
+const DL = "/seller/extension/download";
+const TOKENS = "/seller/me/tokens";
+const COLLECT = "/seller/manual-collect";
+const MANAGE_URL = "chrome://extensions";
+
+// 각 단계: 한 화면 = 한 메시지 + 버튼 1개(주 행동). 다음/이전은 하단 고정.
+const STEPS = [
+  { emoji: "📥", title: "1) 확장 파일 받기",
+    body: "먼저 확장 파일(zip)을 내려받아요. 받은 파일은 <b>압축을 풀어</b> 두세요.",
+    btn: { label: "확장 다운로드", href: DL } },
+  { emoji: "🗂️", title: "2) 압축 풀기",
+    body: "받은 zip 파일을 <b>마우스 오른쪽 → 압축 풀기</b> 하세요. 폴더 하나가 만들어져요.",
+    btn: { label: "압축 풀었어요 · 다음", act: "next" } },
+  { emoji: "🧭", title: "3) 확장 관리 화면 열기",
+    body: "크롬 주소창에 아래 주소를 붙여넣고 엔터를 누르세요. (복사 버튼을 쓰면 편해요.)",
+    code: MANAGE_URL,
+    btn: { label: "주소 복사하기", act: "copy", value: MANAGE_URL } },
+  { emoji: "🛠️", title: "4) ‘개발자 모드’ 켜기",
+    body: "확장 관리 화면 <b>오른쪽 위</b>의 <b>‘개발자 모드’</b> 스위치를 <b>켜기</b>로 바꾸세요.",
+    btn: { label: "켰어요 · 다음", act: "next" } },
+  { emoji: "📂", title: "5) 압축 푼 폴더 불러오기",
+    body: "왼쪽 위 <b>‘압축해제된 확장 프로그램 로드’</b>를 누르고, 방금 <b>압축 푼 폴더</b>를 고르세요. " +
+          "‘코고가네 수집기’가 목록에 뜨면 설치 완료예요.",
+    btn: { label: "설치됐어요 · 다음", act: "next" } },
+  { emoji: "🔑", title: "6) 토큰 한 번 넣기",
+    body: "확장이 내 계정과 연결되도록 <b>토큰</b>을 한 번만 넣어요. 토큰을 발급받아 확장 <b>옵션</b>에 붙여넣으세요. " +
+          "<span class='pc-help' data-bs-toggle='tooltip' data-bs-title='확장 아이콘을 오른쪽 클릭 → 옵션 → 서버 주소와 토큰을 붙여넣기. 서버 주소는 자동으로 채워져 있어요.'>?</span>",
+    btn: { label: "토큰 발급받기", href: TOKENS } },
+  { emoji: "🎉", title: "7) 다 됐어요!",
+    body: "이제 지정 소싱처(타오바오·아마존 등) 상품 페이지에서 <b>코고가네 수집</b> 버튼이, 목록 페이지엔 카드마다 <b>수집 배지</b>가 떠요.",
+    btn: { label: "상품 수집하러 가기", href: COLLECT } },
+];
+
+let cur = 0;
+function render() {
+  const s = STEPS[cur];
+  document.getElementById("extProgress").textContent = `설치 단계 ${cur + 1} / ${STEPS.length}`;
+  document.getElementById("extProgressBar").style.width = Math.round((cur + 1) / STEPS.length * 100) + "%";
+  document.getElementById("extStepNo").textContent = `${cur + 1} / ${STEPS.length}`;
+  let html = `<div style="font-size:3rem">${s.emoji}</div><h2 class="h5 mt-2">${s.title}</h2>` +
+             `<p class="text-muted mt-2 mb-3">${s.body}</p>`;
+  if (s.code) {
+    html += `<div class="d-flex justify-content-center mb-3"><span class="px-3 py-2 rounded" style="background:#f5f1e6;font-family:monospace">${s.code}</span></div>`;
+  }
+  html += `<div class="d-grid gap-2 mx-auto" style="max-width:300px"><button type="button" class="btn btn-cta" id="extPrimary">${s.btn.label}</button></div>`;
+  document.getElementById("extPanel").innerHTML = html;
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => { try { new bootstrap.Tooltip(el); } catch (e) {} });
+  document.getElementById("extPrimary").addEventListener("click", () => handle(s.btn));
+  document.getElementById("extPrev").disabled = cur === 0;
+  document.getElementById("extNext").disabled = cur === STEPS.length - 1;
+}
+function handle(btn) {
+  if (btn.act === "copy") {
+    navigator.clipboard.writeText(btn.value).then(
+      () => { if (window.pcToast) pcToast("주소를 복사했어요. 크롬 주소창에 붙여넣고 엔터!", "success"); next(); },
+      () => { if (window.pcToast) pcToast("복사가 안 됐어요. 주소를 직접 입력해 주세요: " + btn.value, "warning"); }
+    );
+    return;
+  }
+  if (btn.href) { window.location.href = btn.href; return; }
+  if (btn.act === "next") next();
+}
+function next() { if (cur < STEPS.length - 1) { cur++; render(); } }
+function prev() { if (cur > 0) { cur--; render(); } }
+document.getElementById("extNext").addEventListener("click", next);
+document.getElementById("extPrev").addEventListener("click", prev);
+render();
+</script>
 {% endblock %}

--- a/src/seller_console/templates/manual_collect.html
+++ b/src/seller_console/templates/manual_collect.html
@@ -5,7 +5,11 @@
 <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
   <div>
     <h1 class="h4 mb-1">상품 수집 → 등록</h1>
-    <p class="text-muted mb-0">URL 입력부터 마켓 업로드까지 한 화면에서 처리합니다.</p>
+    <p class="text-muted mb-0">
+      <strong>상품 수집이란?</strong> 해외 쇼핑몰의 상품 정보(제목·가격·이미지)를 코고가네로 가져오는 거예요.
+      가져온 상품은 다듬어서 내 마켓에 올릴 수 있어요.
+      <span class="pc-help" data-bs-toggle="tooltip" data-bs-title="상품 페이지 주소를 붙여넣거나, 크롬 확장으로 버튼 한 번에 가져올 수 있어요. 가져온 상품은 ‘수집한 상품’에서 편집·등록합니다.">?</span>
+    </p>
   </div>
   <a href="/seller/api/status" class="btn btn-outline-secondary btn-sm">API 상태</a>
 </div>

--- a/src/seller_console/templates/manual_collect.html
+++ b/src/seller_console/templates/manual_collect.html
@@ -24,7 +24,7 @@
   <span id="step-4" class="console-step">4) 업로드</span>
 </div>
 
-<!-- 원클릭 수집 지원 마켓 (퍼센티 벤치마킹) -->
+<!-- 원클릭 수집 지원 마켓 -->
 <div class="card console-card mb-3" id="oneclickCard">
   <div class="card-body">
     <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
@@ -52,7 +52,7 @@
       {% endfor %}
     </div>
     <div class="alert alert-light border mt-3 mb-0 small d-flex gap-2 align-items-start" role="note">
-      <img src="{{ url_for('seller_console.static', filename='favicon.svg') }}" alt="고가네퍼센티"
+      <img src="{{ url_for('seller_console.static', filename='favicon.svg') }}" alt="코고가네"
            style="width:34px;height:34px;border-radius:8px;flex-shrink:0">
       <div>
         <b class="text-primary">코고가네 인페이지 수집</b> — 크롬 확장을 설치하면 <b>지정 소싱처</b>(타오바오·아마존 등)에서
@@ -71,7 +71,7 @@
       <input type="url" id="productUrl" class="form-control console-focus" placeholder="https://..." autocomplete="off" required>
       <button class="btn btn-primary" id="extractBtn" onclick="extractProduct()">미리보기</button>
     </div>
-    <div class="form-text">Amazon/타오바오/1688 등 기존 수집기 엔드포인트를 그대로 사용합니다.</div>
+    <div class="form-text">타오바오·아마존·1688 등 상품 페이지 주소를 붙여넣으면 제목·가격·이미지를 자동으로 가져와요.</div>
     <div id="urlError" class="text-danger small mt-2 d-none" role="alert"></div>
   </div>
 </div>

--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -78,9 +78,23 @@
   </div>
   {% endif %}
 
-  <div class="row g-3">
+  {% if not single_market and market_statuses|length > 1 %}
+  <!-- v14: 한 마켓씩 순차 진행 스테퍼(연결되면 자동 체크). '전체 보기'로 한눈에도 가능. -->
+  <div class="card console-card mb-3" id="mcStepperCard">
+    <div class="card-body">
+      <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+        <div class="fw-semibold">한 마켓씩 순서대로 연결하기</div>
+        <button type="button" class="btn btn-ghost btn-sm" id="mcToggleAll">전체 보기</button>
+      </div>
+      <div id="mcStepper" class="d-flex flex-wrap gap-2"></div>
+      <div class="small text-muted mt-2">연결을 마치면 ✓ 로 자동 체크돼요. 천천히 하나씩 하면 됩니다.</div>
+    </div>
+  </div>
+  {% endif %}
+
+  <div class="row g-3" id="mcMarketRow">
     {% for m in market_statuses %}
-    <div class="{{ 'col-12' if single_market else 'col-12 col-lg-6' }}">
+    <div class="{{ 'col-12' if single_market else 'col-12 col-lg-6' }} mc-market-col" data-market="{{ m.market }}" data-label="{{ m.label }}" data-connected="{{ '1' if m.connected else '0' }}">
       <div class="card console-card h-100" data-market="{{ m.market }}">
         <div class="card-body">
           <div class="d-flex align-items-center justify-content-between gap-2 mb-2">
@@ -102,6 +116,7 @@
             {% if f.section %}
             <div class="mt-3 mb-2 pt-2 border-top">
               <div class="fw-semibold small text-primary">{{ f.section }}</div>
+              <div class="small text-muted">이 항목은 <strong>{{ m.label }}</strong>에만 필요해요. (다른 마켓엔 없어요.)</div>
             </div>
             {% endif %}
             <div class="mb-2">
@@ -143,8 +158,16 @@
     {% endfor %}
   </div>
 
+  {% if not single_market and market_statuses|length > 1 %}
+  <div class="d-flex justify-content-between align-items-center mt-3" id="mcNav">
+    <button type="button" class="btn btn-ghost btn-sm" id="mcPrev">← 이전 마켓</button>
+    <span class="small text-muted" id="mcProgress"></span>
+    <button type="button" class="btn btn-cta btn-sm" id="mcNext">다음 마켓 →</button>
+  </div>
+  {% endif %}
+
   <p class="text-muted small mt-3 mb-0">
-    각 키 발급 방법은 <code>docs/operations/LIVE_VERIFICATION_GUIDE.md</code> 를 참고하세요.
+    어려운 용어는 옆의 <span class="pc-help" data-bs-toggle="tooltip" data-bs-title="물음표에 마우스를 올리면 쉬운 설명이 나와요.">?</span> 에 설명이 있어요. 키 발급은 각 마켓의 <strong>발급 페이지 열기</strong> 버튼을 누르세요.
   </p>
 </section>
 {% endblock %}
@@ -265,5 +288,42 @@ document.querySelectorAll('.market-connect-form').forEach(form => {
     });
   }
 });
+
+// v14: 한 마켓씩 순차 진행(연결되면 ✓ 자동 체크). '전체 보기'로 그리드 전환.
+(function () {
+  const cols = Array.from(document.querySelectorAll('.mc-market-col'));
+  const stepper = document.getElementById('mcStepper');
+  if (!cols.length || !stepper) return;
+  let showAll = false;
+  // 시작 위치 = 첫 '미연결' 마켓(전부 연결이면 0)
+  let cur = cols.findIndex(c => c.dataset.connected !== '1');
+  if (cur < 0) cur = 0;
+
+  function renderStepper() {
+    stepper.innerHTML = cols.map((c, i) => {
+      const on = c.dataset.connected === '1';
+      const active = i === cur && !showAll;
+      const cls = active ? 'btn-primary' : (on ? 'btn-outline-success' : 'btn-outline-secondary');
+      const mark = on ? '✓ ' : (i + 1) + '. ';
+      return `<button type="button" class="btn btn-sm ${cls} mc-step" data-i="${i}">${mark}${c.dataset.label}</button>`;
+    }).join('');
+    stepper.querySelectorAll('.mc-step').forEach(b => b.addEventListener('click', () => { showAll = false; cur = parseInt(b.dataset.i, 10); apply(); }));
+  }
+  function apply() {
+    cols.forEach((c, i) => { c.style.display = (showAll || i === cur) ? '' : 'none'; });
+    const nav = document.getElementById('mcNav');
+    if (nav) nav.style.display = showAll ? 'none' : '';
+    const prog = document.getElementById('mcProgress');
+    if (prog) prog.textContent = `${cur + 1} / ${cols.length} 마켓`;
+    const prev = document.getElementById('mcPrev'); if (prev) prev.disabled = cur <= 0;
+    const next = document.getElementById('mcNext'); if (next) next.disabled = cur >= cols.length - 1;
+    const tgl = document.getElementById('mcToggleAll'); if (tgl) tgl.textContent = showAll ? '한 마켓씩 보기' : '전체 보기';
+    renderStepper();
+  }
+  const prevB = document.getElementById('mcPrev'); if (prevB) prevB.addEventListener('click', () => { if (cur > 0) { cur--; apply(); } });
+  const nextB = document.getElementById('mcNext'); if (nextB) nextB.addEventListener('click', () => { if (cur < cols.length - 1) { cur++; apply(); } });
+  const tglB = document.getElementById('mcToggleAll'); if (tglB) tglB.addEventListener('click', () => { showAll = !showAll; apply(); });
+  apply();
+})();
 </script>
 {% endblock %}

--- a/src/seller_console/templates/onboarding_wizard.html
+++ b/src/seller_console/templates/onboarding_wizard.html
@@ -62,11 +62,10 @@ const STEPS = [
     lead: '구매대행은 보통 사업자등록 → 통신판매업 신고가 필요해요. 가이드를 보고 천천히 준비하세요.',
     primary: { label: '사업자 가이드 보기', cls: 'btn-primary', href: '/seller/guide/business' },
     secondary: { label: '나중에 · 다음', cls: 'btn-ghost', act: 'next' } },
-  { key: 'google', title: '구글로 시작하기', emoji: '🔑',
-    lead: '구글 계정으로 1초 만에 로그인하세요. 내 수집·마켓·주문이 안전하게 개인화됩니다.',
-    primary: LOGGED_IN
-      ? { label: '로그인 완료 · 다음', cls: 'btn-primary', act: 'next' }
-      : { label: '구글로 시작', cls: 'btn-cta', href: '/auth/google/start?next=/seller/start' },
+  { key: 'google', title: '소셜 계정으로 시작', emoji: '🔑',
+    lead: '구글·네이버·카카오·애플 중 편한 걸로 1초 로그인하세요. 내 수집·마켓·주문이 안전하게 개인화됩니다.',
+    social: !LOGGED_IN,
+    primary: LOGGED_IN ? { label: '로그인 완료 · 다음', cls: 'btn-primary', act: 'next' } : null,
     autoDone: LOGGED_IN },
   { key: 'market', title: '마켓 연동하기', emoji: '🛍️',
     lead: '쿠팡·스마트스토어·11번가 등 판매할 마켓을 연결하세요. 키를 붙여넣고 연결 테스트까지 한 번에. <b>연결을 마치면 이 단계가 자동으로 체크됩니다.</b>',
@@ -107,13 +106,27 @@ function btnHtml(b, role) {
   return `<button type="button" class="btn ${b.cls} ${role}" data-role="${role}">${b.label}</button>`;
 }
 
+// v14: 소셜 로그인 4종(구글·네이버·카카오·애플) — 각 실제 /auth/<provider>/start 로 동작.
+const SOCIAL = [
+  { href: '/auth/google/start?next=/seller/start', label: '구글로 시작', style: 'background:#fff;color:#222;border:1px solid #ddd;' },
+  { href: '/auth/naver/start?next=/seller/start',  label: '네이버로 시작', style: 'background:#03C75A;color:#fff;border:none;' },
+  { href: '/auth/kakao/start?next=/seller/start',  label: '카카오로 시작', style: 'background:#FEE500;color:#191600;border:none;' },
+  { href: '/auth/apple/start?next=/seller/start',  label: 'Apple로 시작', style: 'background:#000;color:#fff;border:none;' },
+];
+function socialHtml() {
+  return '<div class="d-grid gap-2 mx-auto" style="max-width:320px">' +
+    SOCIAL.map(s => `<a class="btn" style="${s.style}" href="${s.href}">${s.label}</a>`).join('') +
+    '</div>';
+}
+
 function renderPanel() {
   const s = STEPS[cur];
   document.getElementById('panel').innerHTML =
     `<div class="ob-emoji">${s.emoji}</div>
      <h1>${s.title}</h1>
      <p class="lead">${s.lead}</p>
-     <div class="ob-actions d-flex flex-wrap gap-2 justify-content-center">
+     ${s.social ? socialHtml() : ''}
+     <div class="ob-actions d-flex flex-wrap gap-2 justify-content-center mt-2">
        ${btnHtml(s.primary, 'primary')}
        ${btnHtml(s.secondary, 'secondary')}
      </div>`;

--- a/tests/test_ext_install_wizard_v14.py
+++ b/tests/test_ext_install_wizard_v14.py
@@ -1,0 +1,48 @@
+"""tests/test_ext_install_wizard_v14.py — v14 확장 설치 단계화 + 복사 동작 + 퍼센티 제거 가드."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+EXT = Path("src/seller_console/templates/extension_install.html").read_text(encoding="utf-8")
+
+
+def test_install_is_stepwise_one_button():
+    assert "STEPS" in EXT and "extPrimary" in EXT          # 단계별 + 단계당 버튼 1개
+    assert "extPrev" in EXT and "extNext" in EXT           # 이전/다음
+    assert "extProgressBar" in EXT                         # 진행 표시
+
+
+def test_copy_button_real_clipboard():
+    assert "navigator.clipboard.writeText" in EXT
+    assert 'act === "copy"' in EXT and "pcToast" in EXT    # 복사 후 실제 피드백
+
+
+def test_no_percenty_in_user_templates():
+    tpl_dir = Path("src/seller_console/templates")
+    for p in tpl_dir.glob("*.html"):
+        assert "퍼센티" not in p.read_text(encoding="utf-8"), f"{p.name}에 '퍼센티' 노출 잔존"
+
+
+def test_no_dev_endpoint_note():
+    mc = Path("src/seller_console/templates/manual_collect.html").read_text(encoding="utf-8")
+    assert "기존 수집기 엔드포인트" not in mc                # 개발 노트 제거
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("SELLER_CONSOLE_AUTH", "0")
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_extension_page_renders(client):
+    html = client.get("/seller/extension").get_data(as_text=True)
+    assert "설치 단계" in html and "압축해제된" in html and "chrome://extensions" in html

--- a/tests/test_for_beginners_v14.py
+++ b/tests/test_for_beginners_v14.py
@@ -1,0 +1,39 @@
+"""tests/test_for_beginners_v14.py — v14 For Beginners 고정 버튼 + 친절 카피 가드."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+BASE = Path("src/seller_console/templates/_base.html").read_text(encoding="utf-8")
+
+
+def test_for_beginners_fixed_button_with_toggle():
+    assert "fbBtn" in BASE and "처음이신가요" in BASE         # 큰 진입 버튼
+    assert "position:fixed" in BASE                          # 모든 페이지 고정
+    assert "fbHide" in BASE and "fbReopen" in BASE           # 바로 밑 on/off
+    assert "kgp_fb_hidden" in BASE                           # 상태 기억(localStorage)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("SELLER_CONSOLE_AUTH", "0")
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_fixed_button_on_every_page(client):
+    for path in ["/seller/dashboard", "/seller/collect", "/seller/markets", "/seller/orders"]:
+        html = client.get(path).get_data(as_text=True)
+        assert "fbBtn" in html, f"{path}에 For Beginners 고정 버튼 없음"
+
+
+def test_collect_has_friendly_explainer(client):
+    html = client.get("/seller/collect").get_data(as_text=True)
+    assert "상품 수집이란?" in html                           # 원숭이도 이해 친절 카피

--- a/tests/test_market_connect_stepper_v14.py
+++ b/tests/test_market_connect_stepper_v14.py
@@ -1,0 +1,43 @@
+"""tests/test_market_connect_stepper_v14.py — v14 마켓 연동 순차 스테퍼 + 쿠팡 스코프 가드."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+HTML = Path("src/seller_console/templates/markets_connect.html").read_text(encoding="utf-8")
+
+
+def test_sequential_stepper_present():
+    assert "mcStepper" in HTML
+    assert "한 마켓씩" in HTML
+    assert "전체 보기" in HTML
+    assert "mc-market-col" in HTML
+    assert 'data-connected="{{' in HTML            # 연결 상태로 자동 체크
+
+
+def test_section_scoped_to_market():
+    # 쿠팡 출고지 등 섹션이 '해당 마켓에만 필요'로 스코프 명시
+    assert "이 항목은" in HTML and "에만 필요해요" in HTML
+
+
+def test_dev_doc_note_removed():
+    assert "LIVE_VERIFICATION_GUIDE" not in HTML    # 개발 문서 경로 노출 제거
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("SELLER_CONSOLE_AUTH", "0")
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_connect_page_renders(client):
+    html = client.get("/seller/markets/connect").get_data(as_text=True)
+    assert html.count('class="') > 0 and "mcStepper" in html

--- a/tests/test_social_login_v14.py
+++ b/tests/test_social_login_v14.py
@@ -1,0 +1,58 @@
+"""tests/test_social_login_v14.py — v14 소셜 로그인 4종(구글·네이버·카카오·애플) 가드."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_apple_provider_honest_config(monkeypatch):
+    for k in ("APPLE_CLIENT_ID", "APPLE_TEAM_ID", "APPLE_KEY_ID", "APPLE_PRIVATE_KEY", "APPLE_CLIENT_SECRET"):
+        monkeypatch.delenv(k, raising=False)
+    from src.auth.providers.apple import AppleProvider
+    assert AppleProvider().is_configured is False        # 키 없으면 비활성(가짜 활성 금지)
+    monkeypatch.setenv("APPLE_CLIENT_ID", "com.kohgane.web")
+    monkeypatch.setenv("APPLE_TEAM_ID", "TEAM123")
+    monkeypatch.setenv("APPLE_KEY_ID", "KEY123")
+    monkeypatch.setenv("APPLE_PRIVATE_KEY", "-----BEGIN PRIVATE KEY-----\\nX\\n-----END PRIVATE KEY-----")
+    assert AppleProvider().is_configured is True
+
+
+def test_apple_authorize_url_form_post(monkeypatch):
+    monkeypatch.setenv("APPLE_CLIENT_ID", "com.kohgane.web")
+    from src.auth.providers.apple import AppleProvider
+    url = AppleProvider().get_authorize_url("st", "https://x/auth/apple/callback")
+    assert "appleid.apple.com/auth/authorize" in url
+    assert "response_mode=form_post" in url
+
+
+def test_apple_in_provider_registry():
+    from src.auth.views import _get_provider, _OAUTH_PROVIDERS
+    assert "apple" in _OAUTH_PROVIDERS
+    assert _get_provider("apple") is not None
+
+
+def test_login_page_has_four_social():
+    html = Path("src/auth/templates/auth/login.html").read_text(encoding="utf-8")
+    assert "/auth/google/start" in html
+    assert "/auth/naver/start" in html
+    assert "/auth/kakao/start" in html
+    assert "/auth/apple/start" in html
+    assert "apple_status" in html
+
+
+def test_onboarding_has_four_social():
+    wiz = Path("src/seller_console/templates/onboarding_wizard.html").read_text(encoding="utf-8")
+    for p in ("/auth/google/start", "/auth/naver/start", "/auth/kakao/start", "/auth/apple/start"):
+        assert p in wiz
+
+
+def test_callback_accepts_post_for_apple():
+    # Apple form_post(POST) 대응 — 콜백 라우트가 POST 허용
+    from src.order_webhook import app
+    rules = [r for r in app.url_map.iter_rules() if "/auth/<provider>/callback" in str(r)]
+    assert rules and "POST" in rules[0].methods


### PR DESCRIPTION
v14 **step 2~4** 묶음(브리프 나열순, 거의 전부).

## ① 소셜 로그인 4종 (구글·네이버·카카오·애플)
신설 `apple.py`(ES256 JWT, form_post, id_token; 키 미설정 시 비활성). views 4 provider + 콜백 GET+POST. login·온보딩 4버튼.

## ② 마켓 연동 순차 스테퍼
한 마켓씩 순차(연결되면 ✓ 자동 체크, 이전/다음, ‘전체 보기’ 토글). 쿠팡 출고지 등 섹션 *“이 항목은 {마켓}에만 필요”* 스코프 명시. 개발 문서경로 제거.

## ③ 확장 설치 단계 위저드 + 복사 동작
키노트식 단계 위저드(한 화면=한 단계, **단계당 버튼 1개**, 이전/다음, 진행바). **복사 버튼 실동작**(clipboard + pcToast).

## ④ For Beginners 고정 버튼 + 친절 카피
모든 페이지 우하단 **‘✨ 처음이신가요?’ 큰 알약 고정** + 바로 밑 작은 **on/off**(상태 기억, 숨기면 작은 ✨ 재오픈). ‘**상품 수집이란?**’ 한 줄 풀이 + ‘?’.

## ⑤ "퍼센티" 전역 제거
사용자 카피·WooCommerce 운송장 노트에서 제거. (`channels/percenty.py`는 실제 퍼센티 채널 연동이라 유지.) ‘기존 수집기 엔드포인트’ 개발노트 → 사용자 카피.

## 테스트
- 신규 가드 4종(`test_social_login_v14`·`test_market_connect_stepper_v14`·`test_ext_install_wizard_v14`·`test_for_beginners_v14`) = 19 케이스. 전체 `pytest` **10183 passed**.

> 남은 v14: 기본 마켓/소싱처 사이트 **로고 아이콘** 표시(현재 이모지) — 후속 소형 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)