### PR TITLE
feat(v15 P1): 디폴트 마켓 확장 + 모바일 양대 스토어 패키징(국내용) + 토큰 확인 (Phase 285·286)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,15 @@
   options DEFAULT_SOURCES 동기화 + manual_collect 원클릭 행(파비콘). 어댑터 불필요(universal_scraper 휴리스틱 폴백).
   manifest 1.5.3→1.5.4. ※Taoworld·OPLE는 도메인 미검증이라 미추가(날조 금지) — 오너 정확한 URL 주면 추가.
   니치/브랜드(요시다카반·ZOZO·VVIC·SHEIN)는 유저 추가 전용 유지. 가드 test_default_markets_v15(3). 전체 10199 passed.
-- ⏳ 남은 v15: i18n 영어1급 · 디자인 토큰 단일소스 · 모바일 양대 스토어 패키징.
+- ✅ **디자인 토큰 단일소스(이미 충족):** src/static/app.css :root에 75개 --pc-* 변수(색·간격·라운드·그림자·포커스·폰트,
+  Phase 234). 추가 작업 불필요.
+- ✅ **모바일 양대 스토어 패키징 경로(Phase 286 — 오너 "국내용 먼저"):** 도메인 루트 `/.well-known/assetlinks.json`
+  (구글 플레이 TWA Digital Asset Links — env TWA_PACKAGE_NAME+TWA_SHA256_FINGERPRINTS, 미설정 시 [] 정직) +
+  `/.well-known/apple-app-site-association`(iOS Universal Links — env IOS_APP_ID, 미설정 시 빈 details). 신설 mobile/
+  (README 한국어 단계별 가이드: PWABuilder/Bubblewrap TWA→Play, Capacitor→App Store + twa-manifest.json·capacitor.config.json).
+  PWA 매니페스트는 이미 스토어 요건 충족(아이콘192·512 maskable·standalone·share_target·shortcuts). 가드
+  test_mobile_store_packaging_v15(4). 전체 10203 passed.
+- ⏳ 남은 v15: i18n 영어 1급(글로벌 — 국내용 다음, 오너 지시 순서). 디자인토큰은 이미 충족.
 - ⏳ P1: For Beginners 크게·고정·on/off(v14 완료, 재확인) · 다크 스테퍼 단계별 완료표시(실제기준) · 로고 클릭→대시보드 ·
   소셜4종(v14 완료) · 디폴트 마켓 추가(Taoworld·iHerb·TEMU·OPLE·Rakuten Fashion…+아이콘, 니치는 유저추가) ·
   i18n 영어1급 · 디자인토큰 단일소스 · 모바일 양대 스토어 패키징.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,15 @@
 - ✅ **P0-3 확장설치 '고가수집기'(Phase 284):** 다운로드 파일명 kohgane-collector→**gogasujipgi-v{ver}.zip**, 설치 페이지
   제목·단계 '고가수집기'. '왜 설치/왜 토큰' 초친절 비유 카드(도우미/열쇠). 페이지당 버튼 1개(v14 유지). '기존 수집기
   엔드포인트' 문구는 v14에서 이미 제거(전 템플릿 0 확인). 가드 test_ext_install_gogasujipgi_v15(4). 전체 10196 passed.
-- ⏳ 남은 v15: For Beginners(v14완료·재확인)·다크 스테퍼 완료표시·로고클릭 홈 / 디폴트 마켓 확장 / i18n·토큰·스토어.
+- ✅ **P1 로고클릭 홈·다크 스테퍼 완료표시(이미 v14 충족, 재확인):** 사이드바/탑바 브랜드는 이미 `/seller/`(→대시보드)
+  링크. 온보딩 스테퍼는 renderStepper가 done[s.key]면 ✓(bi-check-lg)·.ob-step.done 녹색, done은 실제상태(autoDone:
+  LOGGED_IN / MARKETS>0)로만 채움(가짜 체크 없음). → 추가 작업 불필요.
+- ✅ **P1 디폴트 마켓 확장(Phase 285):** 확장 디폴트 소싱처에 대형 크로스보더 마켓 추가 — 아이허브(iherb.com)·DHgate·
+  큐텐(qoo10)·메루카리(mercari.com)·라쿠텐(rakuten.co.jp, Rakuten Fashion 포함). content_script KGP_DEFAULT_SOURCES +
+  options DEFAULT_SOURCES 동기화 + manual_collect 원클릭 행(파비콘). 어댑터 불필요(universal_scraper 휴리스틱 폴백).
+  manifest 1.5.3→1.5.4. ※Taoworld·OPLE는 도메인 미검증이라 미추가(날조 금지) — 오너 정확한 URL 주면 추가.
+  니치/브랜드(요시다카반·ZOZO·VVIC·SHEIN)는 유저 추가 전용 유지. 가드 test_default_markets_v15(3). 전체 10199 passed.
+- ⏳ 남은 v15: i18n 영어1급 · 디자인 토큰 단일소스 · 모바일 양대 스토어 패키징.
 - ⏳ P1: For Beginners 크게·고정·on/off(v14 완료, 재확인) · 다크 스테퍼 단계별 완료표시(실제기준) · 로고 클릭→대시보드 ·
   소셜4종(v14 완료) · 디폴트 마켓 추가(Taoworld·iHerb·TEMU·OPLE·Rakuten Fashion…+아이콘, 니치는 유저추가) ·
   i18n 영어1급 · 디자인토큰 단일소스 · 모바일 양대 스토어 패키징.

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -432,6 +432,12 @@ const KGP_DEFAULT_SOURCES = [
   { id: "temu", label: "테무", test: (h) => /(^|\.)temu\.com$/.test(h) },
   { id: "amazon", label: "아마존", test: (h) => /(^|\.)amazon\.[a-z.]+$/.test(h) },
   { id: "aliexpress", label: "알리익스프레스", test: (h) => /(^|\.)aliexpress\.(com|us)$/.test(h) },
+  // v15: 대형 크로스보더 마켓 디폴트 확장(도메인 검증된 것만). 니치/브랜드(요시다카반 등)는 유저 추가 전용.
+  { id: "iherb", label: "아이허브", test: (h) => /(^|\.)iherb\.com$/.test(h) },
+  { id: "dhgate", label: "DHgate", test: (h) => /(^|\.)dhgate\.com$/.test(h) },
+  { id: "qoo10", label: "큐텐", test: (h) => /(^|\.)qoo10\.[a-z.]+$/.test(h) },
+  { id: "mercari", label: "메루카리", test: (h) => /(^|\.)mercari\.com$/.test(h) },
+  { id: "rakuten", label: "라쿠텐(Rakuten Fashion 포함)", test: (h) => /(^|\.)rakuten\.(co\.jp|com)$/.test(h) },
 ];
 let KGP_SOURCES = null;   // chrome.storage의 사용자 설정 { defaults:{id:bool}, custom:[{host,on}] }
 

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "코고가네 수집기",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "지정 소싱처(타오바오·아마존 등)에서 한 클릭에 코고가네로 수집 (인페이지 수집 + 리스팅 다중 선택 수집 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/extensions/chrome-collector/options.js
+++ b/extensions/chrome-collector/options.js
@@ -19,6 +19,11 @@ const DEFAULT_SOURCES = [
   { id: "temu", label: "테무", host: "temu.com" },
   { id: "amazon", label: "아마존", host: "amazon.*" },
   { id: "aliexpress", label: "알리익스프레스", host: "aliexpress.com" },
+  { id: "iherb", label: "아이허브", host: "iherb.com" },
+  { id: "dhgate", label: "DHgate", host: "dhgate.com" },
+  { id: "qoo10", label: "큐텐", host: "qoo10.com" },
+  { id: "mercari", label: "메루카리", host: "mercari.com" },
+  { id: "rakuten", label: "라쿠텐(Rakuten Fashion 포함)", host: "rakuten.co.jp" },
 ];
 
 // ---- 서버/토큰 (chrome.storage.sync) ----

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,66 @@
+# 코고가네 모바일 양대 스토어 패키징 (v15)
+
+코고가네는 **PWA(설치형 웹앱)**가 이미 동작합니다(`/seller/static/manifest.webmanifest` + 서비스워커 + 공유 수집).
+이 폴더는 그 PWA를 **구글 플레이**·**앱 스토어**에 올리기 위한 **패키징 경로(설정/스크립트)**를 모아둡니다.
+앱은 우리 서버(HTTPS)를 감싸는 얇은 네이티브 셸이라, 웹을 고치면 앱도 같이 갱신됩니다.
+
+> 전제: 사이트가 HTTPS로 서비스되고, manifest/아이콘(192·512 maskable)/서비스워커가 정상이어야 합니다(현재 충족).
+
+---
+
+## 1) 구글 플레이 — TWA (Trusted Web Activity)
+
+가장 쉬운 길은 **PWABuilder** 또는 **Bubblewrap**으로 TWA 앱을 만드는 것입니다.
+
+### PWABuilder (웹, 가장 쉬움)
+1. https://www.pwabuilder.com 접속 → 사이트 주소(`https://<도메인>`) 입력 → **Package For Stores → Android**.
+2. 패키지 옵션은 `mobile/twa-manifest.json` 값을 참고해 채웁니다(패키지명/색/시작 URL).
+3. 생성된 `.aab`(앱 번들)와 **서명 키의 SHA-256 지문**을 받습니다.
+4. 그 지문을 서버 환경변수에 넣습니다(아래 §3) → `/.well-known/assetlinks.json`이 자동으로 검증값을 내보냅니다.
+5. Google Play Console에 `.aab` 업로드 → 심사 제출.
+
+### Bubblewrap (CLI)
+```bash
+npm i -g @bubblewrap/cli
+bubblewrap init --manifest https://<도메인>/seller/static/manifest.webmanifest
+# 패키지명/색은 mobile/twa-manifest.json 참고
+bubblewrap build      # app-release-bundle.aab + 서명지문(SHA-256)
+```
+빌드가 출력한 SHA-256 지문을 §3 환경변수에 등록하세요.
+
+---
+
+## 2) 앱 스토어(iOS) — Capacitor 셸
+
+iOS는 PWA를 스토어에 직접 못 올리므로 **Capacitor**로 웹뷰 셸을 만들어 우리 사이트를 띄웁니다.
+`mobile/capacitor.config.json`이 그 설정(서버 URL을 가리킴)입니다. **Xcode가 설치된 macOS**가 필요합니다.
+
+```bash
+npm i -g @capacitor/cli
+# mobile/ 에서:
+npm init -y && npm i @capacitor/core @capacitor/ios
+npx cap add ios
+npx cap copy
+npx cap open ios      # Xcode 열림 → 서명(Apple Developer 계정) → Archive → App Store Connect 업로드
+```
+- Universal Links를 쓰려면 `IOS_APP_ID`(=`TEAMID.com.bundle.id`)를 §3에 넣으면
+  `/.well-known/apple-app-site-association`이 자동으로 채워집니다.
+
+---
+
+## 3) 서버 환경변수 (오너 액션 — 스토어 연동 검증)
+
+| 환경변수 | 용도 | 예 |
+|---|---|---|
+| `TWA_PACKAGE_NAME` | 플레이 TWA 패키지명 | `com.kohgane.collector` |
+| `TWA_SHA256_FINGERPRINTS` | TWA 서명 SHA-256(콤마로 다중) | `AA:BB:...:FF` |
+| `IOS_APP_ID` | iOS 앱 식별자(TeamID.BundleID) | `ABCDE12345.com.kohgane.app` |
+
+미설정 시 `/.well-known/assetlinks.json`은 `[]`, AASA는 빈 `details`로 응답합니다(**가짜 연동 금지** — 정직).
+
+---
+
+## 참고
+- 웹 매니페스트: `src/seller_console/static/manifest.webmanifest` (name/short_name/아이콘/share_target/shortcuts 충족).
+- 앱은 웹을 감싸는 셸 → 기능 업데이트는 **웹 배포만으로** 반영(스토어 재심사 최소화).
+- 국내(한국) 우선: 기본 언어 `ko`. 글로벌(영문) i18n은 후속.

--- a/mobile/capacitor.config.json
+++ b/mobile/capacitor.config.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "코고가네 iOS(App Store) Capacitor 셸 설정. server.url이 우리 HTTPS 사이트를 가리켜 웹앱을 그대로 띄운다. 도메인은 배포에 맞게 교체.",
+  "appId": "com.kohgane.app",
+  "appName": "코고가네",
+  "webDir": "www",
+  "server": {
+    "url": "https://kohganepercentiii.com/seller/m",
+    "cleartext": false
+  },
+  "ios": {
+    "contentInset": "automatic"
+  },
+  "backgroundColor": "#1a1714"
+}

--- a/mobile/twa-manifest.json
+++ b/mobile/twa-manifest.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "코고가네 구글 플레이 TWA 패키징 설정 템플릿(Bubblewrap/PWABuilder 참고용). 실제 패키지명/지문은 빌드 시 확정.",
+  "packageId": "com.kohgane.collector",
+  "host": "kohganepercentiii.com",
+  "name": "코고가네",
+  "launcherName": "코고가네",
+  "display": "standalone",
+  "themeColor": "#1a1714",
+  "navigationColor": "#1a1714",
+  "backgroundColor": "#1a1714",
+  "startUrl": "/seller/m",
+  "iconUrl": "https://kohganepercentiii.com/seller/static/icon-512.png",
+  "maskableIconUrl": "https://kohganepercentiii.com/seller/static/icon-512.png",
+  "webManifestUrl": "https://kohganepercentiii.com/seller/static/manifest.webmanifest",
+  "shareTarget": {
+    "action": "/seller/collect/quick",
+    "method": "GET",
+    "params": { "title": "title", "text": "text", "url": "u" }
+  },
+  "fallbackType": "customtabs",
+  "defaultLocale": "ko"
+}

--- a/src/order_webhook.py
+++ b/src/order_webhook.py
@@ -1241,6 +1241,40 @@ def i18n_dismiss():
     return resp
 
 
+# ---------------------------------------------------------------------------
+# v15 모바일 양대 스토어 패키징 — TWA(구글 플레이) Digital Asset Links + iOS 앱 연동(AASA).
+# 둘 다 도메인 루트의 /.well-known/ 에 있어야 한다. env 미설정 시 가짜 연동 대신 '빈' 응답(정직).
+#   - 구글 플레이(TWA): TWA_PACKAGE_NAME + TWA_SHA256_FINGERPRINTS(콤마구분)
+#   - App Store(iOS):  IOS_APP_ID = "TEAMID.com.bundle.id"
+# ---------------------------------------------------------------------------
+@app.get('/.well-known/assetlinks.json')
+def well_known_assetlinks():
+    """Android TWA(코고가네 플레이스토어 앱) ↔ 웹사이트 연동 검증용 Digital Asset Links."""
+    pkg = os.getenv("TWA_PACKAGE_NAME", "").strip()
+    fps = [f.strip() for f in os.getenv("TWA_SHA256_FINGERPRINTS", "").split(",") if f.strip()]
+    statements = []
+    if pkg and fps:
+        statements.append({
+            "relation": ["delegate_permission/common.handle_all_urls"],
+            "target": {
+                "namespace": "android_app",
+                "package_name": pkg,
+                "sha256_cert_fingerprints": fps,
+            },
+        })
+    # 미설정 시 빈 배열(가짜 연동 금지). 설정하면 TWA 검증 통과.
+    return jsonify(statements)
+
+
+@app.get('/.well-known/apple-app-site-association')
+def well_known_aasa():
+    """iOS(코고가네 App Store 앱) Universal Links 연동(apple-app-site-association). 확장자 없음·application/json."""
+    app_id = os.getenv("IOS_APP_ID", "").strip()
+    details = [{"appID": app_id, "paths": ["/seller/*", "/auth/*"]}] if app_id else []
+    payload = {"applinks": {"apps": [], "details": details}}
+    return jsonify(payload)
+
+
 @app.get('/')
 def root():
     """루트 라우트 — ROOT_REDIRECT 환경변수로 동작 제어 (Phase 132).

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1091,6 +1091,12 @@ def collect():
         {"name": "1688", "url": "https://www.1688.com", "domain": "1688.com"},
         {"name": "테무", "url": "https://www.temu.com", "domain": "temu.com"},
         {"name": "알리익스프레스", "url": "https://www.aliexpress.com", "domain": "aliexpress.com"},
+        # v15: 대형 크로스보더 마켓 디폴트 확장(도메인 검증된 것만).
+        {"name": "아이허브", "url": "https://www.iherb.com", "domain": "iherb.com"},
+        {"name": "DHgate", "url": "https://www.dhgate.com", "domain": "dhgate.com"},
+        {"name": "큐텐", "url": "https://www.qoo10.com", "domain": "qoo10.com"},
+        {"name": "메루카리", "url": "https://jp.mercari.com", "domain": "mercari.com"},
+        {"name": "라쿠텐", "url": "https://www.rakuten.co.jp", "domain": "rakuten.co.jp"},
         # 아마존은 국가별 사이트가 달라 드롭다운으로 선택
         {"name": "아마존", "domain": "amazon.com", "countries": [
             {"name": "미국 (.com)", "url": "https://www.amazon.com"},

--- a/tests/test_collect_button_zoom_v15.py
+++ b/tests/test_collect_button_zoom_v15.py
@@ -27,4 +27,7 @@ def test_sources_show_favicon():
 
 def test_manifest_version_bumped():
     mf = Path("extensions/chrome-collector/manifest.json").read_text(encoding="utf-8")
-    assert '"version": "1.5.3"' in mf
+    # 1.5.3 이상으로 bump됨(v15에서 누적 증가)
+    import re
+    m = re.search(r'"version":\s*"1\.5\.(\d+)"', mf)
+    assert m and int(m.group(1)) >= 3

--- a/tests/test_default_markets_v15.py
+++ b/tests/test_default_markets_v15.py
@@ -1,0 +1,43 @@
+"""tests/test_default_markets_v15.py — v15 P1 디폴트 마켓 확장(대형 크로스보더) 가드."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+CS = Path("extensions/chrome-collector/content_script.js").read_text(encoding="utf-8")
+OPT = Path("extensions/chrome-collector/options.js").read_text(encoding="utf-8")
+
+NEW = ["iherb", "dhgate", "qoo10", "mercari", "rakuten"]
+
+
+def test_content_script_and_options_sources_in_sync():
+    # 새 디폴트 소싱처가 content_script 게이팅과 options 토글 양쪽에 모두 존재
+    for sid in NEW:
+        assert sid in CS, f"content_script KGP_DEFAULT_SOURCES에 {sid} 없음"
+        assert sid in OPT, f"options DEFAULT_SOURCES에 {sid} 없음"
+
+
+def test_niche_brands_still_user_add_only():
+    # 브랜드·니치 도메인은 디폴트 게이팅에 없음(유저 추가 전용) — 도메인 기준으로 정확히 확인
+    for niche_dom in ("yoshidakaban.com", "vvic.com", "zozo.jp", "shein.com"):
+        assert niche_dom not in CS
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("SELLER_CONSOLE_AUTH", "0")
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_oneclick_row_has_new_markets_with_icons(client):
+    html = client.get("/seller/collect").get_data(as_text=True)
+    for dom in ("iherb.com", "dhgate.com", "qoo10.com", "mercari.com", "rakuten.co.jp"):
+        assert "domain=" + dom in html, f"원클릭 행에 {dom} 파비콘 없음"

--- a/tests/test_mobile_store_packaging_v15.py
+++ b/tests/test_mobile_store_packaging_v15.py
@@ -1,0 +1,59 @@
+"""tests/test_mobile_store_packaging_v15.py — v15 모바일 양대 스토어 패키징 경로 가드."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client():
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_assetlinks_empty_when_unset(client, monkeypatch):
+    monkeypatch.delenv("TWA_PACKAGE_NAME", raising=False)
+    monkeypatch.delenv("TWA_SHA256_FINGERPRINTS", raising=False)
+    r = client.get("/.well-known/assetlinks.json")
+    assert r.status_code == 200
+    assert r.content_type.startswith("application/json")
+    assert json.loads(r.get_data(as_text=True)) == []     # 가짜 연동 금지(빈 배열)
+
+
+def test_assetlinks_populated_when_env_set(client, monkeypatch):
+    monkeypatch.setenv("TWA_PACKAGE_NAME", "com.kohgane.collector")
+    monkeypatch.setenv("TWA_SHA256_FINGERPRINTS", "AA:BB:CC, DD:EE:FF")
+    data = json.loads(client.get("/.well-known/assetlinks.json").get_data(as_text=True))
+    assert len(data) == 1
+    tgt = data[0]["target"]
+    assert tgt["package_name"] == "com.kohgane.collector"
+    assert tgt["sha256_cert_fingerprints"] == ["AA:BB:CC", "DD:EE:FF"]
+
+
+def test_aasa_route(client, monkeypatch):
+    monkeypatch.delenv("IOS_APP_ID", raising=False)
+    r = client.get("/.well-known/apple-app-site-association")
+    assert r.status_code == 200
+    assert r.content_type.startswith("application/json")
+    body = json.loads(r.get_data(as_text=True))
+    assert body["applinks"]["details"] == []
+    monkeypatch.setenv("IOS_APP_ID", "ABCDE12345.com.kohgane.app")
+    body2 = json.loads(client.get("/.well-known/apple-app-site-association").get_data(as_text=True))
+    assert body2["applinks"]["details"][0]["appID"] == "ABCDE12345.com.kohgane.app"
+
+
+def test_packaging_configs_exist():
+    base = Path("mobile")
+    assert (base / "README.md").exists()
+    twa = json.loads((base / "twa-manifest.json").read_text(encoding="utf-8"))
+    assert twa["webManifestUrl"].endswith("manifest.webmanifest")
+    cap = json.loads((base / "capacitor.config.json").read_text(encoding="utf-8"))
+    assert cap["server"]["url"].startswith("https://")


### PR DESCRIPTION
v15 P1 — 디폴트 마켓 확장 + (국내용 먼저) 모바일 스토어 패키징 + 디자인 토큰/로고/스테퍼 재확인.

## ① 디폴트 마켓 확장 (Phase 285)
확장 디폴트 소싱처에 **대형 크로스보더 마켓** 추가(`content_script`↔`options` 동기화 + 원클릭 행 파비콘): **아이허브·DHgate·큐텐·메루카리·라쿠텐**(Rakuten Fashion 포함). 어댑터 불필요(휴리스틱 폴백). manifest `1.5.3→1.5.4`.
- 정직성: **Taoworld·OPLE는 도메인 미검증이라 미추가**(URL 주시면 추가). 니치/브랜드(요시다카반·ZOZO·VVIC·SHEIN)는 유저 추가 전용.

## ② 모바일 양대 스토어 패키징 — 국내용 먼저 (Phase 286)
- **구글 플레이(TWA)**: `/.well-known/assetlinks.json` 라우트 — env `TWA_PACKAGE_NAME`+`TWA_SHA256_FINGERPRINTS` 설정 시 검증 JSON, **미설정 시 `[]`**(가짜 연동 금지).
- **앱 스토어(iOS)**: `/.well-known/apple-app-site-association` — env `IOS_APP_ID` 설정 시 채움.
- 신설 **`mobile/`**: 한국어 단계별 README(PWABuilder/Bubblewrap→Play, Capacitor→App Store, 오너 env 표) + `twa-manifest.json` + `capacitor.config.json`. PWA 매니페스트는 이미 스토어 요건 충족(아이콘 192·512 maskable·standalone·share_target·shortcuts).

## ③ 이미 충족(재확인, 변경 없음)
- **디자인 토큰 단일소스**: `src/static/app.css :root` 75개 `--pc-*` 변수(색·간격·라운드·그림자·폰트).
- **로고 클릭→홈** / **다크 스테퍼 실제완료 표시**: v14에서 충족.

## 테스트
- 신규 `test_default_markets_v15`(3) + `test_mobile_store_packaging_v15`(4). 전체 `pytest` **10203 passed**, `node --check` 통과.

> 남은 v15: **i18n 영어 1급**(글로벌 — 오너 지시 순서상 국내용 다음) — 후속 PR.

❓ **오너 확인**: Taoworld·OPLE 정확한 도메인(URL)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)