### PR TITLE
feat(v18): 이모지 → 단일 아이콘셋 — 영속 chrome + 수집/마켓 화면 (Phase 295)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,10 @@
   단일 아이콘셋 bi-*(bi-shop/phone/list/person/box-arrow-right/tools/life-preserver/stars)로 교체. fb.cta i18n에서 ✨ 제거
   (버튼이 bi-stars 사용). 영향 테스트(admin_vs_seller_nav·emergency_header·responsive 햄버거) 아이콘 기준 갱신.
   가드 test_base_chrome_uses_icon_set_not_emoji. 전체 10248 passed. ※나머지 화면 이모지는 차근차근 후속.
+- ✅ **v18 이모지→아이콘셋 #2 수집·마켓(Phase 295):** manual_collect.html(🛒📥🧩🌐✅📤⚠️→bi-cart/download/puzzle/
+  globe/check-circle/box-arrow-up-right/exclamation-triangle, JS textContent는 텍스트만)·markets.html(🏪🔄🔌📖🔑✅⚠️❌💰🚫📋📭
+  →bi-*, <option>은 아이콘 불가라 텍스트만, JS textContent 텍스트만) 이모지 0. 전체 10248 passed.
+  ※collect_history/collect_preview/messaging/market_status/notifications 등은 차근차근 후속.
 
 ## 🟪 v16 브리프 (오너 2026-06-23 — "수집 정확도·공유 미리보기·토큰/관리자/소싱처")
 - 절대원칙: 추측 금지(에러·누락은 재현/로그)·거짓성공/가짜필러 금지·회귀 금지·정직·토큰 단일소스·경량. 버전충돌 시 v16 우선.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,10 @@
   .pc-body*/.pc-caption, opt-in 점진적용)·8px 스택 유틸(.pc-stack-2~5)·버튼 radius var(--radius)·청록 포커스 링(focus-visible)
   ·입력 토큰 radius+teal 포커스·카드 얕은 그림자(두꺼운 보더 대신). CSS 단일소스라 화면별 수정 없이 전 화면 적용·저회귀.
   가드 보강. 전체 10247 passed. ※이모지 아이콘 전면 제거·단일 아이콘셋 교체는 화면 단위 후속(회귀 관리).
+- ✅ **v18 이모지→아이콘셋 #1 영속 chrome(Phase 295):** _base.html 사이드바/탑바/드롭다운의 이모지(🛒📱☰👤🚪🛠️🆘✨)를
+  단일 아이콘셋 bi-*(bi-shop/phone/list/person/box-arrow-right/tools/life-preserver/stars)로 교체. fb.cta i18n에서 ✨ 제거
+  (버튼이 bi-stars 사용). 영향 테스트(admin_vs_seller_nav·emergency_header·responsive 햄버거) 아이콘 기준 갱신.
+  가드 test_base_chrome_uses_icon_set_not_emoji. 전체 10248 passed. ※나머지 화면 이모지는 차근차근 후속.
 
 ## 🟪 v16 브리프 (오너 2026-06-23 — "수집 정확도·공유 미리보기·토큰/관리자/소싱처")
 - 절대원칙: 추측 금지(에러·누락은 재현/로그)·거짓성공/가짜필러 금지·회귀 금지·정직·토큰 단일소스·경량. 버전충돌 시 v16 우선.

--- a/src/seller_console/i18n.py
+++ b/src/seller_console/i18n.py
@@ -28,7 +28,7 @@ STRINGS: dict[str, dict[str, str]] = {
     "action.prev": {"ko": "이전", "en": "Back"},
     "action.logout": {"ko": "로그아웃", "en": "Log out"},
     # For Beginners 고정 버튼
-    "fb.cta": {"ko": "✨ 처음이신가요?", "en": "✨ New here?"},
+    "fb.cta": {"ko": "처음이신가요?", "en": "New here?"},
     "fb.hide": {"ko": "가이드 버튼 숨기기", "en": "Hide guide button"},
     # 언어 토글
     "lang.korean": {"ko": "한국어", "en": "한국어"},

--- a/src/seller_console/templates/_base.html
+++ b/src/seller_console/templates/_base.html
@@ -26,10 +26,10 @@
 {% set _user_role = session.get('user_role') if session is defined else None %}
 
 <div class="mobile-topbar d-flex align-items-center justify-content-between px-3 py-2 d-md-none">
-  <a href="/seller/" class="text-decoration-none fw-bold">🛒 셀러 콘솔</a>
+  <a href="/seller/" class="text-decoration-none fw-bold"><i class="bi bi-shop"></i> 셀러 콘솔</a>
   <div class="d-flex align-items-center gap-2">
-    <a href="/seller/m" class="btn btn-sm btn-cta py-1">📱 모바일 앱</a>
-    <button class="btn btn-sm btn-outline-secondary" id="sidebarToggle" aria-label="메뉴 열기" onclick="toggleSidebar()">☰</button>
+    <a href="/seller/m" class="btn btn-sm btn-cta py-1"><i class="bi bi-phone"></i> 모바일 앱</a>
+    <button class="btn btn-sm btn-outline-secondary" id="sidebarToggle" aria-label="메뉴 열기" onclick="toggleSidebar()"><i class="bi bi-list"></i></button>
   </div>
 </div>
 <div class="sidebar-overlay d-md-none" id="sidebarOverlay" onclick="closeSidebar()"></div>
@@ -38,7 +38,7 @@
   <nav class="sidebar console-sidebar d-flex flex-column p-3" id="sidebarDrawer" data-testid="seller-sidebar">
     <a href="/seller/" class="console-brand text-decoration-none mb-3">
       <div class="small text-secondary">{{ brand_name_ko|default('코고가네', true) }}</div>
-      <strong>🛒 셀러 콘솔 · {{ _brand_name }}</strong>
+      <strong><i class="bi bi-shop"></i> 셀러 콘솔 · {{ _brand_name }}</strong>
     </a>
 
     <div class="flex-grow-1">
@@ -118,7 +118,7 @@
 
     <div class="small text-secondary mt-3 pt-2 border-top">
       {% if _user_role == 'admin' %}
-      <a class="d-block text-decoration-none mb-1" href="/admin/diagnostics">🛠️ 관리자 패널</a>
+      <a class="d-block text-decoration-none mb-1" href="/admin/diagnostics"><i class="bi bi-tools"></i> 관리자 패널</a>
       {% endif %}
       <a href="/privacy" class="text-decoration-none text-secondary">개인정보처리방침</a>
       <span class="mx-1">·</span>
@@ -161,11 +161,11 @@
             {{ _user_email or _user_name or '사용자' }}
           </button>
           <ul class="dropdown-menu dropdown-menu-end">
-            <li><a class="dropdown-item" href="/seller/me">👤 마이페이지</a></li>
+            <li><a class="dropdown-item" href="/seller/me"><i class="bi bi-person"></i> 마이페이지</a></li>
             <li><hr class="dropdown-divider"></li>
             <li>
               <form method="post" action="/auth/logout" class="px-2">
-                <button type="submit" class="btn btn-outline-secondary btn-sm w-100">🚪 로그아웃</button>
+                <button type="submit" class="btn btn-outline-secondary btn-sm w-100"><i class="bi bi-box-arrow-right"></i> 로그아웃</button>
               </form>
             </li>
           </ul>
@@ -175,7 +175,7 @@
           <a href="/auth/login" class="btn btn-outline-secondary btn-sm">OAuth 로그인</a>
           <a href="/auth/magic-link" class="btn btn-outline-secondary btn-sm">이메일 로그인</a>
           {% if diagnostic_reveal_enabled %}
-          <a href="/auth/diagnostic-token/issue?reveal_safe=1&format=html" class="btn btn-warning btn-sm">🆘 비상 진입 (운영자)</a>
+          <a href="/auth/diagnostic-token/issue?reveal_safe=1&format=html" class="btn btn-warning btn-sm"><i class="bi bi-life-preserver"></i> 비상 진입 (운영자)</a>
           {% endif %}
         </div>
         {% endif %}
@@ -212,12 +212,12 @@
 <div id="fbWrap" style="position:fixed;right:18px;bottom:18px;z-index:1035;display:flex;flex-direction:column;align-items:flex-end;gap:3px">
   <a href="/seller/start" id="fbBtn" class="btn btn-cta"
      style="border-radius:999px;font-weight:800;font-size:1rem;padding:.7rem 1.4rem;box-shadow:0 8px 22px rgba(239,122,34,.35)">
-     {{ t('fb.cta') }}
+     <i class="bi bi-stars"></i> {{ t('fb.cta') }}
   </a>
   <button type="button" id="fbHide" class="btn btn-link p-0 text-muted" style="font-size:.68rem;text-decoration:none">{{ t('fb.hide') }}</button>
 </div>
 <button type="button" id="fbReopen" class="btn btn-cta" title="처음이신가요? 가이드 열기"
-        style="display:none;position:fixed;right:18px;bottom:18px;z-index:1035;border-radius:999px;width:44px;height:44px;font-size:1.1rem;box-shadow:0 6px 18px rgba(239,122,34,.35)">✨</button>
+        style="display:none;position:fixed;right:18px;bottom:18px;z-index:1035;border-radius:999px;width:44px;height:44px;font-size:1.1rem;box-shadow:0 6px 18px rgba(239,122,34,.35)"><i class="bi bi-stars"></i></button>
 <script>
 (function () {
   var wrap = document.getElementById('fbWrap');

--- a/src/seller_console/templates/manual_collect.html
+++ b/src/seller_console/templates/manual_collect.html
@@ -34,8 +34,8 @@
 <div class="card console-card mb-3" id="oneclickCard">
   <div class="card-body">
     <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
-      <label class="form-label fw-semibold mb-0">🛒 원클릭 수집 지원 마켓</label>
-      <span class="small text-muted">마켓을 열고 상품 페이지에서 <b class="text-primary">🛒 수집</b> 버튼을 누르세요</span>
+      <label class="form-label fw-semibold mb-0"><i class="bi bi-cart"></i> 원클릭 수집 지원 마켓</label>
+      <span class="small text-muted">마켓을 열고 상품 페이지에서 <b class="text-primary"><i class="bi bi-cart"></i> 수집</b> 버튼을 누르세요</span>
     </div>
     {# v17 P0: 앱에서 마켓 진입 시 도착 페이지에 수집기가 무조건 뜨도록 마커(kgpsrc=app) 부여 #}
     {% macro mk(u) %}{{ u }}{{ '&' if '?' in u else '?' }}kgpsrc=app{% endmacro %}
@@ -73,7 +73,7 @@
         <b class="text-primary">코고가네 인페이지 수집</b> — 크롬 확장을 설치하면 <b>지정 소싱처</b>(타오바오·아마존 등)에서
         ①상품 <b>상세 페이지</b>의 <b>“코고가네 수집”</b> 버튼으로 한 번에, ②<b>검색·목록 페이지</b>에서는 상품마다 뜨는
         <b>‘수집’ 배지</b>와 상단 <b>전체/선택 수집</b> 바로 <b>여러 상품을 한 번에</b> 수집·한국어 번역됩니다.
-        <a href="/seller/extension" class="ms-1 fw-semibold text-decoration-none">🧩 확장 설치하기 →</a>
+        <a href="/seller/extension" class="ms-1 fw-semibold text-decoration-none"><i class="bi bi-puzzle"></i> 확장 설치하기 →</a>
         <div class="mt-1">확장을 설치하기 어려운 환경이면 <a href="/seller/bookmarklet" class="fw-semibold text-decoration-none">북마클릿(보조) →</a> 으로도 수집할 수 있어요.</div>
       </div>
     </div>
@@ -96,7 +96,7 @@
 <div class="card console-card mb-3">
   <div class="card-body">
     <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
-      <label for="bulkUrls" class="form-label fw-semibold mb-0">📥 여러 URL 한 번에 수집</label>
+      <label for="bulkUrls" class="form-label fw-semibold mb-0"><i class="bi bi-download"></i> 여러 URL 한 번에 수집</label>
       <span class="small text-muted">한 줄에 하나씩 · 최대 1000개</span>
     </div>
     <textarea id="bulkUrls" class="form-control" rows="4"
@@ -177,7 +177,7 @@
             onclick="localizeProduct()"
             {% if not localization_configured %}disabled{% endif %}
           >
-            🌐 현지화 실행
+            <i class="bi bi-globe"></i> 현지화 실행
           </button>
           {% if not localization_configured %}
           <div class="small text-muted mt-2">번역 API 미설정: /admin/diagnostics에서 설정하세요.</div>
@@ -269,10 +269,10 @@ async function bulkCollect() {
     (data.results || []).forEach(r => {
       if (r.ok) {
         html += `<li class="list-group-item list-group-item-success d-flex justify-content-between align-items-center">
-          <span>✅ ${escapeHtml(r.title)}</span>
-          <a href="${r.preview_url}" class="btn btn-sm btn-success py-0">📤 미리보기·등록</a></li>`;
+          <span><i class="bi bi-check-circle text-success"></i> ${escapeHtml(r.title)}</span>
+          <a href="${r.preview_url}" class="btn btn-sm btn-success py-0"><i class="bi bi-box-arrow-up-right"></i> 미리보기·등록</a></li>`;
       } else {
-        html += `<li class="list-group-item list-group-item-warning"><span class="small">⚠️ ${escapeHtml(r.url)} — ${escapeHtml(r.error || '실패')}</span></li>`;
+        html += `<li class="list-group-item list-group-item-warning"><span class="small"><i class="bi bi-exclamation-triangle"></i> ${escapeHtml(r.url)} — ${escapeHtml(r.error || '실패')}</span></li>`;
       }
     });
     html += '</ul>';
@@ -478,7 +478,7 @@ function localizeProduct() {
     .catch((err) => showToast('현지화 실패', err.message || '현지화 중 오류가 발생했습니다.', 'danger'))
     .finally(() => {
       btn.disabled = false;
-      btn.textContent = '🌐 현지화 실행';
+      btn.textContent = '현지화 실행';
     });
 }
 

--- a/src/seller_console/templates/markets.html
+++ b/src/seller_console/templates/markets.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h4 class="fw-bold mb-0">🏪 {{ t('markets.title') }}</h4>
+  <h4 class="fw-bold mb-0"><i class="bi bi-shop"></i> {{ t('markets.title') }}</h4>
   <div class="d-flex gap-2 align-items-center">
     {% if market_data.is_mock %}
     <span class="badge bg-warning text-dark">mock 데이터</span>
@@ -16,10 +16,10 @@
     </span>
     {% endif %}
     <button class="btn btn-outline-primary btn-sm" id="syncAllBtn" onclick="syncAllMarkets()">
-      🔄 지금 동기화
+      <i class="bi bi-arrow-clockwise"></i> 지금 동기화
     </button>
     <button class="btn btn-outline-success btn-sm" id="marketDiagnosticsBtn" onclick="refreshAllMarketDiagnostics()">
-      🔌 실연동 재진단
+      <i class="bi bi-plug"></i> 실연동 재진단
     </button>
     <button class="btn btn-outline-secondary btn-sm" onclick="location.reload()">{{ t('markets.refresh') }}</button>
   </div>
@@ -37,8 +37,8 @@
         <div class="small text-muted">실제 검증된 연동 상태와 운영자 조치 힌트를 함께 확인하세요.</div>
       </div>
       <div class="d-flex align-items-center gap-2">
-        <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm">📖 {{ t('markets.guide') }}</a>
-        <a href="/seller/markets/connect" class="btn btn-primary btn-sm">🔌 {{ t('markets.connect') }}</a>
+        <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm"><i class="bi bi-book"></i> {{ t('markets.guide') }}</a>
+        <a href="/seller/markets/connect" class="btn btn-primary btn-sm"><i class="bi bi-plug"></i> {{ t('markets.connect') }}</a>
         <span class="badge text-bg-light" id="marketDiagnosticsSummary">실연동 진단 대기</span>
       </div>
     </div>
@@ -68,7 +68,7 @@
             <button class="btn btn-outline-primary btn-sm" type="button" data-market-action="connection" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'connection')">{{ t('markets.check_connection') }}</button>
             <button class="btn btn-outline-secondary btn-sm" type="button" data-market-action="scope" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'scope')">권한 확인</button>
             <button class="btn btn-outline-warning btn-sm" type="button" data-market-action="retry" data-market="{{ hub.marketplace }}" onclick="runMarketDiagnostic('{{ hub.marketplace }}', 'retry')">재시도</button>
-            <a class="btn btn-outline-primary btn-sm" href="/seller/markets/connect/{{ hub.marketplace }}">🔑 키 입력</a>
+            <a class="btn btn-outline-primary btn-sm" href="/seller/markets/connect/{{ hub.marketplace }}"><i class="bi bi-key"></i> 키 입력</a>
           </div>
           <div class="small text-muted mt-2">필수 권한: {{ hub.required_scopes|join(', ') }}</div>
           <div class="small text-muted mt-1">필수 env: {{ hub.required_env|join(', ') }}</div>
@@ -117,7 +117,7 @@
         <div class="mt-2">
           <button class="btn btn-outline-secondary btn-sm w-100"
                   onclick="syncMarket('{{ m.marketplace }}')">
-            🔄 동기화
+            <i class="bi bi-arrow-clockwise"></i> 동기화
           </button>
         </div>
         {% endif %}
@@ -146,11 +146,11 @@
       </select>
       <select class="form-select form-select-sm" id="filterStatus" style="width:auto;" onchange="filterTable()">
         <option value="">전체 상태</option>
-        <option value="active">활성 ✅</option>
-        <option value="out_of_stock">품절 ⚠️</option>
-        <option value="error">오류 ❌</option>
-        <option value="price_anomaly">가격이상 💰</option>
-        <option value="suspended">정지 🚫</option>
+        <option value="active">활성</option>
+        <option value="out_of_stock">품절</option>
+        <option value="error">오류</option>
+        <option value="price_anomaly">가격이상</option>
+        <option value="suspended">정지</option>
       </select>
       <input type="text" class="form-control form-control-sm" id="filterSearch"
              placeholder="상품명/SKU 검색..." style="width:200px;" oninput="filterTable()">
@@ -191,15 +191,15 @@
               <td><code class="small">{{ item.sku or '—' }}</code></td>
               <td class="text-center">
                 {% if item.state == "active" %}
-                <span class="badge bg-success">✅ 활성</span>
+                <span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span>
                 {% elif item.state == "out_of_stock" %}
-                <span class="badge bg-warning text-dark">⚠️ 품절</span>
+                <span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> 품절</span>
                 {% elif item.state == "error" %}
-                <span class="badge bg-danger" title="{{ item.error_message }}">❌ 오류</span>
+                <span class="badge bg-danger" title="{{ item.error_message }}"><i class="bi bi-x-circle"></i> 오류</span>
                 {% elif item.state == "price_anomaly" %}
-                <span class="badge bg-info text-dark">💰 가격이상</span>
+                <span class="badge bg-info text-dark"><i class="bi bi-cash-coin"></i> 가격이상</span>
                 {% elif item.state == "suspended" %}
-                <span class="badge bg-dark">🚫 정지</span>
+                <span class="badge bg-dark"><i class="bi bi-slash-circle"></i> 정지</span>
                 {% else %}
                 <span class="badge bg-secondary">{{ item.state }}</span>
                 {% endif %}
@@ -219,10 +219,10 @@
             <tr>
               <td colspan="8" class="text-center text-muted py-4">
                 {% if market_data.is_mock %}
-                <div>📋 <strong>Mock 모드</strong> — Google Sheets <code>catalog</code> 워크시트에 데이터를 추가하면 실 데이터가 표시됩니다.</div>
+                <div><i class="bi bi-clipboard"></i> <strong>Mock 모드</strong> — Google Sheets <code>catalog</code> 워크시트에 데이터를 추가하면 실 데이터가 표시됩니다.</div>
                 <div class="small mt-1">컬럼: product_id / sku / title / marketplace / state / price / currency / price_krw / last_synced_at / error_message</div>
                 {% else %}
-                <div>📭 상품 데이터가 없습니다. Google Sheets에 데이터를 추가해주세요.</div>
+                <div><i class="bi bi-inbox"></i> 상품 데이터가 없습니다. Google Sheets에 데이터를 추가해주세요.</div>
                 {% endif %}
               </td>
             </tr>
@@ -284,7 +284,7 @@ function syncMarket(marketplace) {
   .catch(err => showToast('동기화 실패: ' + err.message, 'danger'))
   .finally(() => {
     btn.disabled = false;
-    btn.textContent = '🔄 지금 동기화';
+    btn.textContent = '지금 동기화';
   });
 }
 
@@ -425,7 +425,7 @@ function refreshAllMarketDiagnostics() {
     .finally(() => {
       if (btn) {
         btn.disabled = false;
-        btn.textContent = '🔌 실연동 재진단';
+        btn.textContent = '실연동 재진단';
       }
     });
 }

--- a/tests/test_admin_vs_seller_nav.py
+++ b/tests/test_admin_vs_seller_nav.py
@@ -27,7 +27,7 @@ def test_seller_route_uses_seller_sidebar(client):
         sess["user_role"] = "admin"
     resp = client.get("/seller/sourcing/watches")
     html = resp.get_data(as_text=True)
-    assert "🛒 셀러 콘솔" in html
+    assert "셀러 콘솔" in html and "bi-shop" in html
     assert "/seller/sourcing/watches" in html
     assert "/admin/products" not in html
 
@@ -40,4 +40,4 @@ def test_admin_route_uses_admin_sidebar(client):
     html = resp.get_data(as_text=True)
     assert "🛒 Admin" in html
     assert "/admin/products" in html
-    assert "🛒 셀러 콘솔" not in html
+    assert "셀러 콘솔 · " not in html

--- a/tests/test_design_tokens_v18.py
+++ b/tests/test_design_tokens_v18.py
@@ -58,3 +58,12 @@ def test_component_baseline_uses_tokens():
     assert "rgba(17, 154, 142" in CSS          # 청록 포커스 링
     assert "box-shadow: var(--shadow-sm)" in CSS
     # 하드코딩 0 원칙: 베이스라인 섹션은 토큰만(focus 링 rgba는 teal 동일색 허용)
+
+
+def test_base_chrome_uses_icon_set_not_emoji():
+    # v18 §8: 사이드바/탑바 등 영속 chrome은 이모지 아이콘 0, 단일 아이콘셋(bi-*) 사용.
+    base = Path("src/seller_console/templates/_base.html").read_text(encoding="utf-8")
+    for ic in ("bi-shop", "bi-phone", "bi-list", "bi-person", "bi-box-arrow-right", "bi-tools"):
+        assert ic in base, f"{ic} 아이콘 누락"
+    for em in ("🛒", "👤", "🚪", "📱", "🛠️", "🆘"):
+        assert em not in base, f"chrome에 이모지 {em} 잔존"

--- a/tests/test_emergency_header.py
+++ b/tests/test_emergency_header.py
@@ -20,11 +20,11 @@ def client():
 def test_emergency_button_visible_when_reveal_enabled(client, monkeypatch):
     monkeypatch.setenv("DIAGNOSTIC_REVEAL", "1")
     html = client.get("/seller/dashboard").get_data(as_text=True)
-    assert "🆘 비상 진입 (운영자)" in html
+    assert "비상 진입 (운영자)" in html and "bi-life-preserver" in html
     assert "/auth/diagnostic-token/issue?reveal_safe=1&format=html" in html
 
 
 def test_emergency_button_hidden_when_reveal_disabled(client, monkeypatch):
     monkeypatch.setenv("DIAGNOSTIC_REVEAL", "0")
     html = client.get("/seller/dashboard").get_data(as_text=True)
-    assert "🆘 비상 진입 (운영자)" not in html
+    assert "비상 진입 (운영자)" not in html

--- a/tests/test_responsive_smoke.py
+++ b/tests/test_responsive_smoke.py
@@ -27,7 +27,7 @@ def test_base_html_has_hamburger_toggle():
     with open("src/seller_console/templates/_base.html", encoding="utf-8") as f:
         content = f.read()
     assert "sidebarToggle" in content
-    assert "☰" in content
+    assert "bi-list" in content   # v18: 햄버거 = 아이콘셋(bi-*)
 
 
 def test_base_html_has_drawer_sidebar():


### PR DESCRIPTION
v18 디자인 마무리 — 차근차근 이모지 → 단일 아이콘셋(`bi-*`) 교체.

## #1 영속 chrome (사이드바/탑바/드롭다운)
🛒/📱/☰/👤/🚪/🛠️/🆘/✨ → `bi-shop/phone/list/person/box-arrow-right/tools/life-preserver/stars`. i18n `fb.cta`에서 ✨ 제거.

## #2 주요 사용자 플로우 (수집 페이지·마켓 현황)
- `manual_collect.html`: 🛒📥🧩🌐✅📤⚠️ → `bi-cart/download/puzzle/globe/check-circle/box-arrow-up-right/exclamation-triangle`. (JS `textContent` 라벨은 텍스트만)
- `markets.html`: 🏪🔄🔌📖🔑✅⚠️❌💰🚫📋📭 → `bi-*`. (`<option>`은 아이콘 태그 불가 → 텍스트만)

## 테스트
- 가드 `test_base_chrome_uses_icon_set_not_emoji`. 영향 테스트 갱신. 전체 `pytest` **10248 passed**.

## 진행 방식
브리프 §8 “이모지 아이콘 0”을 **화면 단위로 차근차근**(회귀 관리). 남은 화면(collect_history/preview·messaging·market_status·notifications·bookmarklet 등)은 후속 배치로 이어갑니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)