### PR TITLE
feat(v15): i18n 영어 1급 1차 — 셀러 콘솔 언어 토글 + 핵심 화면 EN/KO (Phase 287)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,12 @@
   (README 한국어 단계별 가이드: PWABuilder/Bubblewrap TWA→Play, Capacitor→App Store + twa-manifest.json·capacitor.config.json).
   PWA 매니페스트는 이미 스토어 요건 충족(아이콘192·512 maskable·standalone·share_target·shortcuts). 가드
   test_mobile_store_packaging_v15(4). 전체 10203 passed.
-- ⏳ 남은 v15: i18n 영어 1급(글로벌 — 국내용 다음, 오너 지시 순서). 디자인토큰은 이미 충족.
+- ✅ **i18n 영어 1급 1차(Phase 287):** 신설 `src/seller_console/i18n.py`(t(key,lang)+STRINGS ko/en, 누락키=키반환 정직,
+  미지원언어=ko 폴백). 컨텍스트 프로세서가 t·current_lang 주입(kgp_lang 쿠키 단일소스, 기존 /i18n/set 재사용).
+  _base.html: `<html lang>` 동적, 탑바 언어 토글(한국어/EN), For Beginners 버튼·6 핵심 내비 라벨 t()로 외부화.
+  → en 쿠키 시 핵심 화면 영어 1급 동작. 나머지 화면 문자열은 STRINGS에 ko/en 추가하며 점진 확장. 가드
+  test_i18n_seller_console_v15(3). 전체 10206 passed. → v15 큰 줄기 완료(P0·P1·국내스토어·i18n 1차).
+- ⏳ i18n 점진 확장: 대시보드/주문/마켓/온보딩 등 화면별 문자열 STRINGS에 추가(후속, 화면 단위 PR).
 - ⏳ P1: For Beginners 크게·고정·on/off(v14 완료, 재확인) · 다크 스테퍼 단계별 완료표시(실제기준) · 로고 클릭→대시보드 ·
   소셜4종(v14 완료) · 디폴트 마켓 추가(Taoworld·iHerb·TEMU·OPLE·Rakuten Fashion…+아이콘, 니치는 유저추가) ·
   i18n 영어1급 · 디자인토큰 단일소스 · 모바일 양대 스토어 패키징.

--- a/src/seller_console/i18n.py
+++ b/src/seller_console/i18n.py
@@ -1,0 +1,57 @@
+"""src/seller_console/i18n.py — 셀러 콘솔 경량 i18n (v15, 한국어 기본 + 영어 1급).
+
+원칙(오너): 국내(ko) 우선, 영어(en)도 1급으로 동작. 모든 UI 문자열을 점진적으로 외부화한다.
+- 언어 선택은 `kgp_lang` 쿠키(ko|en) — 기존 /i18n/set 라우트가 설정(단일 소스).
+- `t(key, lang)` 로 문구를 가져온다. 키 없으면 키 자체를 반환(누락이 화면에 드러나 정직).
+- 새 문자열은 STRINGS에 ko/en 쌍으로 추가 → 템플릿에서 {{ t('key') }} 로 사용.
+"""
+from __future__ import annotations
+
+SUPPORTED = ("ko", "en")
+DEFAULT_LANG = "ko"
+
+# 핵심 UI 문자열(점진 확장). ko=국내 기본, en=영어 1급.
+STRINGS: dict[str, dict[str, str]] = {
+    # 공통/내비
+    "nav.home": {"ko": "홈(대시보드)", "en": "Home (Dashboard)"},
+    "nav.collect": {"ko": "상품 수집", "en": "Collect products"},
+    "nav.history": {"ko": "수집 이력", "en": "Collection history"},
+    "nav.orders": {"ko": "주문 관리", "en": "Orders"},
+    "nav.markets": {"ko": "마켓 연동", "en": "Connect markets"},
+    "nav.help": {"ko": "도움말·가이드", "en": "Help & guides"},
+    "nav.advanced": {"ko": "고급 기능 더보기", "en": "More (advanced)"},
+    # 공통 액션
+    "action.save": {"ko": "저장", "en": "Save"},
+    "action.cancel": {"ko": "취소", "en": "Cancel"},
+    "action.confirm": {"ko": "확인", "en": "Confirm"},
+    "action.next": {"ko": "다음", "en": "Next"},
+    "action.prev": {"ko": "이전", "en": "Back"},
+    "action.logout": {"ko": "로그아웃", "en": "Log out"},
+    # For Beginners 고정 버튼
+    "fb.cta": {"ko": "✨ 처음이신가요?", "en": "✨ New here?"},
+    "fb.hide": {"ko": "가이드 버튼 숨기기", "en": "Hide guide button"},
+    # 언어 토글
+    "lang.korean": {"ko": "한국어", "en": "한국어"},
+    "lang.english": {"ko": "English", "en": "English"},
+    "lang.label": {"ko": "언어", "en": "Language"},
+    # 수집 페이지
+    "collect.title": {"ko": "상품 수집 → 등록", "en": "Collect → List products"},
+    "collect.what_is": {
+        "ko": "상품 수집이란?",
+        "en": "What is product collection?",
+    },
+}
+
+
+def normalize_lang(lang: str | None) -> str:
+    lang = (lang or "").strip().lower()
+    return lang if lang in SUPPORTED else DEFAULT_LANG
+
+
+def t(key: str, lang: str | None = None) -> str:
+    """키에 해당하는 현지화 문구. 키 미존재 시 키를 그대로 반환(누락이 보이게 — 정직)."""
+    lng = normalize_lang(lang)
+    entry = STRINGS.get(key)
+    if not entry:
+        return key
+    return entry.get(lng) or entry.get(DEFAULT_LANG) or key

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="{{ current_lang|default('ko', true) }}">
 <head>
   {% set _brand_name = brand_name|default('KOHgogane', true) %}
   <meta charset="utf-8">
@@ -44,18 +44,18 @@
     <div class="flex-grow-1">
     <!-- 핵심 메뉴(항상 노출) — 비기너 과부하 방지(v5). 나머지는 '고급 기능'으로 접음. -->
     <ul class="nav flex-column gap-1">
-      <li><a class="console-nav-link {% if _path == '/seller/' or _path.startswith('/seller/dashboard') %}active{% endif %}" href="/seller/dashboard"><i class="bi bi-speedometer2"></i><span>홈(대시보드)</span></a></li>
+      <li><a class="console-nav-link {% if _path == '/seller/' or _path.startswith('/seller/dashboard') %}active{% endif %}" href="/seller/dashboard"><i class="bi bi-speedometer2"></i><span>{{ t('nav.home') }}</span></a></li>
       <li><a class="console-nav-link {% if _path == '/seller/sourcing' or _path.startswith('/seller/sourcing/my-sources') or _path.startswith('/seller/sourcing/collect') or _path.startswith('/seller/sourcing/recommend') %}active{% endif %}" href="/seller/sourcing"><i class="bi bi-stars"></i><span>AI 소싱·등록</span></a></li>
-      <li><a class="console-nav-link {% if _path.startswith('/seller/manual-collect') or (_path.startswith('/seller/collect') and not _path.startswith('/seller/collect/history') and not _path.startswith('/seller/collect-history')) %}active{% endif %}" href="/seller/manual-collect"><i class="bi bi-search"></i><span>상품 수집</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/manual-collect') or (_path.startswith('/seller/collect') and not _path.startswith('/seller/collect/history') and not _path.startswith('/seller/collect-history')) %}active{% endif %}" href="/seller/manual-collect"><i class="bi bi-search"></i><span>{{ t('nav.collect') }}</span></a></li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/collect/history') or _path.startswith('/seller/collect-history') %}active{% endif %}" href="/seller/collect/history"><i class="bi bi-journal-text"></i><span>수집한 상품</span></a></li>
-      <li><a class="console-nav-link {% if _path == '/seller/orders' or (_path.startswith('/seller/orders') and not _path.startswith('/seller/orders/auto')) %}active{% endif %}" href="/seller/orders"><i class="bi bi-receipt"></i><span>주문 관리</span></a></li>
-      <li><a class="console-nav-link {% if (_path.startswith('/seller/markets') and not _path.startswith('/seller/markets/connect') and not _path.startswith('/seller/markets/guide')) or _path.startswith('/seller/market-status') %}active{% endif %}" href="/seller/markets"><i class="bi bi-shop"></i><span>마켓 연동</span></a></li>
-      <li><a class="console-nav-link {% if _path.startswith('/seller/guide/business') %}active{% endif %}" href="/seller/guide/business"><i class="bi bi-question-circle"></i><span>도움말·가이드</span></a></li>
+      <li><a class="console-nav-link {% if _path == '/seller/orders' or (_path.startswith('/seller/orders') and not _path.startswith('/seller/orders/auto')) %}active{% endif %}" href="/seller/orders"><i class="bi bi-receipt"></i><span>{{ t('nav.orders') }}</span></a></li>
+      <li><a class="console-nav-link {% if (_path.startswith('/seller/markets') and not _path.startswith('/seller/markets/connect') and not _path.startswith('/seller/markets/guide')) or _path.startswith('/seller/market-status') %}active{% endif %}" href="/seller/markets"><i class="bi bi-shop"></i><span>{{ t('nav.markets') }}</span></a></li>
+      <li><a class="console-nav-link {% if _path.startswith('/seller/guide/business') %}active{% endif %}" href="/seller/guide/business"><i class="bi bi-question-circle"></i><span>{{ t('nav.help') }}</span></a></li>
     </ul>
 
     <!-- 고급 기능(접이식, 기본 닫힘 — 현재 위치가 안에 있으면 JS가 자동으로 펼침) -->
     <details class="adv-nav" id="advNav">
-      <summary class="console-nav-adv-summary"><i class="bi bi-sliders2"></i> 고급 기능 더보기</summary>
+      <summary class="console-nav-adv-summary"><i class="bi bi-sliders2"></i> {{ t('nav.advanced') }}</summary>
     <ul class="nav flex-column gap-1 mt-1">
       <li class="console-nav-group-title">AI 소싱·등록</li>
       <li><a class="console-nav-link {% if _path.startswith('/seller/listing/ai-create') %}active{% endif %}" href="/seller/listing/ai-create"><i class="bi bi-robot"></i><span>AI 상품등록(자동 생성)</span></a></li>
@@ -138,7 +138,14 @@
         </div>
       </form>
 
-      <div>
+      <div class="d-flex align-items-center gap-2">
+        {# v15 i18n: 언어 토글(한국어/English) — 기존 /i18n/set 쿠키 단일소스 #}
+        <div class="btn-group btn-group-sm" role="group" aria-label="{{ t('lang.label') }}">
+          <a href="/i18n/set?lang=ko&next={{ request.full_path|urlencode }}"
+             class="btn {{ 'btn-primary' if current_lang == 'ko' else 'btn-outline-secondary' }}">한국어</a>
+          <a href="/i18n/set?lang=en&next={{ request.full_path|urlencode }}"
+             class="btn {{ 'btn-primary' if current_lang == 'en' else 'btn-outline-secondary' }}">EN</a>
+        </div>
         {% if _user_id %}
         <div class="dropdown">
           <button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
@@ -196,9 +203,9 @@
 <div id="fbWrap" style="position:fixed;right:18px;bottom:18px;z-index:1035;display:flex;flex-direction:column;align-items:flex-end;gap:3px">
   <a href="/seller/start" id="fbBtn" class="btn btn-cta"
      style="border-radius:999px;font-weight:800;font-size:1rem;padding:.7rem 1.4rem;box-shadow:0 8px 22px rgba(239,122,34,.35)">
-     ✨ 처음이신가요?
+     {{ t('fb.cta') }}
   </a>
-  <button type="button" id="fbHide" class="btn btn-link p-0 text-muted" style="font-size:.68rem;text-decoration:none">가이드 버튼 숨기기</button>
+  <button type="button" id="fbHide" class="btn btn-link p-0 text-muted" style="font-size:.68rem;text-decoration:none">{{ t('fb.hide') }}</button>
 </div>
 <button type="button" id="fbReopen" class="btn btn-cta" title="처음이신가요? 가이드 열기"
         style="display:none;position:fixed;right:18px;bottom:18px;z-index:1035;border-radius:999px;width:44px;height:44px;font-size:1.1rem;box-shadow:0 6px 18px rgba(239,122,34,.35)">✨</button>

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -60,11 +60,19 @@ _ONBOARDING_DISMISS_COOKIE_MAX_AGE = 60 * 60 * 24 * 180
 
 @bp.app_context_processor
 def inject_seller_template_flags():
+    # v15 i18n: kgp_lang 쿠키(ko|en) 기반 현지화. t('key')로 템플릿에서 사용(영어 1급).
+    from .i18n import normalize_lang, t as _t
+    try:
+        _lang = normalize_lang(request.cookies.get("kgp_lang"))
+    except Exception:
+        _lang = "ko"
     return {
         "diagnostic_reveal_enabled": os.getenv("DIAGNOSTIC_REVEAL", "0") == "1",
         "sidebar_grouped": os.getenv("SIDEBAR_GROUPED", "1") == "1",
         "brand_name": get_brand_name(),
         "brand_name_ko": get_brand_name_ko(),
+        "current_lang": _lang,
+        "t": (lambda key, lang=_lang: _t(key, lang)),
     }
 
 

--- a/tests/test_i18n_seller_console_v15.py
+++ b/tests/test_i18n_seller_console_v15.py
@@ -1,0 +1,46 @@
+"""tests/test_i18n_seller_console_v15.py — v15 셀러 콘솔 i18n(한국어 기본 + 영어 1급) 가드."""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_i18n_helper_ko_en_and_fallback():
+    from src.seller_console.i18n import t, normalize_lang
+    assert t("nav.home", "ko") == "홈(대시보드)"
+    assert t("nav.home", "en") == "Home (Dashboard)"
+    assert t("nav.collect", "en") == "Collect products"
+    # 미지원 언어 → 기본(ko)
+    assert normalize_lang("fr") == "ko"
+    assert t("nav.home", "fr") == "홈(대시보드)"
+    # 누락 키 → 키 자체 반환(누락이 보이게 — 정직)
+    assert t("does.not.exist", "en") == "does.not.exist"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("SELLER_CONSOLE_AUTH", "0")
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_default_korean_render(client):
+    html = client.get("/seller/dashboard").get_data(as_text=True)
+    assert 'lang="ko"' in html
+    assert "홈(대시보드)" in html
+    assert "i18n/set?lang=en" in html          # 언어 토글 노출
+
+
+def test_english_render_via_cookie(client):
+    client.set_cookie("kgp_lang", "en")
+    html = client.get("/seller/dashboard").get_data(as_text=True)
+    assert 'lang="en"' in html
+    assert "Home (Dashboard)" in html          # 영어 1급 — 핵심 내비 영어로
+    assert "Collect products" in html
+    assert "New here?" in html                 # For Beginners 버튼도 영어


### PR DESCRIPTION
v15 마지막 — **i18n 영어 1급** 1차(국내용 다음, 오너 순서). 한국어 기본 유지 + 영어를 1급으로.

## 변경
- **신설 `src/seller_console/i18n.py`** — `t(key, lang)` + `STRINGS`(ko/en). 누락 키는 **키 자체 반환**(누락이 화면에 보이게 — 정직), 미지원 언어는 **ko 폴백**.
- **컨텍스트 프로세서**가 `t`·`current_lang` 주입 — `kgp_lang` 쿠키 **단일 소스**(기존 `/i18n/set` 재사용, 신규 라우트 없음).
- **`_base.html`**: `<html lang>` 동적, 탑바 **언어 토글(한국어/EN)**, For Beginners 버튼 + **6개 핵심 내비**(홈·상품 수집·주문·마켓 연동·도움말·고급) 라벨을 `t()`로 외부화.
- `en` 쿠키 시 핵심 화면이 영어로(Home/Collect products/Orders/… + “New here?”). **ko 기본**(국내 우선).

## 점진 확장 설계
- 화면별 문자열을 `STRINGS`에 ko/en으로 추가하며 넓혀갑니다(대시보드/주문/마켓/온보딩 …) — 화면 단위 후속 PR. 인프라는 이번에 완비.

## 테스트
- 신규 `test_i18n_seller_console_v15`(3) — 헬퍼 ko/en·폴백·누락키, ko 기본 렌더, en 쿠키 렌더. 전체 `pytest` **10206 passed**.

## v15 전체 마무리
P0(#296) · P1 디폴트마켓+국내 스토어 패키징(#297) · i18n 1차(이 PR). 디자인 토큰·로고홈·다크 스테퍼는 이미 충족(재확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_