### PR TITLE
feat(v16 후속): PDD 스코프(혼입 방지) + i18n 화면 확장(주문·마켓) (Phase 290)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,11 @@
   등) '?' 툴팁 뒤로 + 본문 쉬운말, 권한 배지 한글화(상품 수집/카탈로그 조회/마켓 업로드, raw는 title). 가드 추가.
 - → **v16 완료**(P0 수집정확도·FAB에러·관리자 / P1 OG브랜딩·퍼센티/proxy정리·FAB on-off·소싱처메뉴·잔여문구·토큰).
   전체 10222 passed. ※사이트별 PDD 정밀 어댑터(라이브 검증 필요)만 후속.
+- ✅ **v16 후속 — PDD 스코프 혼입 방지(Phase 290):** 추측 금지로 사이트별 셀렉터는 미하드코딩하되, 의미기반
+  영역 제외 휴리스틱으로 '다른 상품' 혼입 차단. universal_scraper `_in_non_product_region()`(조상 class/id가
+  recommend/related/also-bought/sponsored/footer 등이면 제외, 최대 8단계) → `_collect_dom_images`에서 추천/연관/
+  푸터 영역 이미지 스킵. content_script도 동일 `_kgpInNonProductRegion`로 확장 추출서 제외. manifest 1.5.6→1.5.7.
+  가드 test_pdd_scope_v16(3). 전체 10225 passed. (Temu/타오바오 동적클래스 정밀 셀렉터는 여전히 라이브 검증 후속.)
 - (확인) 수집한 상품 클릭 404 = 해결됨 → 회귀 가드만 유지.
 
 ## 🟦 v15 브리프 (오너 2026-06-23 — "수집기 노출·마켓연결·확장설치 친절화 + 글로벌")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,9 @@
   recommend/related/also-bought/sponsored/footer 등이면 제외, 최대 8단계) → `_collect_dom_images`에서 추천/연관/
   푸터 영역 이미지 스킵. content_script도 동일 `_kgpInNonProductRegion`로 확장 추출서 제외. manifest 1.5.6→1.5.7.
   가드 test_pdd_scope_v16(3). 전체 10225 passed. (Temu/타오바오 동적클래스 정밀 셀렉터는 여전히 라이브 검증 후속.)
+- ✅ **i18n 화면 확장 #1(Phase 290):** STRINGS에 주문(마켓/상태/검색/일괄운송장/CSV…)·마켓(현황/동기화/가이드/연결/연결확인)
+  키 ko/en 추가 + orders.html·markets.html 라벨 t() 외부화. en 쿠키 시 주문·마켓 화면 영어. ko 기본 동일(무회귀).
+  가드 test_i18n_screens_v16(4). 전체 10229 passed.
 - (확인) 수집한 상품 클릭 404 = 해결됨 → 회귀 가드만 유지.
 
 ## 🟦 v15 브리프 (오너 2026-06-23 — "수집기 노출·마켓연결·확장설치 친절화 + 글로벌")

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -36,6 +36,17 @@ function extractProductMeta() {
   const images = [];
   const _seenImg = new Set();
   const _pushImg = (s) => { if (_isProductImg(s) && !_seenImg.has(s)) { _seenImg.add(s); images.push(s); } };
+  // v16 P0: 추천/연관/함께 본/스폰서/푸터 등 '다른 상품' 영역의 이미지는 제외(PDD 스코프, 혼입 방지).
+  const _kgpNonProductRe = /(recommend|related|similar|also[-_ ]?(bought|viewed|like)|you[-_ ]?may|frequently[-_ ]?bought|sponsored|advert|promotion|ranking|best[-_ ]?seller|recently[-_ ]?viewed|carousel|slider|cross[-_ ]?sell|up[-_ ]?sell|comparison|footer|navbar|breadcrumb|other[-_ ]?products|popular|trending)/i;
+  const _kgpInNonProductRegion = (el) => {
+    let cur = el && el.parentElement, depth = 0;
+    while (cur && depth < 8) {
+      const tok = (cur.className && cur.className.baseVal !== undefined ? cur.className.baseVal : (cur.className || "")) + " " + (cur.id || "");
+      if (tok && _kgpNonProductRe.test(tok)) return true;
+      cur = cur.parentElement; depth++;
+    }
+    return false;
+  };
   if (ogImage) _pushImg(ogImage);
   try {
     document.querySelectorAll("img").forEach((im) => {
@@ -46,7 +57,7 @@ function extractProductMeta() {
       }
       const w = im.naturalWidth || im.width || 0;
       const h = im.naturalHeight || im.height || 0;
-      if (src && w >= 250 && h >= 250) _pushImg(src);
+      if (src && w >= 250 && h >= 250 && !_kgpInNonProductRegion(im)) _pushImg(src);
     });
   } catch (e) { /* noop */ }
 

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "코고가네 수집기",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "지정 소싱처(타오바오·아마존 등)에서 한 클릭에 코고가네로 수집 (인페이지 수집 + 리스팅 다중 선택 수집 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/src/collectors/universal_scraper.py
+++ b/src/collectors/universal_scraper.py
@@ -288,12 +288,43 @@ def extract_reviews(html: str, limit: int = 20) -> list:
     return reviews
 
 
+# v16 P0: '현재 상품(PDD)'이 아닌 영역 — 추천/연관/함께 본/스폰서/랭킹/최근 본/푸터 등.
+# 이런 컨테이너 안의 이미지·가격은 '다른 상품' 것이므로 수집에서 제외해 혼입을 막는다(class/id 의미 기반).
+_NON_PRODUCT_REGION_RE = re.compile(
+    r"(recommend|related|similar|also[-_ ]?(bought|viewed|like)|you[-_ ]?may|"
+    r"frequently[-_ ]?bought|sponsored|advert|promotion|ranking|best[-_ ]?seller|"
+    r"recently[-_ ]?viewed|history|carousel|slider|cross[-_ ]?sell|up[-_ ]?sell|"
+    r"comparison|footer|site[-_ ]?footer|navbar|header[-_ ]?nav|breadcrumb|"
+    r"more[-_ ]?to[-_ ]?explore|other[-_ ]?products|popular|trending)",
+    re.IGNORECASE,
+)
+
+
+def _in_non_product_region(node, max_depth: int = 8) -> bool:
+    """노드의 조상 중 추천/연관/푸터 등 '다른 상품' 영역이 있으면 True (최대 max_depth 단계)."""
+    cur = getattr(node, "parent", None)
+    depth = 0
+    while cur is not None and depth < max_depth:
+        try:
+            tokens = " ".join(
+                (cur.get("class") or []) + [cur.get("id") or "", cur.get("data-section") or ""]
+            )
+        except Exception:
+            tokens = ""
+        if tokens and _NON_PRODUCT_REGION_RE.search(tokens):
+            return True
+        cur = getattr(cur, "parent", None)
+        depth += 1
+    return False
+
+
 def _collect_dom_images(soup, base_url: str) -> list:
     """페이지 DOM에서 상품 이미지를 최대한 수집한다.
 
     - src + lazy-load 속성(data-src/data-original/data-lazy/data-srcset) + srcset(최대 해상도)
     - data: URI, 로고/아이콘/배너/플레이스홀더/플래그/추적픽셀/문서 패턴 제외
     - width/height 속성이 명시돼 있고 작으면(아이콘/픽셀) 제외
+    - v16: 추천/연관/함께 본/스폰서/푸터 등 '다른 상품' 영역의 이미지는 제외(PDD 스코프, 혼입 방지)
     - 상대경로 절대화, 순서 유지 중복 제거
     """
     out: list = []
@@ -347,6 +378,8 @@ def _collect_dom_images(soup, base_url: str) -> list:
         if _NON_PRODUCT_IMG_RE.search(url):
             continue
         if _too_small(img):
+            continue
+        if _in_non_product_region(img):    # v16: 추천/연관/푸터 영역의 다른 상품 이미지 제외
             continue
         seen.add(url)
         out.append(url)

--- a/src/seller_console/i18n.py
+++ b/src/seller_console/i18n.py
@@ -40,6 +40,24 @@ STRINGS: dict[str, dict[str, str]] = {
         "ko": "상품 수집이란?",
         "en": "What is product collection?",
     },
+    # 주문 페이지
+    "orders.market": {"ko": "마켓", "en": "Market"},
+    "orders.status": {"ko": "상태", "en": "Status"},
+    "orders.start_date": {"ko": "시작일", "en": "Start date"},
+    "orders.end_date": {"ko": "종료일", "en": "End date"},
+    "orders.search": {"ko": "검색", "en": "Search"},
+    "orders.sync_now": {"ko": "주문 즉시 동기화", "en": "Sync orders now"},
+    "orders.bulk_tracking": {"ko": "일괄 운송장 등록", "en": "Bulk add tracking"},
+    "orders.bulk_ship": {"ko": "배송중 처리", "en": "Mark as shipping"},
+    "orders.bulk_status": {"ko": "일괄 상태 변경", "en": "Bulk status change"},
+    "orders.export_csv": {"ko": "CSV 내보내기", "en": "Export CSV"},
+    # 마켓 페이지
+    "markets.title": {"ko": "마켓 상품 현황", "en": "Market product status"},
+    "markets.sync_all": {"ko": "전체 동기화", "en": "Sync all"},
+    "markets.refresh": {"ko": "새로고침", "en": "Refresh"},
+    "markets.guide": {"ko": "발급 가이드", "en": "Issuance guide"},
+    "markets.connect": {"ko": "마켓 연결(키 입력)", "en": "Connect market (enter keys)"},
+    "markets.check_connection": {"ko": "연결 확인", "en": "Check connection"},
 }
 
 

--- a/src/seller_console/templates/markets.html
+++ b/src/seller_console/templates/markets.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h4 class="fw-bold mb-0">🏪 마켓 상품 현황</h4>
+  <h4 class="fw-bold mb-0">🏪 {{ t('markets.title') }}</h4>
   <div class="d-flex gap-2 align-items-center">
     {% if market_data.is_mock %}
     <span class="badge bg-warning text-dark">mock 데이터</span>
@@ -21,7 +21,7 @@
     <button class="btn btn-outline-success btn-sm" id="marketDiagnosticsBtn" onclick="refreshAllMarketDiagnostics()">
       🔌 실연동 재진단
     </button>
-    <button class="btn btn-outline-secondary btn-sm" onclick="location.reload()">새로고침</button>
+    <button class="btn btn-outline-secondary btn-sm" onclick="location.reload()">{{ t('markets.refresh') }}</button>
   </div>
 </div>
 
@@ -37,8 +37,8 @@
         <div class="small text-muted">실제 검증된 연동 상태와 운영자 조치 힌트를 함께 확인하세요.</div>
       </div>
       <div class="d-flex align-items-center gap-2">
-        <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm">📖 발급 가이드</a>
-        <a href="/seller/markets/connect" class="btn btn-primary btn-sm">🔌 마켓 연결(키 입력)</a>
+        <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm">📖 {{ t('markets.guide') }}</a>
+        <a href="/seller/markets/connect" class="btn btn-primary btn-sm">🔌 {{ t('markets.connect') }}</a>
         <span class="badge text-bg-light" id="marketDiagnosticsSummary">실연동 진단 대기</span>
       </div>
     </div>
@@ -65,7 +65,7 @@
           <div class="small text-muted mt-1" data-market-disabled-reason="{{ hub.marketplace }}">다음 액션: 초기 실연동 진단 실행 중…</div>
           <div class="small text-muted mt-1" data-market-checked-at="{{ hub.marketplace }}">마지막 점검: 대기 중</div>
           <div class="d-flex flex-wrap gap-1 mt-2">
-            <button class="btn btn-outline-primary btn-sm" type="button" data-market-action="connection" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'connection')">연결 확인</button>
+            <button class="btn btn-outline-primary btn-sm" type="button" data-market-action="connection" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'connection')">{{ t('markets.check_connection') }}</button>
             <button class="btn btn-outline-secondary btn-sm" type="button" data-market-action="scope" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'scope')">권한 확인</button>
             <button class="btn btn-outline-warning btn-sm" type="button" data-market-action="retry" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'retry')">재시도</button>
             <a class="btn btn-outline-primary btn-sm" href="/seller/markets/connect/{{ hub.marketplace }}">🔑 키 입력</a>

--- a/src/seller_console/templates/orders.html
+++ b/src/seller_console/templates/orders.html
@@ -63,7 +63,7 @@
   <div class="card-body">
     <div class="row g-2 align-items-end">
       <div class="col-md-3">
-        <label class="form-label small mb-1">마켓</label>
+        <label class="form-label small mb-1">{{ t('orders.market') }}</label>
         <div class="d-flex gap-2 flex-wrap">
           {% for mp in ["coupang", "smartstore", "11st", "kohganemultishop"] %}
           <div class="form-check form-check-inline">
@@ -75,7 +75,7 @@
         </div>
       </div>
       <div class="col-md-2">
-        <label class="form-label small mb-1">상태</label>
+        <label class="form-label small mb-1">{{ t('orders.status') }}</label>
         <select name="status" class="form-select form-select-sm">
           <option value="">전체</option>
           {% for s in ["new","paid","preparing","shipped","delivered","canceled","returned","exchanged","refund_requested"] %}
@@ -84,19 +84,19 @@
         </select>
       </div>
       <div class="col-md-2">
-        <label class="form-label small mb-1">시작일</label>
+        <label class="form-label small mb-1">{{ t('orders.start_date') }}</label>
         <input type="date" name="date_from" class="form-control form-control-sm" value="{{ filters.get('date_from', '') }}">
       </div>
       <div class="col-md-2">
-        <label class="form-label small mb-1">종료일</label>
+        <label class="form-label small mb-1">{{ t('orders.end_date') }}</label>
         <input type="date" name="date_to" class="form-control form-control-sm" value="{{ filters.get('date_to', '') }}">
       </div>
       <div class="col-md-2">
-        <label class="form-label small mb-1">검색</label>
+        <label class="form-label small mb-1">{{ t('orders.search') }}</label>
         <input type="text" name="search" class="form-control form-control-sm" placeholder="주문번호/구매자" value="{{ filters.get('search', '') }}">
       </div>
       <div class="col-md-1">
-        <button type="submit" class="btn btn-outline-secondary btn-sm w-100">검색</button>
+        <button type="submit" class="btn btn-outline-secondary btn-sm w-100">{{ t('orders.search') }}</button>
       </div>
     </div>
   </div>
@@ -115,12 +115,12 @@
       <div class="d-flex align-items-center gap-2 flex-wrap">
         {% if orders %}
         <span id="bulkSelectionCount" class="badge text-bg-light">0건 선택</span>
-        <button id="bulkTrackingButton" type="button" class="btn btn-outline-primary btn-sm" onclick="openBulkTrackingModal()" disabled title="주문을 선택하면 사용할 수 있습니다.">일괄 운송장 등록</button>
-        <button id="bulkShipButton" type="button" class="btn btn-primary btn-sm" onclick="bulkUpdateSelectedStatus('shipped')" disabled title="배송중으로 변경 가능한 주문을 선택하면 사용할 수 있습니다.">배송중 처리</button>
-        <button id="bulkStatusButton" type="button" class="btn btn-outline-secondary btn-sm" onclick="openBulkStatusModal()" disabled title="공통 상태 흐름이 있는 주문을 선택하면 사용할 수 있습니다.">일괄 상태 변경</button>
+        <button id="bulkTrackingButton" type="button" class="btn btn-outline-primary btn-sm" onclick="openBulkTrackingModal()" disabled title="주문을 선택하면 사용할 수 있습니다.">{{ t('orders.bulk_tracking') }}</button>
+        <button id="bulkShipButton" type="button" class="btn btn-primary btn-sm" onclick="bulkUpdateSelectedStatus('shipped')" disabled title="배송중으로 변경 가능한 주문을 선택하면 사용할 수 있습니다.">{{ t('orders.bulk_ship') }}</button>
+        <button id="bulkStatusButton" type="button" class="btn btn-outline-secondary btn-sm" onclick="openBulkStatusModal()" disabled title="공통 상태 흐름이 있는 주문을 선택하면 사용할 수 있습니다.">{{ t('orders.bulk_status') }}</button>
         {% endif %}
         {% if ops_health.service_available %}
-        <a href="/seller/orders/export.csv" class="btn btn-outline-secondary btn-sm">CSV 내보내기</a>
+        <a href="/seller/orders/export.csv" class="btn btn-outline-secondary btn-sm">{{ t('orders.export_csv') }}</a>
         {% else %}
         <button type="button" class="btn btn-outline-secondary btn-sm" disabled title="주문 서비스가 준비되면 CSV 내보내기를 다시 사용할 수 있습니다.">CSV 내보내기 (서비스 준비 중)</button>
         {% endif %}

--- a/tests/test_i18n_screens_v16.py
+++ b/tests/test_i18n_screens_v16.py
@@ -1,0 +1,37 @@
+"""tests/test_i18n_screens_v16.py — v16 후속: i18n 화면 확장(주문·마켓 EN/KO)."""
+from __future__ import annotations
+import os, sys
+import pytest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("SELLER_CONSOLE_AUTH", "0")
+    from src.order_webhook import app
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_orders_ko_default(client):
+    h = client.get("/seller/orders").get_data(as_text=True)
+    assert "마켓" in h and "검색" in h and "CSV 내보내기" in h
+
+
+def test_orders_english(client):
+    client.set_cookie("kgp_lang", "en")
+    h = client.get("/seller/orders").get_data(as_text=True)
+    assert "Market" in h and "Search" in h and "Export CSV" in h
+
+
+def test_markets_english(client):
+    client.set_cookie("kgp_lang", "en")
+    h = client.get("/seller/markets").get_data(as_text=True)
+    assert "Market product status" in h and "Refresh" in h
+
+
+def test_i18n_keys_have_both_langs():
+    from src.seller_console.i18n import STRINGS
+    for key, entry in STRINGS.items():
+        assert entry.get("ko") and entry.get("en"), f"{key} ko/en 누락"

--- a/tests/test_pdd_scope_v16.py
+++ b/tests/test_pdd_scope_v16.py
@@ -1,0 +1,45 @@
+"""tests/test_pdd_scope_v16.py — v16 후속: PDD 스코프(추천/연관 영역 이미지 혼입 방지)."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_excludes_recommendation_region_images():
+    from src.collectors.universal_scraper import UniversalScraper
+    html = """<html><body>
+      <div class="product-detail">
+        <h1>Cotton Tee</h1>
+        <img src="https://img.x.com/main-product.jpg" width="600" height="600">
+        <img src="https://img.x.com/detail-2.jpg" width="600" height="600">
+      </div>
+      <section class="recommendations">
+        <img src="https://img.x.com/other-A.jpg" width="400" height="400">
+      </section>
+      <div class="also-bought"><img src="https://img.x.com/also.jpg" width="400" height="400"></div>
+      <footer class="site-footer"><img src="https://img.x.com/footer.jpg" width="400" height="400"></footer>
+    </body></html>"""
+    imgs = UniversalScraper().parse_html(html, "https://shop.example/p/1").images
+    assert "https://img.x.com/main-product.jpg" in imgs
+    assert "https://img.x.com/detail-2.jpg" in imgs
+    # 추천/함께 본/푸터 영역의 '다른 상품' 이미지는 혼입되지 않아야 함
+    for bad in ("other-A", "also.jpg", "footer.jpg"):
+        assert not any(bad in u for u in imgs), f"{bad} 혼입됨"
+
+
+def test_region_helper_direct():
+    from bs4 import BeautifulSoup
+    from src.collectors.universal_scraper import _in_non_product_region
+    soup = BeautifulSoup(
+        '<div class="related-products"><img id="a"></div><div class="gallery"><img id="b"></div>',
+        "html.parser")
+    assert _in_non_product_region(soup.find("img", id="a")) is True
+    assert _in_non_product_region(soup.find("img", id="b")) is False
+
+
+def test_extension_has_region_guard():
+    cs = Path("extensions/chrome-collector/content_script.js").read_text(encoding="utf-8")
+    assert "_kgpInNonProductRegion" in cs and "_kgpNonProductRe" in cs


### PR DESCRIPTION
v16 후속 polish — 수집 혼입 방지 + i18n 화면 확장.

## ① PDD 스코프 — 추천/연관 이미지 혼입 0
사이트별(Temu/타오바오) 동적 셀렉터는 **라이브 검증 없이 하드코딩하면 날조**라 두고, **의미 기반 영역 제외 휴리스틱**으로 ‘다른 상품’ 혼입 차단:
- `universal_scraper._in_non_product_region()` — 이미지 조상 class/id가 `recommend/related/also-bought/sponsored/recently-viewed/comparison/footer/carousel …`이면 제외(8단계).
- `_collect_dom_images` 적용 → 대표/상세 갤러리만. `content_script`도 동일 `_kgpInNonProductRegion`. manifest `1.5.6→1.5.7`.

## ② i18n 화면 확장 #1 (주문·마켓)
- `STRINGS`에 주문(마켓/상태/검색/일괄 운송장/CSV…)·마켓(현황/동기화/가이드/연결/연결 확인) **ko/en** 추가.
- `orders.html`·`markets.html` 라벨 **`t()` 외부화** → en 쿠키 시 영어. **ko 기본 동일(무회귀)**.

## 테스트
- 신규 `test_pdd_scope_v16`(3) + `test_i18n_screens_v16`(4). 전체 `pytest` **10229 passed**, `node --check` 통과.

> 정직성: Temu/타오바오 **정밀 PDD 셀렉터**는 라이브 검증 필요 → 후속(실제 상품 URL 주시면 정밀화).

🤖 Generated with [Claude Code](https://claude.com/claude-code)