### PR TITLE
feat(v18): 이모지 → 단일 아이콘셋 — 수집 이력·편집 화면 (Phase 295)

### DIFF
--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -4,7 +4,7 @@
 <div class="container-fluid py-4">
   <div class="d-flex align-items-center mb-4">
     <div>
-      <h1 class="h3 mb-0">📦 수집 이력</h1>
+      <h1 class="h3 mb-0"><i class="bi bi-box-seam"></i> 수집 이력</h1>
       <small class="text-muted">크롬 확장, 북마클릿, 수동 입력으로 수집된 상품 기록</small>
     </div>
   </div>
@@ -83,7 +83,7 @@
           <select name="status" class="form-select form-select-sm">
             <option value="">전체 상태</option>
             <option value="ok" {% if filters.status == "ok" %}selected{% endif %}>활성</option>
-            <option value="archived" {% if filters.status == "archived" %}selected{% endif %}>📦 보관</option>
+            <option value="archived" {% if filters.status == "archived" %}selected{% endif %}>보관</option>
           </select>
         </div>
         {% if groups %}
@@ -92,7 +92,7 @@
           <select name="group" class="form-select form-select-sm">
             <option value="">전체 그룹</option>
             {% for g in groups %}
-            <option value="{{ g.id }}" {% if g.id == filters.group %}selected{% endif %}>🗂 {{ g.name }}</option>
+            <option value="{{ g.id }}" {% if g.id == filters.group %}selected{% endif %}>{{ g.name }}</option>
             {% endfor %}
           </select>
         </div>
@@ -140,20 +140,20 @@
       <div class="pc-bulk-toolbar d-flex flex-wrap align-items-center gap-2 p-2 border-bottom">
         <span class="small text-muted">선택 <strong id="selCount">0</strong>개</span>
         <button type="button" class="btn btn-success btn-sm" id="bulkUploadBtn" onclick="openBulkUploadModal()" disabled>
-          📤 선택 상품 일괄 마켓 등록
+          <i class="bi bi-box-arrow-up-right"></i> 선택 상품 일괄 마켓 등록
         </button>
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkCategoryBtn" onclick="openBulkCategoryModal()" disabled>
-          🏷 카테고리 지정
+          <i class="bi bi-tag"></i> 카테고리 지정
         </button>
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkGroupBtn" onclick="openBulkGroupModal()" disabled>
-          🗂 그룹 지정
+          <i class="bi bi-folder"></i> 그룹 지정
         </button>
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkTranslateBtn" onclick="runBulkTranslate()" disabled>
-          🌐 한국어 번역
+          <i class="bi bi-globe"></i> 한국어 번역
         </button>
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkCleanBtn" onclick="runBulkClean()" disabled
                 title="설정한 금지어 제거 + 단어 치환을 제목에 적용">
-          ✨ 상품명 정제
+          <i class="bi bi-stars"></i> 상품명 정제
         </button>
         {% if translation_free %}
         <span class="small {{ 'text-muted' if translation_free.remaining > 0 else 'text-danger' }}" id="translFree"
@@ -162,16 +162,16 @@
         </span>
         {% endif %}
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkPriceBtn" onclick="openBulkPriceModal()" disabled>
-          💰 가격/마진
+          <i class="bi bi-cash-coin"></i> 가격/마진
         </button>
         <button type="button" class="btn btn-outline-secondary btn-sm" id="bulkStatusBtn" onclick="openBulkStatusModal()" disabled>
-          📦 상태
+          <i class="bi bi-box-seam"></i> 상태
         </button>
         <button type="button" class="btn btn-outline-secondary btn-sm" id="bulkDuplicateBtn" onclick="runBulkDuplicate()" disabled>
-          📋 복제
+          <i class="bi bi-files"></i> 복제
         </button>
         <button type="button" class="btn btn-outline-danger btn-sm" id="bulkDeleteBtn" onclick="openBulkDeleteModal()" disabled>
-          🗑 선택 삭제
+          <i class="bi bi-trash"></i> 선택 삭제
         </button>
       </div>
       <div class="table-responsive">
@@ -204,7 +204,7 @@
                 {% else %}
                 <a href="/seller/collect/preview/{{ it.id }}">
                   <span class="d-inline-flex align-items-center justify-content-center text-muted"
-                        style="width:52px;height:52px;border-radius:8px;background:#f1f3f5;font-size:18px">🖼️</span>
+                        style="width:52px;height:52px;border-radius:8px;background:#f1f3f5;font-size:18px"><i class="bi bi-image"></i></span>
                 </a>
                 {% endif %}
               </td>
@@ -235,16 +235,16 @@
               <td class="text-muted small">{{ it.collected_at[:16] if it.collected_at else "-" }}</td>
               <td>
                 {% if it.status == "ok" %}
-                  <span class="badge bg-success">✓</span>
+                  <span class="badge bg-success"><i class="bi bi-check-lg"></i></span>
                 {% elif it.status == "archived" %}
-                  <span class="badge bg-secondary">📦 보관</span>
+                  <span class="badge bg-secondary"><i class="bi bi-archive"></i> 보관</span>
                 {% else %}
                   <span class="badge bg-danger">{{ it.status }}</span>
                 {% endif %}
               </td>
               <td class="text-nowrap">
                 <a href="/seller/collect/preview/{{ it.id }}"
-                   class="btn btn-success btn-sm py-0" title="확인·수정 후 마켓에 등록">✏️ 편집·등록</a>
+                   class="btn btn-success btn-sm py-0" title="확인·수정 후 마켓에 등록"><i class="bi bi-pencil-square"></i> 편집·등록</a>
               </td>
             </tr>
           {% endfor %}
@@ -276,8 +276,8 @@
       {% else %}
       <p class="text-muted mb-3">아직 수집 이력이 없습니다.</p>
       <p class="small text-muted">
-        <a href="/seller/extension" class="text-decoration-none fw-semibold">🧩 크롬 확장 설치</a> 후
-        지정 소싱처에서 수집하거나, <a href="/seller/collect" class="text-decoration-none">🔍 수동 수집기</a>로 시작해보세요.
+        <a href="/seller/extension" class="text-decoration-none fw-semibold"><i class="bi bi-puzzle"></i> 크롬 확장 설치</a> 후
+        지정 소싱처에서 수집하거나, <a href="/seller/collect" class="text-decoration-none"><i class="bi bi-search"></i> 수동 수집기</a>로 시작해보세요.
       </p>
       {% endif %}
     </div>
@@ -318,7 +318,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">닫기</button>
-        <button type="button" class="btn btn-success" id="bulkUploadConfirm" onclick="runBulkUpload()">📤 등록 실행</button>
+        <button type="button" class="btn btn-success" id="bulkUploadConfirm" onclick="runBulkUpload()"><i class="bi bi-box-arrow-up-right"></i> 등록 실행</button>
       </div>
     </div>
   </div>
@@ -329,14 +329,14 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">📦 상태 변경</h5>
+        <h5 class="modal-title"><i class="bi bi-box-seam"></i> 상태 변경</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
       </div>
       <div class="modal-body">
         <p class="small text-muted">선택한 <strong id="statusSelCount">0</strong>개 상품의 상태를 바꿉니다. ‘보관’은 작업이 끝난 상품을 정리할 때 사용합니다(삭제 아님).</p>
         <div class="d-flex gap-2">
-          <button type="button" class="btn btn-success flex-grow-1" onclick="runBulkStatus('ok')">✓ 활성</button>
-          <button type="button" class="btn btn-secondary flex-grow-1" onclick="runBulkStatus('archived')">📦 보관</button>
+          <button type="button" class="btn btn-success flex-grow-1" onclick="runBulkStatus('ok')"><i class="bi bi-check-lg"></i> 활성</button>
+          <button type="button" class="btn btn-secondary flex-grow-1" onclick="runBulkStatus('archived')"><i class="bi bi-archive"></i> 보관</button>
         </div>
       </div>
     </div>
@@ -348,7 +348,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">💰 가격/마진 일괄 적용</h5>
+        <h5 class="modal-title"><i class="bi bi-cash-coin"></i> 가격/마진 일괄 적용</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
       </div>
       <div class="modal-body">
@@ -377,7 +377,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">🗂 그룹 지정</h5>
+        <h5 class="modal-title"><i class="bi bi-folder"></i> 그룹 지정</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
       </div>
       <div class="modal-body">
@@ -386,7 +386,7 @@
         <select id="bulkGroupSelect" class="form-select form-select-sm mb-2">
           <option value="">(그룹 없음 / 해제)</option>
           {% for g in groups %}
-          <option value="{{ g.id }}">🗂 {{ g.name }}</option>
+          <option value="{{ g.id }}">{{ g.name }}</option>
           {% endfor %}
         </select>
         <label class="form-label small mb-1" for="bulkGroupNew">또는 새 그룹 만들기</label>
@@ -397,7 +397,7 @@
           <ul class="list-group list-group-flush" id="groupManageList">
             {% for g in groups %}
             <li class="list-group-item d-flex justify-content-between align-items-center px-0 py-1" data-gid="{{ g.id }}">
-              <span class="small">🗂 {{ g.name }}</span>
+              <span class="small"><i class="bi bi-folder"></i> {{ g.name }}</span>
               <button type="button" class="btn btn-ghost btn-sm py-0" onclick="deleteGroup('{{ g.id }}', this)">삭제</button>
             </li>
             {% endfor %}
@@ -418,14 +418,14 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">🏷 카테고리 일괄 지정</h5>
+        <h5 class="modal-title"><i class="bi bi-tag"></i> 카테고리 일괄 지정</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
       </div>
       <div class="modal-body">
         <p class="small text-muted">선택한 <strong id="catSelCount">0</strong>개 상품에 카테고리를 지정합니다. 각 마켓 업로더가 이 코드를 자기 마켓 카테고리로 매핑합니다.</p>
         <div class="form-check mb-2">
           <input class="form-check-input" type="checkbox" id="bulkCatAuto" onchange="document.getElementById('bulkCatSelect').disabled=this.checked">
-          <label class="form-check-label" for="bulkCatAuto">🔮 자동 분류 (제목·키워드로 각 상품 자동 판정)</label>
+          <label class="form-check-label" for="bulkCatAuto"><i class="bi bi-magic"></i> 자동 분류 (제목·키워드로 각 상품 자동 판정)</label>
         </div>
         <label class="form-label small mb-1" for="bulkCatSelect">카테고리</label>
         <select id="bulkCatSelect" class="form-select form-select-sm">
@@ -447,7 +447,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">🗑 선택 상품 삭제</h5>
+        <h5 class="modal-title"><i class="bi bi-trash"></i> 선택 상품 삭제</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
       </div>
       <div class="modal-body">
@@ -456,7 +456,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">취소</button>
-        <button type="button" class="btn btn-danger" id="bulkDeleteConfirm" onclick="runBulkDelete()">🗑 삭제</button>
+        <button type="button" class="btn btn-danger" id="bulkDeleteConfirm" onclick="runBulkDelete()"><i class="bi bi-trash"></i> 삭제</button>
       </div>
     </div>
   </div>
@@ -517,8 +517,8 @@ async function runBulkStatus(status) {
     if (!data.ok) { pcToast(data.error || '상태 변경 실패', 'error'); return; }
     // 상태 배지 갱신
     const badge = status === 'archived'
-      ? '<span class="badge bg-secondary">📦 보관</span>'
-      : '<span class="badge bg-success">✓</span>';
+      ? '<span class="badge bg-secondary"><i class="bi bi-archive"></i> 보관</span>'
+      : '<span class="badge bg-success"><i class="bi bi-check-lg"></i></span>';
     ids.forEach(id => {
       const chk = document.querySelector(`.row-chk[value="${id}"]`);
       const tr = chk && chk.closest('tr');
@@ -839,7 +839,7 @@ async function runBulkUpload() {
     let html = `<div class="alert alert-info py-2">전체 ${data.total}개 · 성공 <strong>${data.succeeded}</strong> · 실패 ${data.total - data.succeeded}</div><ul class="list-group">`;
     (data.results || []).forEach(r => {
       const cls = r.ok ? 'list-group-item-success' : 'list-group-item-warning';
-      const icon = r.ok ? '✅' : '⚠️';
+      const icon = r.ok ? '<i class="bi bi-check-circle text-success"></i>' : '<i class="bi bi-exclamation-triangle text-warning"></i>';
       html += `<li class="list-group-item ${cls}"><span>${icon} ${(r.title || r.id)}</span></li>`;
     });
     html += '</ul>';

--- a/src/seller_console/templates/collect_preview.html
+++ b/src/seller_console/templates/collect_preview.html
@@ -5,14 +5,14 @@
   <div class="mb-3 d-flex justify-content-between align-items-center">
     <a href="/seller/collect/history" class="text-decoration-none text-muted small">← 수집 이력으로 돌아가기</a>
     <span class="text-muted small">
-      🌐 <a href="{{ item.url }}" target="_blank" rel="noopener noreferrer">{{ item.domain }}</a>
+      <i class="bi bi-globe"></i> <a href="{{ item.url }}" target="_blank" rel="noopener noreferrer">{{ item.domain }}</a>
       · {{ item.collected_at[:16] if item.collected_at else "" }}
     </span>
   </div>
 
   <div class="card mb-3">
     <div class="card-header d-flex justify-content-between align-items-center">
-      <span class="fw-semibold">✏️ 수집 상품 편집</span>
+      <span class="fw-semibold"><i class="bi bi-pencil-square"></i> 수집 상품 편집</span>
       {% if extra.edited %}<span class="badge bg-info text-dark">수정됨</span>{% endif %}
       {% if extra.is_mock %}<span class="badge bg-warning text-dark">목업</span>{% endif %}
     </div>
@@ -38,7 +38,7 @@
             <div class="col-7">
               <label class="form-label small fw-semibold" for="editPrice">가격(원가)</label>
               <input type="number" step="0.01" min="0" class="form-control" id="editPrice" placeholder="0.00" oninput="updateKrwPreview()">
-              <div id="priceNeedsCheck" class="form-text small text-warning d-none">⚠️ 페이지에서 가격을 자동으로 읽지 못했어요. <b>가격 확인 필요</b> — 실제 가격을 입력해 주세요.</div>
+              <div id="priceNeedsCheck" class="form-text small text-warning d-none"><i class="bi bi-exclamation-triangle"></i> 페이지에서 가격을 자동으로 읽지 못했어요. <b>가격 확인 필요</b> — 실제 가격을 입력해 주세요.</div>
             </div>
             <div class="col-5">
               <label class="form-label small fw-semibold" for="editCurrency">통화</label>
@@ -58,7 +58,7 @@
           </div>
           <div class="text-muted mb-1" id="fxNote" style="font-size:.74rem;"></div>
           <div class="alert alert-warning py-1 px-2 mb-3 d-none" id="priceWarn" style="font-size:.8rem;">
-            ⚠️ <strong>판매가(가격)가 0이거나 비어 있습니다.</strong> 이 상태로는 마켓이 등록을 거부합니다
+            <i class="bi bi-exclamation-triangle"></i> <strong>판매가(가격)가 0이거나 비어 있습니다.</strong> 이 상태로는 마켓이 등록을 거부합니다
             (“연결됨”이어도 업로드 실패). 위에 가격을 입력하거나 <strong>↻ 원화로 환산</strong>으로 채워주세요.
           </div>
         </div>
@@ -89,7 +89,7 @@
             <button type="button" class="btn btn-outline-secondary btn-sm py-0" onclick="addImageRow()">+ 이미지 추가</button>
           </div>
           <div id="imageRows" class="vstack gap-2"></div>
-          <div class="form-text">⭐ = 대표/썸네일(맨 위가 대표). 보통은 위 갤러리만 보면 됩니다.</div>
+          <div class="form-text"><i class="bi bi-star-fill text-warning"></i> = 대표/썸네일(맨 위가 대표). 보통은 위 갤러리만 보면 됩니다.</div>
         </details>
       </div>
 
@@ -112,11 +112,11 @@
             <option value="{{ opt.code }}" {{ 'selected' if (current_category == opt.code) or (not current_category and category_suggestion and category_suggestion.code == opt.code) else '' }}>{{ opt.label }}</option>
             {% endfor %}
           </select>
-          <button type="button" class="btn btn-outline-primary" id="btnAutoCategory" onclick="autoClassify()" title="상품명·키워드로 카테고리 자동 추천">🔮 자동 분류</button>
+          <button type="button" class="btn btn-outline-primary" id="btnAutoCategory" onclick="autoClassify()" title="상품명·키워드로 카테고리 자동 추천"><i class="bi bi-magic"></i> 자동 분류</button>
         </div>
         <div id="categoryHint" class="form-text">
           {% if not current_category and category_suggestion and category_suggestion.code != 'GEN' %}
-          🔮 ‘{{ category_suggestion.label }}’ 로 자동 추천됨 — 맞지 않으면 직접 바꾸세요.
+          <i class="bi bi-magic"></i> ‘{{ category_suggestion.label }}’ 로 자동 추천됨 — 맞지 않으면 직접 바꾸세요.
           {% else %}
           상품명 기준으로 추천하려면 <b>자동 분류</b>를 누르세요.
           {% endif %}
@@ -138,12 +138,12 @@
     </div>
 
     <div class="card-footer d-flex gap-2 flex-wrap">
-      <button class="btn btn-primary btn-sm" id="btnSaveEdits" onclick="saveEdits()">💾 변경사항 저장</button>
+      <button class="btn btn-primary btn-sm" id="btnSaveEdits" onclick="saveEdits()"><i class="bi bi-save"></i> 변경사항 저장</button>
       <a href="{{ item.url }}" target="_blank" rel="noopener noreferrer"
-         class="btn btn-outline-secondary btn-sm">🔗 원본 페이지</a>
-      <a href="/seller/pricing" class="btn btn-outline-primary btn-sm">💰 마진 계산기</a>
+         class="btn btn-outline-secondary btn-sm"><i class="bi bi-link-45deg"></i> 원본 페이지</a>
+      <a href="/seller/pricing" class="btn btn-outline-primary btn-sm"><i class="bi bi-cash-coin"></i> 마진 계산기</a>
       <button class="btn btn-success btn-sm ms-auto" id="btnOpenUploadModal" onclick="openUploadModal()">
-        📤 마켓에 등록
+        <i class="bi bi-box-arrow-up-right"></i> 마켓에 등록
       </button>
     </div>
   </div>
@@ -152,7 +152,7 @@
   {% if extra %}
   <div class="card">
     <div class="card-header d-flex justify-content-between align-items-center">
-      <span class="small fw-semibold">🔍 수집된 원본 메타</span>
+      <span class="small fw-semibold"><i class="bi bi-search"></i> 수집된 원본 메타</span>
       <button class="btn btn-outline-secondary btn-sm py-0"
               onclick="this.closest('.card').querySelector('pre').classList.toggle('d-none')">
         펼치기/접기
@@ -177,7 +177,7 @@
   <div class="modal-dialog modal-lg modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title fw-bold" id="uploadModalLabel">📤 마켓 등록</h5>
+        <h5 class="modal-title fw-bold" id="uploadModalLabel"><i class="bi bi-box-arrow-up-right"></i> 마켓 등록</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
       </div>
       <div class="modal-body">
@@ -206,10 +206,10 @@
               <input class="form-check-input market-upload-check m-0" type="checkbox" value="{{ code }}" id="{{ chkid }}">
               <span class="fw-semibold flex-grow-1">{{ label }}</span>
               {% if ok %}
-              <span class="badge text-bg-success" title="API 키가 입력됨 — 실제 연결은 ‘사전검증/등록’에서 확인됩니다">✅ 키 설정됨</span>
+              <span class="badge text-bg-success" title="API 키가 입력됨 — 실제 연결은 ‘사전검증/등록’에서 확인됩니다"><i class="bi bi-check-circle"></i> 키 설정됨</span>
               {% else %}
               <a href="/seller/markets/connect/{{ code }}" target="_blank" class="badge text-bg-secondary text-decoration-none"
-                 title="API 키 미입력 — 클릭해 연결" onclick="event.stopPropagation()">❌ 미설정</a>
+                 title="API 키 미입력 — 클릭해 연결" onclick="event.stopPropagation()"><i class="bi bi-x-circle"></i> 미설정</a>
               {% endif %}
             </label>
           </div>
@@ -234,7 +234,7 @@
           <div class="d-flex gap-2 mt-3">
             <button class="btn btn-outline-secondary" data-bs-dismiss="modal">취소</button>
             <button class="btn btn-primary" id="btnPrevalidate" onclick="runPrevalidate()">
-              🔍 사전검증 →
+              <i class="bi bi-search"></i> 사전검증 →
             </button>
           </div>
         </div>
@@ -246,7 +246,7 @@
           <div class="d-flex gap-2 mt-3">
             <button class="btn btn-outline-secondary" onclick="goToStep('stepSelect')">← 다시 선택</button>
             <button class="btn btn-success" id="btnConfirmUpload" onclick="runUpload()">
-              ✅ 통과 마켓에 업로드
+              <i class="bi bi-check-circle"></i> 통과 마켓에 업로드
             </button>
           </div>
         </div>
@@ -260,7 +260,7 @@
 
         <!-- Step 4: 업로드 결과 -->
         <div id="stepResult" class="d-none">
-          <h6 class="fw-semibold mb-3">📋 등록 결과</h6>
+          <h6 class="fw-semibold mb-3"><i class="bi bi-clipboard"></i> 등록 결과</h6>
           <div id="uploadResults"></div>
           <div class="d-flex gap-2 mt-3">
             <button class="btn btn-outline-secondary" data-bs-dismiss="modal">닫기</button>
@@ -324,8 +324,8 @@ function addImageRow(url) {
     <img class="img-thumb flex-shrink-0 rounded border" alt="" style="width:46px;height:46px;object-fit:cover;background:#f1f3f5;cursor:zoom-in"
          title="클릭하면 원본 보기" onerror="this.style.visibility='hidden'">
     <input type="url" class="form-control form-control-sm img-url" placeholder="https://..." value="${escapeHtml(url || '')}">
-    <button class="btn btn-outline-primary btn-sm btn-clean-img flex-shrink-0" type="button" title="워터마크 제거·정제(CDN 설정 시 재호스팅)">🧹</button>
-    <button class="btn btn-outline-danger btn-sm btn-del flex-shrink-0" type="button" title="삭제">✕</button>`;
+    <button class="btn btn-outline-primary btn-sm btn-clean-img flex-shrink-0" type="button" title="워터마크 제거·정제(CDN 설정 시 재호스팅)"><i class="bi bi-eraser"></i></button>
+    <button class="btn btn-outline-danger btn-sm btn-del flex-shrink-0" type="button" title="삭제"><i class="bi bi-x-lg"></i></button>`;
   const input = row.querySelector('.img-url');
   const thumb = row.querySelector('.img-thumb');
   function syncThumb() {
@@ -379,10 +379,10 @@ function refreshImageBadges() {
     if (!btn) return;
     if (i === 0) {
       btn.classList.add('btn-warning'); btn.classList.remove('btn-outline-warning');
-      btn.textContent = '⭐대표'; btn.disabled = true; btn.title = '현재 대표/썸네일';
+      btn.textContent = '대표'; btn.disabled = true; btn.title = '현재 대표/썸네일';
     } else {
       btn.classList.add('btn-outline-warning'); btn.classList.remove('btn-warning');
-      btn.textContent = '⭐'; btn.disabled = false; btn.title = '대표 이미지로 지정';
+      btn.textContent = '지정'; btn.disabled = false; btn.title = '대표 이미지로 지정';
     }
   });
   renderGallery();
@@ -420,7 +420,7 @@ function addOptionRow(name, values) {
   row.innerHTML = `
     <input type="text" class="form-control opt-name" style="max-width:160px;" placeholder="옵션명(예: 색상)" value="${escapeHtml(name || '')}">
     <input type="text" class="form-control opt-values" placeholder="값들(쉼표 구분: Black, White)" value="${escapeHtml(values || '')}">
-    <button class="btn btn-outline-danger" type="button" title="삭제">✕</button>`;
+    <button class="btn btn-outline-danger" type="button" title="삭제"><i class="bi bi-x-lg"></i></button>`;
   row.querySelector('button').addEventListener('click', () => row.remove());
   wrap.appendChild(row);
 }
@@ -585,14 +585,14 @@ async function autoClassify() {
       if (d.code === 'GEN') {
         hint.innerHTML = '키워드가 약해 자동 추천이 어려워요 — 직접 선택해 주세요.';
       } else {
-        hint.innerHTML = `🔮 ‘${d.label}’ 로 추천(신뢰도 ${Math.round((d.confidence||0)*100)}%). 맞지 않으면 직접 바꾸세요.`;
+        hint.innerHTML = `<i class="bi bi-magic"></i> ‘${d.label}’ 로 추천(신뢰도 ${Math.round((d.confidence||0)*100)}%). 맞지 않으면 직접 바꾸세요.`;
       }
       renderKeywordChips(d.suggested_keywords || []);
     }
   } catch (e) {
     hint.textContent = '자동 분류 실패 — 직접 선택해 주세요.';
   } finally {
-    btn.disabled = false; btn.textContent = '🔮 자동 분류';
+    btn.disabled = false; btn.textContent = '자동 분류';
   }
 }
 
@@ -658,7 +658,7 @@ async function saveEdits() {
   } catch (err) {
     pcToast('저장 요청 실패: ' + err.message, 'error');
   } finally {
-    btn.disabled = false; btn.textContent = '💾 변경사항 저장';
+    btn.disabled = false; btn.textContent = '변경사항 저장';
   }
 }
 
@@ -725,7 +725,7 @@ async function runPrevalidate() {
     });
     const data = await resp.json();
     btn.disabled = false;
-    btn.textContent = '🔍 사전검증 →';
+    btn.textContent = '사전검증 →';
 
     if (!data.ok) {
       pcToast(data.error || '사전검증 실패', 'error');
@@ -735,7 +735,7 @@ async function runPrevalidate() {
     goToStep('stepPrevalidate');
   } catch (err) {
     btn.disabled = false;
-    btn.textContent = '🔍 사전검증 →';
+    btn.textContent = '사전검증 →';
     pcToast('사전검증 요청 실패: ' + err.message, 'error');
   }
 }
@@ -756,7 +756,7 @@ function renderPrevalidateResults(results) {
         <div>
           <div class="fw-semibold">${r.market_label || r.market} ${badge}</div>
           <div class="text-muted small">${r.message}</div>
-          ${r.hint ? `<div class="text-warning small mt-1">💡 ${r.hint}</div>` : ''}
+          ${r.hint ? `<div class="text-warning small mt-1"><i class="bi bi-lightbulb"></i> ${r.hint}</div>` : ''}
         </div>
       </div>`;
   });
@@ -817,7 +817,7 @@ function renderUploadResults(data) {
       const idPart = r.external_product_id ? ` (ID: ${r.external_product_id})` : '';
       html += `
         <div class="list-group-item list-group-item-success">
-          <div class="fw-semibold">✅ ${r.market_label || r.market}${idPart} — 등록 성공${linkPart}</div>
+          <div class="fw-semibold"><i class="bi bi-check-circle text-success"></i> ${r.market_label || r.market}${idPart} — 등록 성공${linkPart}</div>
           <div class="small">${r.message}</div>
         </div>`;
     } else if (r.queued) {
@@ -825,14 +825,14 @@ function renderUploadResults(data) {
         <div class="list-group-item list-group-item-warning">
           <div class="fw-semibold">⏳ ${r.market_label || r.market} — 큐에 적재됨</div>
           <div class="small">${r.message}</div>
-          ${r.hint ? `<div class="text-muted small mt-1">💡 ${r.hint}</div>` : ''}
+          ${r.hint ? `<div class="text-muted small mt-1"><i class="bi bi-lightbulb"></i> ${r.hint}</div>` : ''}
         </div>`;
     } else {
       html += `
         <div class="list-group-item list-group-item-danger">
-          <div class="fw-semibold">❌ ${r.market_label || r.market} — 실패</div>
+          <div class="fw-semibold"><i class="bi bi-x-circle text-danger"></i> ${r.market_label || r.market} — 실패</div>
           <div class="small">${r.message}</div>
-          ${r.hint ? `<div class="text-warning small mt-1">💡 조치: ${r.hint}</div>` : ''}
+          ${r.hint ? `<div class="text-warning small mt-1"><i class="bi bi-lightbulb"></i> 조치: ${r.hint}</div>` : ''}
           ${r.error_code ? `<div class="text-muted small">오류코드: ${r.error_code}</div>` : ''}
         </div>`;
     }

--- a/tests/test_collect_bulk_status_duplicate.py
+++ b/tests/test_collect_bulk_status_duplicate.py
@@ -73,4 +73,4 @@ def test_history_page_has_status_and_duplicate_buttons(client):
         html = client.get("/seller/collect/history").get_data(as_text=True)
     assert "bulkStatusBtn" in html and "bulkDuplicateBtn" in html
     assert "runBulkDuplicate" in html
-    assert "📦 보관" in html  # archived 배지 렌더
+    assert "보관" in html and "bi-archive" in html  # archived 배지(v18 아이콘셋)

--- a/tests/test_edit_market_connection_badges.py
+++ b/tests/test_edit_market_connection_badges.py
@@ -28,8 +28,8 @@ def test_edit_page_shows_connection_badges(client):
          patch("src.seller_console.market_credentials.is_connected",
                side_effect=lambda sid, m: m in ("shopify", "coupang")):
         html = client.get("/seller/collect/preview/x").get_data(as_text=True)
-    assert "✅ 키 설정됨" in html          # 연결된 마켓
-    assert "❌ 미설정" in html         # 미연결 마켓
+    assert "키 설정됨" in html and "bi-check-circle" in html   # 연결된 마켓(v18 아이콘셋)
+    assert "미설정" in html and "bi-x-circle" in html         # 미연결 마켓
     assert "키 설정 2/5" in html          # 요약
     assert "/seller/markets/connect/smartstore" in html  # 미연결 → 연결 링크
 
@@ -39,4 +39,4 @@ def test_edit_page_all_connected_shows_full(client):
          patch("src.seller_console.market_credentials.is_connected", return_value=True):
         html = client.get("/seller/collect/preview/x").get_data(as_text=True)
     assert "키 설정 5/5" in html
-    assert "❌ 미설정" not in html
+    assert "미설정</a>" not in html  # 미설정 배지 없음


### PR DESCRIPTION
v18 디자인 마무리 — 차근차근 이모지 → 단일 아이콘셋(`bi-*`). 수집 플로우 화면.

## #3 수집 이력 (`collect_history.html`, 34개)
헤더·일괄 액션·모달·배지·`<option>`(텍스트만)·JS 문자열을 `bi-*`로.

## #4 수집 상품 편집 (`collect_preview.html`, ~36개)
헤더·가격 경고·대표 별·카테고리·저장·등록·결과 배지를 `bi-*`로(🌐/✏️/⚠️/⭐/🔮/💾/🔗/💰/📤/🔍/✅/❌/📋/🧹/✕/💡). JS `innerHTML` 리터럴은 `bi-*` 스팬, `textContent`는 텍스트만.

## 테스트
- 영향 테스트(`bulk_status_duplicate`·`edit_market_connection_badges`) 아이콘 기준 갱신. 전체 `pytest` **10248 passed**.

> 남은 화면(messaging·market_status·notifications·markets_connect·bookmarklet·me·pricing_rules 등) 차근차근 이어갑니다. (api_status는 관리자 전용이라 후순위.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)