### PR TITLE
feat(v18): 이모지 → 단일 아이콘셋 — 셀러 콘솔 전 화면 완료 (Phase 295)

### DIFF
--- a/src/seller_console/templates/about.html
+++ b/src/seller_console/templates/about.html
@@ -4,25 +4,25 @@
 <div class="container py-5" style="max-width: 760px;">
 
   <div class="text-center mb-5">
-    <div style="font-size:3.4rem;">🛒</div>
+    <div style="font-size:3.4rem;"><i class="bi bi-bag-check"></i></div>
     <h1 class="display-5 fw-bold mb-2">코고가네</h1>
     <p class="lead text-muted">해외 상품을 수집하고, 한국어로 다듬고, 우리 마켓에 등록까지.<br>구매대행 셀러를 위한 가장 쉬운 길.</p>
-    <a href="/seller/start" class="btn btn-cta btn-lg mt-2">✨ 처음이신가요? 시작하기</a>
+    <a href="/seller/start" class="btn btn-cta btn-lg mt-2"><i class="bi bi-stars"></i> 처음이신가요? 시작하기</a>
   </div>
 
   <div class="row g-4 text-center mb-5">
     <div class="col-md-4">
-      <div class="fs-1 mb-2">🔎</div>
+      <div class="fs-1 mb-2"><i class="bi bi-search"></i></div>
       <h5 class="fw-bold">수집</h5>
       <p class="text-muted small">타오바오·아마존·알리 등 어떤 상품이든 버튼 한 번으로 가져와요. 크롬 확장·모바일 공유·붙여넣기까지.</p>
     </div>
     <div class="col-md-4">
-      <div class="fs-1 mb-2">🌐</div>
+      <div class="fs-1 mb-2"><i class="bi bi-globe"></i></div>
       <h5 class="fw-bold">다듬기</h5>
       <p class="text-muted small">제목·설명을 한국어로 번역하고, 금지어를 정리하고, 가격·마진을 한 번에 맞춰요.</p>
     </div>
     <div class="col-md-4">
-      <div class="fs-1 mb-2">🚀</div>
+      <div class="fs-1 mb-2"><i class="bi bi-rocket-takeoff"></i></div>
       <h5 class="fw-bold">등록</h5>
       <p class="text-muted small">쿠팡·스마트스토어·11번가 등 여러 마켓에 한 번에 올리고, 주문·정산까지 한곳에서.</p>
     </div>

--- a/src/seller_console/templates/analytics.html
+++ b/src/seller_console/templates/analytics.html
@@ -2,7 +2,7 @@
 {% block title %}BI 분석{% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h3 class="mb-0">📈 재고/판매 분석 BI</h3>
+  <h3 class="mb-0"><i class="bi bi-graph-up-arrow"></i> 재고/판매 분석 BI</h3>
   <a href="/seller/analytics?force_refresh=1" class="btn btn-sm btn-outline-secondary">새로고침</a>
 </div>
 
@@ -15,7 +15,7 @@
 <div class="row g-3">
   <div class="col-12 col-lg-6">
     <div class="card h-100">
-      <div class="card-header fw-semibold">🏆 베스트셀러 TOP 20</div>
+      <div class="card-header fw-semibold"><i class="bi bi-trophy"></i> 베스트셀러 TOP 20</div>
       <div class="card-body p-0">
         <table class="table table-sm mb-0">
           <thead><tr><th>SKU</th><th>판매량</th><th>매출</th><th></th></tr></thead>
@@ -38,7 +38,7 @@
   </div>
   <div class="col-12 col-lg-6">
     <div class="card h-100">
-      <div class="card-header fw-semibold">📦 재고 알림</div>
+      <div class="card-header fw-semibold"><i class="bi bi-box-seam"></i> 재고 알림</div>
       <div class="card-body">
         <div class="mb-2 text-danger">재고 임박: {{ data.inventory_alerts.low_stock|length }}개</div>
         <div class="mb-2 text-warning">재고 과잉: {{ data.inventory_alerts.over_stock|length }}개</div>
@@ -50,10 +50,10 @@
 
 <div class="row g-3 mt-1">
   <div class="col-12 col-lg-6">
-    <div class="card h-100"><div class="card-header fw-semibold">📢 광고 ROI</div><div class="card-body">ROAS 임계값: {{ data.ad_roi.roas_threshold }}</div></div>
+    <div class="card h-100"><div class="card-header fw-semibold"><i class="bi bi-megaphone"></i>  광고 ROI</div><div class="card-body">ROAS 임계값: {{ data.ad_roi.roas_threshold }}</div></div>
   </div>
   <div class="col-12 col-lg-6">
-    <div class="card h-100"><div class="card-header fw-semibold">🚚 CS/배송 품질</div><div class="card-body">
+    <div class="card h-100"><div class="card-header fw-semibold"><i class="bi bi-truck"></i>  CS/배송 품질</div><div class="card-body">
       <div>24h 미응답: {{ data.quality.unanswered_24h }}건</div>
       <div>배송 지연: {{ data.quality.delayed_shipping }}건</div>
       <div>환불률: {{ data.quality.refund_rate }}%</div>

--- a/src/seller_console/templates/api_status.html
+++ b/src/seller_console/templates/api_status.html
@@ -11,9 +11,9 @@
       <div class="d-flex justify-content-between align-items-start mb-2">
         <h6 class="card-title mb-0 fw-semibold">{{ api.name }}</h6>
         {% if api.status == 'active' %}
-          <span class="badge bg-success">✅ 활성</span>
+          <span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span>
         {% else %}
-          <span class="badge bg-warning text-dark">⚠️ 미설정</span>
+          <span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> 미설정</span>
         {% endif %}
       </div>
       <p class="text-muted small mb-2">{{ api.purpose }}</p>
@@ -23,10 +23,10 @@
         {% for var_name, var_val in api.env_vars.items() %}
         <div class="d-flex align-items-center gap-2 mb-1">
           {% if var_val %}
-            <span class="badge bg-light text-dark border" style="font-family:monospace;font-size:0.7rem;">✅ {{ var_name }}</span>
+            <span class="badge bg-light text-dark border" style="font-family:monospace;font-size:0.7rem;"><i class="bi bi-check-circle"></i> {{ var_name }}</span>
             <span class="text-muted" style="font-family:monospace;font-size:0.7rem;">{{ var_val }}</span>
           {% else %}
-            <span class="badge bg-danger" style="font-family:monospace;font-size:0.7rem;">❌ {{ var_name }}</span>
+            <span class="badge bg-danger" style="font-family:monospace;font-size:0.7rem;"><i class="bi bi-x-circle"></i> {{ var_name }}</span>
             <span class="text-muted small">미설정</span>
           {% endif %}
         </div>
@@ -36,7 +36,7 @@
       <!-- 발급 링크 -->
       {% if api.status == 'missing' %}
       <a href="{{ api.docs_url }}" class="btn btn-outline-primary btn-sm" target="_blank">
-        📋 발급 가이드 →
+        <i class="bi bi-card-list"></i> 발급 가이드 →
       </a>
       {% endif %}
     </div>
@@ -45,13 +45,13 @@
 {% endmacro %}
 
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h4 class="mb-0 fw-bold">🔑 API 상태</h4>
+  <h4 class="mb-0 fw-bold"><i class="bi bi-key"></i> API 상태</h4>
   <a href="/seller/api-status/json" class="btn btn-outline-secondary btn-sm" target="_blank">JSON 보기</a>
 </div>
 
 <!-- Render Env 경고 배너 -->
 <div class="alert alert-warning d-flex align-items-start gap-2 mb-3" role="alert">
-  <span class="fs-5">⚠️</span>
+  <span class="fs-5"><i class="bi bi-exclamation-triangle"></i></span>
   <div>
     <strong>GitHub Secrets는 인식하지 않습니다.</strong>
     환경변수는 반드시
@@ -86,16 +86,16 @@
 
 <!-- 카테고리 탭 -->
 {% set cat_labels = {
-  "marketplace": "🛒 마켓",
-  "sourcing": "📦 소싱",
-  "ai": "🤖 AI",
-  "payment": "💳 결제",
-  "auth": "🔐 인증",
-  "notification": "🔔 알림",
-  "logistics": "🚚 물류",
-  "self_mall": "🏪 자체몰",
-  "utility": "🛠 유틸",
-  "infra": "⚙️ 인프라"
+  "marketplace": "마켓",
+  "sourcing": "소싱",
+  "ai": "AI",
+  "payment": "결제",
+  "auth": "인증",
+  "notification": "알림",
+  "logistics": "물류",
+  "self_mall": "자체몰",
+  "utility": "유틸",
+  "infra": "인프라"
 } %}
 
 {% set all_cats = [] %}
@@ -162,10 +162,10 @@
 {% endif %}
 
 <div class="mt-4 p-3 bg-light rounded">
-  <h6 class="fw-semibold mb-2">📌 환경변수 등록 방법</h6>
+  <h6 class="fw-semibold mb-2"><i class="bi bi-pin-angle"></i> 환경변수 등록 방법</h6>
   <ol class="text-muted small mb-0">
     <li><a href="https://dashboard.render.com" target="_blank">Render Dashboard</a> → 내 서비스 → <strong>Environment</strong> 탭 클릭</li>
-    <li>환경변수 이름(위의 ❌ 항목)과 값을 입력하고 저장</li>
+    <li>환경변수 이름(위의 미설정 항목)과 값을 입력하고 저장</li>
     <li>Manual Deploy → 이 페이지 새로고침으로 확인</li>
   </ol>
 </div>

--- a/src/seller_console/templates/billing.html
+++ b/src/seller_console/templates/billing.html
@@ -2,13 +2,13 @@
 {% block title %}요금제·충전{% endblock %}
 {% block content %}
 <div class="container py-4" style="max-width: 880px;">
-  <h1 class="h3 mb-1">💳 요금제 · 충전</h1>
+  <h1 class="h3 mb-1"><i class="bi bi-credit-card"></i> 요금제 · 충전</h1>
   <p class="text-muted">쉽고 간편하게. 지금 플랜: <strong>{{ plans[account.plan].label }}</strong>
     · 무료 번역 <strong>{{ free_remaining }}</strong>/{{ free_limit }}회 남음
     {% if account.token_balance %}· 토큰 <strong>{{ account.token_balance }}</strong>{% endif %}</p>
 
   {% if not pay_ready %}
-  <div class="alert alert-light border small">🔒 결제 연동(토스페이먼츠)이 아직 켜지지 않았어요. Free는 바로 쓰실 수 있고,
+  <div class="alert alert-light border small"><i class="bi bi-shield-lock"></i> 결제 연동(토스페이먼츠)이 아직 켜지지 않았어요. Free는 바로 쓰실 수 있고,
     유료 플랜은 결제가 열리면 한 번에 결제됩니다. <span class="pc-help" data-bs-toggle="tooltip" data-bs-title="Render에 TOSS_CLIENT_KEY/TOSS_SECRET_KEY 설정 시 결제가 활성화됩니다.">?</span></div>
   {% endif %}
 

--- a/src/seller_console/templates/bookmarklet.html
+++ b/src/seller_console/templates/bookmarklet.html
@@ -2,11 +2,11 @@
 {% block title %}북마클릿 설치{% endblock %}
 {% block content %}
 <div class="container-fluid py-4">
-  <h1 class="h3 mb-1">📌 북마클릿 (고급)</h1>
+  <h1 class="h3 mb-1"><i class="bi bi-bookmark-star"></i> 북마클릿 (고급)</h1>
   <p class="text-muted mb-3">쇼핑 페이지에서 클릭 한 번으로 상품을 수집합니다. <strong>토큰 없이</strong> 바로 작동해요(로그인만 되어 있으면 됩니다).</p>
 
   <div class="alert alert-primary d-flex align-items-center gap-2 mb-4" role="note">
-    <span style="font-size:1.3rem">🧩</span>
+    <span style="font-size:1.3rem"><i class="bi bi-puzzle"></i></span>
     <div class="small">
       <strong>북마클릿이 뭔가요?</strong> 북마크바에 두고 누르면 그 페이지의 상품을 수집하는 작은 버튼이에요.
       <strong>언제 쓰나요?</strong> 크롬 확장을 설치하기 어려운 환경(회사·공용 PC, 일부 모바일 브라우저)에서 쓰는 <strong>보조 수단</strong>입니다.<br>
@@ -17,11 +17,11 @@
 
   <!-- v17 P1: 확장 vs 북마클릿 차이 표 -->
   <div class="card mb-4">
-    <div class="card-header"><strong>🔍 크롬 확장 vs 북마클릿 — 무엇을 쓸까요?</strong></div>
+    <div class="card-header"><strong><i class="bi bi-search"></i> 크롬 확장 vs 북마클릿 — 무엇을 쓸까요?</strong></div>
     <div class="table-responsive">
       <table class="table table-sm mb-0 align-middle">
         <thead class="table-light">
-          <tr><th>비교</th><th>🧩 크롬 확장 <span class="badge text-bg-success">메인·권장</span></th><th>📌 북마클릿 <span class="badge text-bg-secondary">보조</span></th></tr>
+          <tr><th>비교</th><th><i class="bi bi-puzzle"></i> 크롬 확장 <span class="badge text-bg-success">메인·권장</span></th><th><i class="bi bi-bookmark"></i> 북마클릿 <span class="badge text-bg-secondary">보조</span></th></tr>
         </thead>
         <tbody>
           <tr><td>설치</td><td>한 번 설치(고가수집기)</td><td>설치 불필요 — 북마크바에 주소만 등록</td></tr>
@@ -39,7 +39,7 @@
     <!-- 설치 안내 -->
     <div class="col-lg-7">
       <div class="card mb-4">
-        <div class="card-header"><strong>🔧 설치 방법 (2단계)</strong></div>
+        <div class="card-header"><strong><i class="bi bi-wrench"></i> 설치 방법 (2단계)</strong></div>
         <div class="card-body">
           <ol class="mb-2">
             <li>아래 <strong>🧤 버튼</strong>을 마우스로 드래그해 브라우저 북마크바에 놓으세요.</li>
@@ -47,7 +47,7 @@
                 <strong>‘수집 완료’</strong>만 표시됩니다. 결과는 <strong>내 계정의 ‘수집 이력’</strong>에서 확인·편집하세요.</li>
           </ol>
           <div class="alert alert-success small mb-0">
-            ✅ <strong>토큰이 필요 없습니다.</strong> 새 탭이 코고가네(로그인된 내 계정)로 열려 안전하게 수집됩니다.
+            <i class="bi bi-check-circle text-success"></i> <strong>토큰이 필요 없습니다.</strong> 새 탭이 코고가네(로그인된 내 계정)로 열려 안전하게 수집됩니다.
             (예전 토큰 방식은 일부 사이트의 보안정책(CSP)에 막혀 작동하지 않았어요 — 이 방식은 그 문제가 없습니다.)
           </div>
         </div>
@@ -55,7 +55,7 @@
 
       <!-- 수집 시 번역 선택 -->
       <div class="card mb-4">
-        <div class="card-header"><strong>🌐 번역 설정</strong></div>
+        <div class="card-header"><strong><i class="bi bi-globe"></i> 번역 설정</strong></div>
         <div class="card-body">
           <div class="form-check form-switch">
             <input class="form-check-input" type="checkbox" id="translateToggle" checked>
@@ -67,7 +67,7 @@
 
       <!-- 북마클릿 버튼 -->
       <div class="card">
-        <div class="card-header"><strong>📌 북마클릿 (드래그해서 북마크바에 추가)</strong></div>
+        <div class="card-header"><strong><i class="bi bi-bookmark-plus"></i> 북마클릿 (드래그해서 북마크바에 추가)</strong></div>
         <div class="card-body text-center py-4">
           <!-- 토큰 불필요: 새 탭(로그인 세션)으로 데이터를 보내 수집(CSP/CORS 우회).
                북마크바에 이모지 1글자(🧤)만 이름으로 들어가 아이콘처럼 보이게 한다(긴 JS 코드 노출 방지). -->
@@ -97,7 +97,7 @@
       </div>
 
       <div class="card mt-3">
-        <div class="card-header"><strong>ℹ️ 동작 원리</strong></div>
+        <div class="card-header"><strong><i class="bi bi-info-circle"></i> 동작 원리</strong></div>
         <div class="card-body small text-muted">
           <ol class="mb-2">
             <li>상품 페이지의 <strong>이미지·상세설명·리뷰·HTML</strong>을 읽습니다.</li>

--- a/src/seller_console/templates/catalog.html
+++ b/src/seller_console/templates/catalog.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h4 class="mb-0 fw-bold">📦 상품 카탈로그</h4>
+  <h4 class="mb-0 fw-bold"><i class="bi bi-box-seam"></i> 상품 카탈로그</h4>
   <div class="d-flex gap-2">
     <a href="/seller/collect" class="btn btn-primary btn-sm">+ 새 상품 수집</a>
     <span class="badge bg-secondary align-self-center">
@@ -14,7 +14,7 @@
 
 {% if error_msg %}
 <div class="alert alert-warning mb-4">
-  <strong>⚠️ 로드 오류:</strong> {{ error_msg }}
+  <strong><i class="bi bi-exclamation-triangle"></i> 로드 오류:</strong> {{ error_msg }}
 </div>
 {% endif %}
 
@@ -149,7 +149,7 @@
               <button class="btn btn-outline-secondary btn-sm py-0"
                       aria-label="상품 동기화"
                       onclick="syncItem(this, '{{ item.product_id }}', '{{ item.marketplace }}')">
-                🔄 동기화
+                <i class="bi bi-arrow-clockwise"></i> 동기화
               </button>
               {% else %}
               <button class="btn btn-outline-secondary btn-sm py-0" disabled aria-disabled="true">

--- a/src/seller_console/templates/collect_quick_result.html
+++ b/src/seller_console/templates/collect_quick_result.html
@@ -5,11 +5,11 @@
   <div class="card console-card">
     <div class="card-body text-center py-4">
       {% if ok %}
-      <div class="display-6 mb-2">✅</div>
+      <div class="display-6 mb-2"><i class="bi bi-check-circle text-success"></i></div>
       <h1 class="h5 mb-2">수집 완료</h1>
       <p class="text-muted small mb-3">{{ message }}</p>
       {% else %}
-      <div class="display-6 mb-2">⚠️</div>
+      <div class="display-6 mb-2"><i class="bi bi-exclamation-triangle text-warning"></i></div>
       <h1 class="h5 mb-2">자동 수집이 어려운 페이지예요</h1>
       <p class="text-muted small mb-3">{{ message }}</p>
       {% endif %}
@@ -31,7 +31,7 @@
       </div>
 
       <div class="alert alert-light border small mt-4 mb-0 text-start">
-        💡 <strong>봇 차단이 강한 사이트</strong>(로그인 필요·강한 보호)는 <strong>크롬 확장(고가네 수집)</strong>을
+        <i class="bi bi-lightbulb"></i> <strong>봇 차단이 강한 사이트</strong>(로그인 필요·강한 보호)는 <strong>크롬 확장(고가네 수집)</strong>을
         쓰면 브라우저 화면 그대로 수집됩니다. <a href="/seller/markets/guide">설치 가이드 →</a>
       </div>
     </div>

--- a/src/seller_console/templates/collect_receiver.html
+++ b/src/seller_console/templates/collect_receiver.html
@@ -25,7 +25,7 @@ function showSuccess(d) {
   if (d.review_count) meta.push('리뷰 ' + d.review_count + '개');
   meta.push(d.translated ? '한국어 번역 포함' : '원문');
   render(
-    '<div class="display-6 mb-2">✅</div>' +
+    '<div class="display-6 mb-2"><i class="bi bi-check-circle text-success"></i></div>' +
     '<h1 class="h5 mb-1">수집 완료!</h1>' +
     '<div class="fw-semibold text-truncate mb-1">' + (d.title || '') + '</div>' +
     '<div class="small text-muted mb-3">' + meta.join(' · ') + '</div>' +
@@ -40,7 +40,7 @@ function showSuccess(d) {
 
 function showError(msg) {
   render(
-    '<div class="display-6 mb-2">⚠️</div>' +
+    '<div class="display-6 mb-2"><i class="bi bi-exclamation-triangle text-warning"></i></div>' +
     '<h1 class="h5 mb-2">자동 수집이 어려운 페이지예요</h1>' +
     '<p class="text-muted small mb-3">' + (msg || '상품 정보를 읽지 못했습니다.') + '</p>' +
     '<div class="d-flex gap-2 justify-content-center flex-wrap">' +
@@ -53,7 +53,7 @@ function showError(msg) {
 function showLogin() {
   // 로그인 페이지로 튕기지 않고, 이 창 안에서 친절히 로그인 안내
   render(
-    '<div class="display-6 mb-2">🔒</div>' +
+    '<div class="display-6 mb-2"><i class="bi bi-shield-lock"></i></div>' +
     '<h1 class="h5 mb-2">코고가네 로그인이 필요해요</h1>' +
     '<p class="text-muted small mb-3">로그인 후 다시 상품 페이지에서 북마클릿을 누르면 바로 수집됩니다.</p>' +
     '<div class="d-flex gap-2 justify-content-center flex-wrap">' +

--- a/src/seller_console/templates/cs_faq.html
+++ b/src/seller_console/templates/cs_faq.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h4 class="mb-0">📚 CS FAQ 관리</h4>
+  <h4 class="mb-0"><i class="bi bi-book"></i> CS FAQ 관리</h4>
   <a class="btn btn-outline-secondary btn-sm" href="/seller/cs/inbox">Inbox</a>
 </div>
 

--- a/src/seller_console/templates/cs_inbox.html
+++ b/src/seller_console/templates/cs_inbox.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h4 class="mb-0">📨 CS Inbox</h4>
+  <h4 class="mb-0"><i class="bi bi-envelope"></i> CS Inbox</h4>
   <div class="d-flex gap-2">
     <a class="btn btn-outline-secondary btn-sm" href="/seller/cs/faq">FAQ 관리</a>
     <a class="btn btn-outline-secondary btn-sm" href="/seller/cs/sla">SLA 현황</a>

--- a/src/seller_console/templates/cs_mobile.html
+++ b/src/seller_console/templates/cs_mobile.html
@@ -19,7 +19,7 @@
 
 <div class="container-sm py-3" style="max-width:520px">
   <div class="d-flex justify-content-between align-items-center mb-3">
-    <h5 class="mb-0">📱 CS Mobile</h5>
+    <h5 class="mb-0"><i class="bi bi-phone"></i> CS Mobile</h5>
     <div class="d-flex gap-2">
       <a class="btn btn-outline-secondary btn-sm" href="/seller/cs/inbox">PC 버전</a>
       <button class="btn btn-outline-primary btn-sm" id="install-banner" onclick="installPWA()">홈화면 추가</button>
@@ -70,7 +70,7 @@
            id="ai-{{ msg.message_id }}"
            ontouchstart=""
            onclick="toggleAI('{{ msg.message_id }}')">
-        💡 {{ msg.suggested_reply }}
+        <i class="bi bi-lightbulb"></i> {{ msg.suggested_reply }}
       </div>
       {% endif %}
 
@@ -81,18 +81,18 @@
                   placeholder="답변 입력 (비워두면 AI 제안 사용)"></textarea>
         <div class="d-flex gap-2 action-btns">
           <button type="submit" name="action" value="send"
-                  class="btn btn-success flex-fill">✅ 발송</button>
+                  class="btn btn-success flex-fill"><i class="bi bi-send"></i> 발송</button>
           <button type="submit" name="action" value="hold"
                   class="btn btn-outline-warning flex-fill">⏸ 보류</button>
           <button type="submit" name="action" value="resolve"
-                  class="btn btn-outline-secondary flex-fill">✔ 해결</button>
+                  class="btn btn-outline-secondary flex-fill"><i class="bi bi-check-lg"></i> 해결</button>
         </div>
       </form>
     </div>
   </div>
   {% else %}
   <div class="text-center text-muted py-5">
-    <div style="font-size:2rem">🎉</div>
+    <div style="font-size:2rem"><i class="bi bi-emoji-smile"></i></div>
     <div>미응답 메시지 없음</div>
   </div>
   {% endfor %}

--- a/src/seller_console/templates/cs_quality.html
+++ b/src/seller_console/templates/cs_quality.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h4 class="mb-0">🧪 CS 답변 품질 루프</h4>
+  <h4 class="mb-0"><i class="bi bi-clipboard-check"></i> CS 답변 품질 루프</h4>
   <div class="d-flex gap-2">
     <a class="btn btn-outline-secondary btn-sm" href="/seller/cs/inbox">Inbox</a>
     <a class="btn btn-outline-secondary btn-sm" href="/seller/cs/faq">FAQ</a>

--- a/src/seller_console/templates/cs_stats.html
+++ b/src/seller_console/templates/cs_stats.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h4 class="mb-0">📊 CS 통계 대시보드</h4>
+  <h4 class="mb-0"><i class="bi bi-bar-chart"></i> CS 통계 대시보드</h4>
   <div class="d-flex gap-2">
     <a class="btn btn-outline-secondary btn-sm" href="/seller/cs/inbox">Inbox</a>
     <a class="btn btn-outline-secondary btn-sm" href="/seller/cs/mobile">Mobile</a>
@@ -43,7 +43,7 @@
   <!-- 채널별 -->
   <div class="col-md-4">
     <div class="card border-0 shadow-sm">
-      <div class="card-header fw-semibold">📡 채널별</div>
+      <div class="card-header fw-semibold"><i class="bi bi-broadcast"></i> 채널별</div>
       <div class="card-body p-0">
         <table class="table table-sm mb-0">
           <thead><tr><th>채널</th><th>전체</th><th>해결</th></tr></thead>
@@ -66,7 +66,7 @@
   <!-- 카테고리별 -->
   <div class="col-md-4">
     <div class="card border-0 shadow-sm">
-      <div class="card-header fw-semibold">🏷 카테고리별</div>
+      <div class="card-header fw-semibold"><i class="bi bi-tag"></i> 카테고리별</div>
       <div class="card-body p-0">
         <table class="table table-sm mb-0">
           <thead><tr><th>카테고리</th><th>전체</th><th>해결</th></tr></thead>
@@ -89,7 +89,7 @@
   <!-- 언어별 -->
   <div class="col-md-4">
     <div class="card border-0 shadow-sm">
-      <div class="card-header fw-semibold">🌐 언어별</div>
+      <div class="card-header fw-semibold"><i class="bi bi-globe"></i> 언어별</div>
       <div class="card-body p-0">
         <table class="table table-sm mb-0">
           <thead><tr><th>언어</th><th>건수</th></tr></thead>

--- a/src/seller_console/templates/dashboard.html
+++ b/src/seller_console/templates/dashboard.html
@@ -8,7 +8,7 @@
       <h1 class="h4 mb-1">통합 셀러 대시보드</h1>
       <p class="text-muted mb-0">오늘 핵심 지표와 주요 작업을 한 번에 확인하세요.</p>
     </div>
-    <a href="/seller/start" class="btn btn-cta btn-lg">✨ For Beginners · 처음이신가요?</a>
+    <a href="/seller/start" class="btn btn-cta btn-lg"><i class="bi bi-stars"></i> For Beginners · 처음이신가요?</a>
   </div>
 
   {% if onboarding.show_completion_notice %}

--- a/src/seller_console/templates/discovery.html
+++ b/src/seller_console/templates/discovery.html
@@ -4,11 +4,11 @@
 <div class="container-fluid py-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
-      <h1 class="h3 mb-0">🔍 Discovery 후보 관리</h1>
+      <h1 class="h3 mb-0"><i class="bi bi-search"></i> Discovery 후보 관리</h1>
       <small class="text-muted">자동 발견된 쇼핑몰 후보를 검토합니다.</small>
     </div>
     <div class="d-flex gap-2">
-      <a href="/seller/discovery/keywords" class="btn btn-outline-secondary">🏷 키워드 관리</a>
+      <a href="/seller/discovery/keywords" class="btn btn-outline-secondary"><i class="bi bi-tag"></i> 키워드 관리</a>
       <button class="btn btn-primary" id="runScoutBtn">▶ Discovery 실행</button>
     </div>
   </div>
@@ -65,8 +65,8 @@
             </td>
             <td>
               {% if c.status == 'pending' %}
-              <button class="btn btn-sm btn-success approve-btn" data-domain="{{ c.domain }}">✅ 승인</button>
-              <button class="btn btn-sm btn-outline-danger reject-btn ms-1" data-domain="{{ c.domain }}">❌ 거부</button>
+              <button class="btn btn-sm btn-success approve-btn"><i class="bi bi-check-lg"></i> 승인</button>
+              <button class="btn btn-sm btn-outline-danger reject-btn><i class="bi bi-x-lg"></i> 거부</button>
               {% endif %}
             </td>
           </tr>

--- a/src/seller_console/templates/discovery_keywords.html
+++ b/src/seller_console/templates/discovery_keywords.html
@@ -4,7 +4,7 @@
 <div class="container-fluid py-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
-      <h1 class="h3 mb-0">🏷 Discovery 키워드 관리</h1>
+      <h1 class="h3 mb-0"><i class="bi bi-tag"></i> Discovery 키워드 관리</h1>
       <small class="text-muted">Sheets `discovery_keywords` 워크시트와 동기화됩니다.</small>
     </div>
     <a href="/seller/discovery" class="btn btn-outline-secondary">← Discovery 후보 목록</a>
@@ -13,7 +13,7 @@
   <div class="row g-4">
     <div class="col-md-5">
       <div class="card">
-        <div class="card-header"><strong>➕ 키워드 추가</strong></div>
+        <div class="card-header"><strong><i class="bi bi-plus-circle"></i> 키워드 추가</strong></div>
         <div class="card-body">
           <div class="input-group">
             <input type="text" class="form-control" id="newKeyword"

--- a/src/seller_console/templates/extension_install.html
+++ b/src/seller_console/templates/extension_install.html
@@ -11,14 +11,14 @@
   <div class="row g-2 mb-3">
     <div class="col-md-6">
       <div class="card console-card h-100"><div class="card-body py-3">
-        <div class="fw-semibold mb-1">🧤 고가수집기가 뭐예요?</div>
+        <div class="fw-semibold mb-1"><i class="bi bi-box-seam"></i> 고가수집기가 뭐예요?</div>
         <div class="small text-muted">쇼핑몰 상품 페이지에서 <b>제목·가격·이미지를 한 번에 가져오는 도우미</b>예요.
           하나하나 복사할 필요 없이 버튼 한 번이면 끝나요.</div>
       </div></div>
     </div>
     <div class="col-md-6">
       <div class="card console-card h-100"><div class="card-body py-3">
-        <div class="fw-semibold mb-1">🔑 토큰은 왜 넣어요?</div>
+        <div class="fw-semibold mb-1"><i class="bi bi-key"></i> 토큰은 왜 넣어요?</div>
         <div class="small text-muted">토큰은 <b>“이 수집기가 내 계정 것”임을 알려주는 열쇠</b>예요.
           딱 <b>한 번만</b> 넣으면, 가져온 상품이 내 계정으로 쏙 들어와요.</div>
       </div></div>
@@ -61,28 +61,28 @@ const MANAGE_URL = "chrome://extensions";
 
 // 각 단계: 한 화면 = 한 메시지 + 버튼 1개(주 행동). 다음/이전은 하단 고정.
 const STEPS = [
-  { emoji: "📥", title: "1) 고가수집기 받기",
+  { icon: "bi-download", title: "1) 고가수집기 받기",
     body: "먼저 <b>고가수집기</b> 파일을 내려받아요(<b>gogasujipgi</b> 파일). 받은 파일은 <b>압축을 풀어</b> 두세요.",
     btn: { label: "고가수집기 다운로드", href: DL } },
-  { emoji: "🗂️", title: "2) 압축 풀기",
+  { icon: "bi-file-zip", title: "2) 압축 풀기",
     body: "받은 zip 파일을 <b>마우스 오른쪽 → 압축 풀기</b> 하세요. 폴더 하나가 만들어져요.",
     btn: { label: "압축 풀었어요 · 다음", act: "next" } },
-  { emoji: "🧭", title: "3) 확장 관리 화면 열기",
+  { icon: "bi-compass", title: "3) 확장 관리 화면 열기",
     body: "크롬 주소창에 아래 주소를 붙여넣고 엔터를 누르세요. (복사 버튼을 쓰면 편해요.)",
     code: MANAGE_URL,
     btn: { label: "주소 복사하기", act: "copy", value: MANAGE_URL } },
-  { emoji: "🛠️", title: "4) ‘개발자 모드’ 켜기",
+  { icon: "bi-tools", title: "4) ‘개발자 모드’ 켜기",
     body: "확장 관리 화면 <b>오른쪽 위</b>의 <b>‘개발자 모드’</b> 스위치를 <b>켜기</b>로 바꾸세요.",
     btn: { label: "켰어요 · 다음", act: "next" } },
-  { emoji: "📂", title: "5) 압축 푼 폴더 불러오기",
+  { icon: "bi-folder2-open", title: "5) 압축 푼 폴더 불러오기",
     body: "왼쪽 위 <b>‘압축해제된 확장 프로그램 로드’</b>를 누르고, 방금 <b>압축 푼 폴더</b>를 고르세요. " +
           "‘코고가네 수집기’가 목록에 뜨면 설치 완료예요.",
     btn: { label: "설치됐어요 · 다음", act: "next" } },
-  { emoji: "🔑", title: "6) 토큰 한 번 넣기",
+  { icon: "bi-key", title: "6) 토큰 한 번 넣기",
     body: "확장이 내 계정과 연결되도록 <b>토큰</b>을 한 번만 넣어요. 토큰을 발급받아 확장 <b>옵션</b>에 붙여넣으세요. " +
           "<span class='pc-help' data-bs-toggle='tooltip' data-bs-title='확장 아이콘을 오른쪽 클릭 → 옵션 → 서버 주소와 토큰을 붙여넣기. 서버 주소는 자동으로 채워져 있어요.'>?</span>",
     btn: { label: "토큰 발급받기", href: TOKENS } },
-  { emoji: "🎉", title: "7) 다 됐어요!",
+  { icon: "bi-check-circle", title: "7) 다 됐어요!",
     body: "이제 지정 소싱처(타오바오·아마존 등) 상품 페이지에서 <b>코고가네 수집</b> 버튼이, 목록 페이지엔 카드마다 <b>수집 배지</b>가 떠요.",
     btn: { label: "상품 수집하러 가기", href: COLLECT } },
 ];
@@ -93,7 +93,7 @@ function render() {
   document.getElementById("extProgress").textContent = `설치 단계 ${cur + 1} / ${STEPS.length}`;
   document.getElementById("extProgressBar").style.width = Math.round((cur + 1) / STEPS.length * 100) + "%";
   document.getElementById("extStepNo").textContent = `${cur + 1} / ${STEPS.length}`;
-  let html = `<div style="font-size:3rem">${s.emoji}</div><h2 class="h5 mt-2">${s.title}</h2>` +
+  let html = `<div style="font-size:3rem"><i class="bi ${s.icon}"></i></div><h2 class="h5 mt-2">${s.title}</h2>` +
              `<p class="text-muted mt-2 mb-3">${s.body}</p>`;
   if (s.code) {
     html += `<div class="d-flex justify-content-center mb-3"><span class="px-3 py-2 rounded" style="background:#f5f1e6;font-family:monospace">${s.code}</span></div>`;

--- a/src/seller_console/templates/guide_business.html
+++ b/src/seller_console/templates/guide_business.html
@@ -3,13 +3,13 @@
 {% block content %}
 <div class="container-fluid py-4" style="max-width: 920px;">
   <div class="mb-4">
-    <h1 class="h3 mb-1">🪪 사업자 등록 가이드</h1>
+    <h1 class="h3 mb-1"><i class="bi bi-person-badge"></i> 사업자 등록 가이드</h1>
     <p class="text-muted mb-0">구매대행 셀러로 시작하려면 보통 <strong>사업자등록 → 통신판매업 신고</strong> 순서로 진행합니다. 아래 단계를 하나씩 따라가세요.</p>
   </div>
 
   <!-- 면책 (브리프 §4.3) -->
   <div class="alert alert-warning small mb-4">
-    ⚠️ <strong>안내 면책:</strong> 아래는 일반적인 절차 안내이며 법령·세무·수수료·신고 요건은 <strong>수시로 바뀝니다</strong>.
+    <i class="bi bi-exclamation-triangle"></i> <strong>안내 면책:</strong> 아래는 일반적인 절차 안내이며 법령·세무·수수료·신고 요건은 <strong>수시로 바뀝니다</strong>.
     실제 신고 전 <strong>관할 세무서·지자체·세무 전문가</strong>에게 최신 요건을 꼭 확인하세요. 공식 사이트의 절차/메뉴 위치도 변경될 수 있습니다.
   </div>
 
@@ -25,7 +25,7 @@
             <li>준비물: 신분증, (필요 시) 임대차계약서 등 — 요건은 관할서 확인</li>
             <li>업종코드/과세유형은 본인 상황에 맞게 — 모르면 세무서에 문의</li>
           </ul>
-          <a href="https://www.hometax.go.kr" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm">🔗 홈택스 열기(사업자등록)</a>
+          <a href="https://www.hometax.go.kr" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm"><i class="bi bi-box-arrow-up-right"></i> 홈택스 열기(사업자등록)</a>
           <a href="https://www.gov.kr" target="_blank" rel="noopener noreferrer" class="btn btn-outline-secondary btn-sm">정부24</a>
         </div>
       </div>
@@ -44,7 +44,7 @@
             <li>준비물: 사업자등록증, 구매안전서비스 이용확인증(결제대행/오픈마켓 발급) 등</li>
             <li>신고 후 발급되는 <strong>통신판매업 신고번호</strong>는 쇼핑몰·상세페이지에 표기</li>
           </ul>
-          <a href="https://www.gov.kr" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm">🔗 정부24 열기(통신판매업 신고)</a>
+          <a href="https://www.gov.kr" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm"><i class="bi bi-box-arrow-up-right"></i> 정부24 열기(통신판매업 신고)</a>
           <a href="https://www.ftc.go.kr" target="_blank" rel="noopener noreferrer" class="btn btn-outline-secondary btn-sm">공정위(사업자 정보공개)</a>
         </div>
       </div>
@@ -64,7 +64,7 @@
             <li>전자제품·화장품·식품 등은 별도 인증/신고가 필요할 수 있음</li>
             <li>상표권·디자인권 침해 상품 판매 금지</li>
           </ul>
-          <a href="https://www.customs.go.kr" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm">🔗 관세청(해외직구/통관)</a>
+          <a href="https://www.customs.go.kr" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm"><i class="bi bi-box-arrow-up-right"></i> 관세청(해외직구/통관)</a>
         </div>
       </div>
     </div>
@@ -72,7 +72,7 @@
 
   <!-- 체크리스트 -->
   <div class="card mb-3">
-    <div class="card-header"><strong>✅ 시작 전 체크리스트</strong></div>
+    <div class="card-header"><strong><i class="bi bi-check-circle"></i> 시작 전 체크리스트</strong></div>
     <div class="card-body">
       <div class="row">
         {% for label in [
@@ -97,7 +97,7 @@
 
   <div class="d-flex flex-wrap gap-2">
     <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm">다음: 마켓 API 키 발급 가이드 →</a>
-    <a href="/seller/extension" class="btn btn-outline-secondary btn-sm">🧩 크롬 확장 설치</a>
+    <a href="/seller/extension" class="btn btn-outline-secondary btn-sm"><i class="bi bi-puzzle"></i> 크롬 확장 설치</a>
   </div>
 </div>
 

--- a/src/seller_console/templates/market_status.html
+++ b/src/seller_console/templates/market_status.html
@@ -3,12 +3,12 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h4 class="fw-bold mb-0">🏪 마켓 상품 현황</h4>
+  <h4 class="fw-bold mb-0"><i class="bi bi-shop"></i> 마켓 상품 현황</h4>
   <div class="d-flex gap-2 align-items-center">
     {% if market_data.is_mock %}
     <span class="badge bg-warning text-dark">mock 데이터</span>
     {% endif %}
-    <button class="btn btn-outline-secondary btn-sm" onclick="location.reload()">🔄 새로고침</button>
+    <button class="btn btn-outline-secondary btn-sm" onclick="location.reload()"><i class="bi bi-arrow-clockwise"></i> 새로고침</button>
   </div>
 </div>
 
@@ -56,9 +56,9 @@
       </select>
       <select class="form-select form-select-sm" id="filterStatus" style="width:auto;" onchange="filterTable()">
         <option value="">전체 상태</option>
-        <option value="active">활성 ✅</option>
-        <option value="out_of_stock">품절 ⚠️</option>
-        <option value="error">오류 ❌</option>
+        <option value="active">활성</option>
+        <option value="out_of_stock">품절</option>
+        <option value="error">오류</option>
       </select>
       <input type="text" class="form-control form-control-sm" id="filterSearch"
              placeholder="상품명 검색..." style="width:200px;" oninput="filterTable()">
@@ -86,41 +86,41 @@
           <tr data-market="coupang smartstore elevenst" data-status="active">
             <td><code>ALO-LGG-001</code></td>
             <td>[Mock] Alo Yoga 에어리프트 레깅스 블랙 M</td>
-            <td class="text-center"><span class="badge bg-success">✅ 활성</span></td>
-            <td class="text-center"><span class="badge bg-success">✅ 활성</span></td>
-            <td class="text-center"><span class="badge bg-success">✅ 활성</span></td>
+            <td class="text-center"><span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span></td>
+            <td class="text-center"><span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span></td>
+            <td class="text-center"><span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span></td>
             <td>aloyoga.com</td>
           </tr>
           <tr data-market="coupang" data-status="out_of_stock">
             <td><code>LUL-ALN-002</code></td>
             <td>[Mock] lululemon Align 팬츠 28" 네이비 6</td>
-            <td class="text-center"><span class="badge bg-warning text-dark">⚠️ 품절</span></td>
-            <td class="text-center"><span class="badge bg-success">✅ 활성</span></td>
-            <td class="text-center"><span class="badge bg-success">✅ 활성</span></td>
+            <td class="text-center"><span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> 품절</span></td>
+            <td class="text-center"><span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span></td>
+            <td class="text-center"><span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span></td>
             <td>lululemon.com</td>
           </tr>
           <tr data-market="smartstore elevenst" data-status="error">
             <td><code>PTR-TNK-003</code></td>
             <td>[Mock] Porter Tank 나일론 숄더백 블랙</td>
             <td class="text-center"><span class="badge bg-secondary">-</span></td>
-            <td class="text-center"><span class="badge bg-danger">❌ 오류</span></td>
-            <td class="text-center"><span class="badge bg-success">✅ 활성</span></td>
+            <td class="text-center"><span class="badge bg-danger"><i class="bi bi-x-circle"></i> 오류</span></td>
+            <td class="text-center"><span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span></td>
             <td>porter.jp</td>
           </tr>
           <tr data-market="coupang smartstore" data-status="active">
             <td><code>MMP-EDP-004</code></td>
             <td>[Mock] Memo Paris 일라 두 멜 75ml</td>
-            <td class="text-center"><span class="badge bg-success">✅ 활성</span></td>
-            <td class="text-center"><span class="badge bg-success">✅ 활성</span></td>
+            <td class="text-center"><span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span></td>
+            <td class="text-center"><span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span></td>
             <td class="text-center"><span class="badge bg-secondary">-</span></td>
             <td>memoparis.com</td>
           </tr>
           <tr data-market="elevenst" data-status="out_of_stock">
             <td><code>AMZ-SHO-005</code></td>
             <td>[Mock] Nike 러닝화 260 블랙</td>
-            <td class="text-center"><span class="badge bg-warning text-dark">⚠️ 품절</span></td>
-            <td class="text-center"><span class="badge bg-warning text-dark">⚠️ 품절</span></td>
-            <td class="text-center"><span class="badge bg-warning text-dark">⚠️ 품절</span></td>
+            <td class="text-center"><span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> 품절</span></td>
+            <td class="text-center"><span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> 품절</span></td>
+            <td class="text-center"><span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> 품절</span></td>
             <td>amazon.co.jp</td>
           </tr>
         </tbody>

--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -17,13 +17,13 @@
       {% if single_market %}
       <a href="/seller/markets/connect" class="btn btn-outline-secondary btn-sm">전체 마켓 보기</a>
       {% endif %}
-      <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm">📖 발급 가이드</a>
+      <a href="/seller/markets/guide" class="btn btn-outline-primary btn-sm"><i class="bi bi-book"></i> 발급 가이드</a>
       <a href="/seller/markets" class="btn btn-outline-secondary btn-sm">← 마켓 현황으로</a>
     </div>
   </div>
 
   <div class="alert alert-light border small d-flex gap-2 align-items-start mb-3" role="note">
-    <span style="font-size:1.1rem">🔑</span>
+    <span style="font-size:1.1rem"><i class="bi bi-key"></i></span>
     <div>여기에 넣는 건 <strong>‘내 마켓 키’</strong>(쿠팡·네이버 등에서 발급받은 본인 API 키)예요.
       서버 환경변수(<code>MARKET_CRED_ENC_KEY</code> 같은 인프라 키)와는 다릅니다 —
       <strong>그건 운영자가 관리하고, 여기엔 입력하지 않아도 됩니다.</strong></div>
@@ -34,7 +34,7 @@
     {% for chip in market_chips %}
     <a href="/seller/markets/connect/{{ chip.market }}"
        class="btn btn-sm {{ 'btn-primary' if single_market == chip.market else 'btn-outline-secondary' }}">
-      {{ chip.label }} {{ '✅' if chip.connected else '' }}
+      {{ chip.label }} {% if chip.connected %}<i class="bi bi-check-circle text-success"></i>{% endif %}
     </a>
     {% endfor %}
   </div>
@@ -52,7 +52,7 @@
   <div class="alert alert-light border d-flex gap-2 align-items-center mb-4" role="note">
     <i class="bi bi-shield-lock text-primary"></i>
     <div class="small mb-0">
-      🔒 입력한 키는 <strong>안전하게 암호화</strong>되어 보관돼요.
+      <i class="bi bi-shield-lock"></i> 입력한 키는 <strong>안전하게 암호화</strong>되어 보관돼요.
       <span class="pc-help" tabindex="0" role="button" aria-label="자세히"
             data-bs-toggle="tooltip" data-bs-html="true"
             data-bs-title="서버에 <code>MARKET_CRED_ENC_KEY</code> 설정 시 키를 암호화 저장합니다. ‘연결 테스트’는 실제 마켓에 읽기/안전한 빈 쓰기만 시도하며 상품을 등록하지 않습니다.">?</span>
@@ -63,8 +63,8 @@
   <div class="card console-card mb-3">
     <div class="card-body">
       <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
-        <h2 class="h6 mb-0">📖 {{ guide_entry.label }} 키 발급 방법</h2>
-        <a href="{{ guide_entry.official_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm">🔗 {{ guide_entry.official_label }}</a>
+        <h2 class="h6 mb-0"><i class="bi bi-book"></i> {{ guide_entry.label }} 키 발급 방법</h2>
+        <a href="{{ guide_entry.official_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm"><i class="bi bi-box-arrow-up-right"></i> {{ guide_entry.official_label }}</a>
       </div>
       <ol class="small mb-0">
         {% for s in guide_entry.steps %}
@@ -72,7 +72,7 @@
         {% endfor %}
       </ol>
       {% if guide_entry.tips %}
-      <div class="small text-muted mt-2">{% for tip in guide_entry.tips %}<div>💡 {{ tip }}</div>{% endfor %}</div>
+      <div class="small text-muted mt-2">{% for tip in guide_entry.tips %}<div><i class="bi bi-lightbulb"></i>  {{ tip }}</div>{% endfor %}</div>
       {% endif %}
     </div>
   </div>
@@ -101,7 +101,7 @@
             <h2 class="h6 mb-0">{{ m.label }}</h2>
             <span class="badge rounded-pill {{ 'text-bg-success' if m.connected else 'text-bg-secondary' }}"
                   data-role="status-badge">
-              {{ '✅ 연결됨' if m.connected else '🪪 미연결' }}
+              {% if m.connected %}<i class="bi bi-check-circle"></i> 연결됨{% else %}<i class="bi bi-dash-circle"></i> 미연결{% endif %}
             </span>
           </div>
           <div class="small text-muted mb-2">
@@ -111,7 +111,7 @@
           <div class="fw-semibold small mb-1">① 키 발급받기</div>
           {% if _g and _g.official_url %}
           <a href="{{ _g.official_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-cta btn-sm w-100 mb-1">
-            🔗 {{ _g.official_label or '발급 페이지 열기' }}
+            <i class="bi bi-box-arrow-up-right"></i> {{ _g.official_label or '발급 페이지 열기' }}
           </a>
           <div class="small text-muted mb-3">↑ 이 버튼만 마켓 사이트가 새 탭으로 열려요(로그인 필요). 키를 받은 뒤 이 화면으로 돌아오세요.</div>
           {% else %}
@@ -217,13 +217,13 @@ function renderTestResult(form, result) {
   box.innerHTML = '';
   if (result && result.status === 'connected') {
     box.classList.add('text-success');
-    box.textContent = '✅ 연결 성공 — ' + (result.summary || '');
+    box.textContent = '연결 성공 — ' + (result.summary || '');
     return;
   }
   box.classList.add('text-warning');
   const code = result ? (result.status || '실패') : '실패';
   const head = document.createElement('div');
-  head.textContent = '⚠️ ' + code;
+  head.textContent = code;
   box.appendChild(head);
   // 마켓이 보낸 원문 응답(디버깅용) — 그대로 표시
   if (result && result.summary) {
@@ -236,7 +236,7 @@ function renderTestResult(form, result) {
   if (result && result.hint) {
     const hint = document.createElement('div');
     hint.className = 'mt-1';
-    hint.textContent = '💡 조치: ' + result.hint;
+    hint.textContent = '조치: ' + result.hint;
     box.appendChild(hint);
   }
 }
@@ -245,7 +245,7 @@ function updateBadge(card, connected) {
   const badge = card.querySelector('[data-role="status-badge"]');
   if (!badge) return;
   badge.className = 'badge rounded-pill ' + (connected ? 'text-bg-success' : 'text-bg-secondary');
-  badge.textContent = connected ? '✅ 연결됨' : '🪪 미연결';
+  badge.textContent = connected ? '연결됨' : '미연결';
 }
 
 document.querySelectorAll('.market-connect-form').forEach(form => {

--- a/src/seller_console/templates/markets_guide.html
+++ b/src/seller_console/templates/markets_guide.html
@@ -17,10 +17,10 @@
 <section class="mb-4">
   <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
     <div>
-      <h1 class="h4 mb-1">📖 마켓 API 키 발급 가이드</h1>
+      <h1 class="h4 mb-1"><i class="bi bi-book"></i> 마켓 API 키 발급 가이드</h1>
       <p class="text-muted mb-0">각 마켓에서 키를 받아 → 우리 사이트에 붙여넣기만 하면 연결됩니다.</p>
     </div>
-    <a href="/seller/markets/connect" class="btn btn-primary btn-sm">🔌 키 입력 화면으로</a>
+    <a href="/seller/markets/connect" class="btn btn-primary btn-sm"><i class="bi bi-plug"></i> 키 입력 화면으로</a>
   </div>
 
   <!-- 개념 일러스트 (이미지) -->
@@ -54,7 +54,7 @@
   <div class="alert alert-warning d-flex gap-2 align-items-start mb-4">
     <i class="bi bi-shield-exclamation"></i>
     <div class="small mb-0">
-      <strong>🚧 한국 마켓(쿠팡·네이버·11번가)은 ‘API 호출 허용 IP’ 등록이 필요할 수 있어요.</strong>
+      <strong><i class="bi bi-cone-striped"></i> 한국 마켓(쿠팡·네이버·11번가)은 ‘API 호출 허용 IP’ 등록이 필요할 수 있어요.</strong>
       키가 정확해도 <code>your ip ... is not allowed(403)</code> / <code>GW.IP_NOT_ALLOWED</code> 가 뜨면
       <strong>이 서버의 아웃바운드 IP</strong>를 각 마켓 판매자센터의 허용 IP에 등록하세요.
       <ul class="mb-0 mt-1">
@@ -82,12 +82,12 @@
           {% endif %}
         </h2>
         <a href="{{ g.official_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary btn-sm">
-          🔗 {{ g.official_label }}
+          <i class="bi bi-box-arrow-up-right"></i> {{ g.official_label }}
         </a>
       </div>
       {% if g.status == 'planned' %}
       <div class="alert alert-warning small py-2">
-        🌐 글로벌 확장 마켓입니다. 키 발급 방법을 미리 안내하며, 어댑터 실연동은 순차 적용 예정입니다.
+        <i class="bi bi-globe"></i> 글로벌 확장 마켓입니다. 키 발급 방법을 미리 안내하며, 어댑터 실연동은 순차 적용 예정입니다.
         지금 키를 준비해두면 연동 시 바로 사용할 수 있어요.
       </div>
       {% endif %}
@@ -130,12 +130,12 @@
 
       {% if g.tips %}
       <div class="alert alert-light border small mb-3">
-        {% for tip in g.tips %}<div>💡 {{ tip }}</div>{% endfor %}
+        {% for tip in g.tips %}<div><i class="bi bi-lightbulb"></i> {{ tip }}</div>{% endfor %}
       </div>
       {% endif %}
 
       {% if g.shipping %}
-      <!-- 📦 출고지·반품지 (쿠팡 상품 등록 필수) — 그림 + 단계 + 예시 -->
+      <!-- 출고지·반품지 (쿠팡 상품 등록 필수) — 그림 + 단계 + 예시 -->
       <div class="card border-warning mb-3">
         <div class="card-body">
           <h3 class="h6 text-warning-emphasis mb-2">{{ g.shipping.title }}</h3>
@@ -195,7 +195,7 @@
           {% endif %}
           {% if g.shipping.tips %}
           <div class="alert alert-light border small mb-0">
-            {% for tip in g.shipping.tips %}<div>💡 {{ tip }}</div>{% endfor %}
+            {% for tip in g.shipping.tips %}<div><i class="bi bi-lightbulb"></i> {{ tip }}</div>{% endfor %}
           </div>
           {% endif %}
         </div>
@@ -203,9 +203,9 @@
       {% endif %}
 
       {% if g.status == 'planned' %}
-      <span class="text-muted small">🔧 어댑터 연동 적용 후 입력칸이 열립니다.</span>
+      <span class="text-muted small"><i class="bi bi-wrench"></i> 어댑터 연동 적용 후 입력칸이 열립니다.</span>
       {% else %}
-      <a href="/seller/markets/connect/{{ g.key }}" class="btn btn-success btn-sm">✅ {{ g.label }} 키 입력하러 가기</a>
+      <a href="/seller/markets/connect/{{ g.key }}" class="btn btn-success btn-sm"><i class="bi bi-check-circle"></i> {{ g.label }} 키 입력하러 가기</a>
       {% endif %}
     </div>
   </div>

--- a/src/seller_console/templates/me.html
+++ b/src/seller_console/templates/me.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h4 class="mb-0 fw-bold">👤 마이페이지</h4>
+  <h4 class="mb-0 fw-bold"><i class="bi bi-person"></i> 마이페이지</h4>
   {% if user and user.role == 'admin' %}
     <span class="badge bg-danger px-3 py-2 fs-6">⭐ Admin</span>
   {% endif %}
@@ -64,14 +64,14 @@
 <!-- 연결된 소셜 계정 -->
 <div class="card border-0 shadow-sm mb-3">
   <div class="card-body">
-    <h6 class="fw-semibold mb-3">🔗 연결된 소셜 계정</h6>
+    <h6 class="fw-semibold mb-3"><i class="bi bi-link-45deg"></i> 연결된 소셜 계정</h6>
     {% set providers = ['kakao', 'google', 'naver'] %}
     {% set linked_providers = user.social_accounts | map(attribute='provider') | list %}
     {% for prov in providers %}
       {% set label = {'kakao': '카카오', 'google': '구글', 'naver': '네이버'}[prov] %}
       <div class="d-flex justify-content-between align-items-center border-bottom pb-2 mb-2">
         <span>
-          {% if prov == 'kakao' %}🟡{% elif prov == 'google' %}🔴{% else %}🟢{% endif %}
+          {% if prov == 'kakao' %}<i class="bi bi-chat-fill text-warning"></i>{% elif prov == 'google' %}<i class="bi bi-google text-danger"></i>{% else %}<i class="bi bi-circle-fill text-success"></i>{% endif %}
           {{ label }}
         </span>
         {% if prov in linked_providers %}
@@ -87,9 +87,9 @@
 <!-- 알림 설정 -->
 <div class="card border-0 shadow-sm mb-3">
   <div class="card-body">
-    <h6 class="fw-semibold mb-3">🔔 알림 채널</h6>
+    <h6 class="fw-semibold mb-3"><i class="bi bi-bell"></i> 알림 채널</h6>
     <div class="d-flex justify-content-between align-items-center mb-2">
-      <span>📨 텔레그램</span>
+      <span><i class="bi bi-telegram"></i> 텔레그램</span>
       {% if telegram_active %}
         <span class="badge bg-success">활성</span>
       {% else %}
@@ -97,7 +97,7 @@
       {% endif %}
     </div>
     <div class="d-flex justify-content-between align-items-center">
-      <span>📧 이메일 (Resend)</span>
+      <span><i class="bi bi-envelope"></i> 이메일 (Resend)</span>
       {% if resend_active %}
         <span class="badge bg-success">활성</span>
       {% else %}
@@ -110,11 +110,11 @@
 <!-- 계정 관리 -->
 <div class="card border-0 shadow-sm mb-3">
   <div class="card-body">
-    <h6 class="fw-semibold mb-3">⚙️ 계정 관리</h6>
+    <h6 class="fw-semibold mb-3"><i class="bi bi-gear"></i> 계정 관리</h6>
     <form method="post" action="/auth/logout" class="d-inline">
-      <button type="submit" class="btn btn-outline-secondary btn-sm">🚪 로그아웃</button>
+      <button type="submit" class="btn btn-outline-secondary btn-sm"><i class="bi bi-box-arrow-right"></i> 로그아웃</button>
     </form>
-    <button class="btn btn-outline-danger btn-sm ms-2" onclick="confirmDeactivate()">🗑 탈퇴</button>
+    <button class="btn btn-outline-danger btn-sm ms-2" onclick="confirmDeactivate()"><i class="bi bi-trash"></i> 탈퇴</button>
   </div>
 </div>
 {% endif %}

--- a/src/seller_console/templates/messaging.html
+++ b/src/seller_console/templates/messaging.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h4 class="mb-0 fw-bold">💬 고객 메시징 허브</h4>
+  <h4 class="mb-0 fw-bold"><i class="bi bi-chat-dots"></i> 고객 메시징 허브</h4>
   <small class="text-muted">다채널 고객 알림 (카카오·LINE·WhatsApp·WeChat·SMS·이메일·텔레그램)</small>
 </div>
 
@@ -16,9 +16,9 @@
         <div class="d-flex justify-content-between align-items-start">
           <span class="fw-semibold small">{{ ch.name }}</span>
           {% if ch.status == 'ok' %}
-            <span class="badge bg-success" style="font-size:0.65rem;">✅ 활성</span>
+            <span class="badge bg-success" style="font-size:0.65rem;"><i class="bi bi-check-circle"></i> 활성</span>
           {% else %}
-            <span class="badge bg-secondary" style="font-size:0.65rem;">⚪ 미설정</span>
+            <span class="badge bg-secondary" style="font-size:0.65rem;"><i class="bi bi-circle"></i> 미설정</span>
           {% endif %}
         </div>
         <div class="text-muted" style="font-size:0.7rem;margin-top:4px;">{{ ch.detail }}</div>
@@ -32,7 +32,7 @@
   <!-- 왼쪽: 템플릿 미리보기 + 테스트 발송 -->
   <div class="col-md-5">
     <div class="card border-0 shadow-sm mb-4">
-      <div class="card-header bg-white fw-semibold border-0">📤 테스트 메시지 발송</div>
+      <div class="card-header bg-white fw-semibold border-0"><i class="bi bi-send"></i> 테스트 메시지 발송</div>
       <div class="card-body">
         <div class="mb-3">
           <label class="form-label small fw-semibold">이벤트</label>
@@ -62,7 +62,7 @@
           </select>
         </div>
         <button class="btn btn-primary btn-sm w-100" onclick="sendTestMessage()">
-          📤 운영자에게 테스트 발송
+          <i class="bi bi-send"></i> 운영자에게 테스트 발송
         </button>
         <div id="testResult" class="mt-2 small text-muted"></div>
       </div>
@@ -70,19 +70,19 @@
 
     <!-- 채널별 우선순위 안내 -->
     <div class="card border-0 shadow-sm">
-      <div class="card-header bg-white fw-semibold border-0">🗺️ locale → 채널 라우팅</div>
+      <div class="card-header bg-white fw-semibold border-0"><i class="bi bi-diagram-3"></i> locale → 채널 라우팅</div>
       <div class="card-body p-0">
         <table class="table table-sm table-hover mb-0">
           <thead class="table-light">
             <tr><th class="ps-3">locale</th><th>채널 우선순위</th></tr>
           </thead>
           <tbody>
-            <tr><td class="ps-3">🇰🇷 ko</td><td><small>카카오 → SMS → 텔레그램 → 이메일</small></td></tr>
-            <tr><td class="ps-3">🇯🇵 ja</td><td><small>LINE → LINE Notify → SMS → 이메일</small></td></tr>
-            <tr><td class="ps-3">🇺🇸 en</td><td><small>WhatsApp → 이메일 → SMS</small></td></tr>
-            <tr><td class="ps-3">🇨🇳 zh-CN</td><td><small>WeChat → 이메일 → SMS</small></td></tr>
-            <tr><td class="ps-3">🇹🇼 zh-TW</td><td><small>LINE → 이메일 → SMS</small></td></tr>
-            <tr><td class="ps-3">🌏 기타</td><td><small>이메일 → SMS → 텔레그램</small></td></tr>
+            <tr><td class="ps-3">ko</td><td><small>카카오 → SMS → 텔레그램 → 이메일</small></td></tr>
+            <tr><td class="ps-3">ja</td><td><small>LINE → LINE Notify → SMS → 이메일</small></td></tr>
+            <tr><td class="ps-3">en</td><td><small>WhatsApp → 이메일 → SMS</small></td></tr>
+            <tr><td class="ps-3">zh-CN</td><td><small>WeChat → 이메일 → SMS</small></td></tr>
+            <tr><td class="ps-3">zh-TW</td><td><small>LINE → 이메일 → SMS</small></td></tr>
+            <tr><td class="ps-3">기타</td><td><small>이메일 → SMS → 텔레그램</small></td></tr>
           </tbody>
         </table>
       </div>
@@ -93,8 +93,8 @@
   <div class="col-md-7">
     <div class="card border-0 shadow-sm">
       <div class="card-header bg-white d-flex justify-content-between align-items-center border-0">
-        <span class="fw-semibold">📋 최근 발송 로그</span>
-        <button class="btn btn-outline-secondary btn-sm" onclick="refreshLog()">🔄 새로고침</button>
+        <span class="fw-semibold"><i class="bi bi-card-list"></i> 최근 발송 로그</span>
+        <button class="btn btn-outline-secondary btn-sm" onclick="refreshLog()"><i class="bi bi-arrow-clockwise"></i> 새로고침</button>
       </div>
       <div class="card-body p-0" id="logTableContainer">
         {% if log %}
@@ -118,9 +118,9 @@
                 <td>{{ row.locale }}</td>
                 <td>
                   {% if row.status == 'ok' %}
-                    <span class="text-success">✅</span>
+                    <span class="text-success"><i class="bi bi-check-circle"></i></span>
                   {% else %}
-                    <span class="text-danger" title="{{ row.error }}">❌</span>
+                    <span class="text-danger" title="{{ row.error }}"><i class="bi bi-x-circle"></i></span>
                   {% endif %}
                 </td>
               </tr>
@@ -130,7 +130,7 @@
         </div>
         {% else %}
         <div class="text-center text-muted py-5">
-          <div class="fs-1">📭</div>
+          <div class="fs-1"><i class="bi bi-inbox"></i></div>
           <p class="mt-2">발송 이력이 없습니다.<br>테스트 메시지를 먼저 발송해보세요.</p>
         </div>
         {% endif %}
@@ -158,13 +158,13 @@ async function sendTestMessage() {
     });
     const data = await resp.json();
     if (data.ok && data.result?.sent) {
-      resultEl.innerHTML = `<span class="text-success">✅ 발송 성공 (채널: ${data.result.channel})</span>`;
+      resultEl.innerHTML = `<span class="text-success"><i class="bi bi-check-circle"></i> 발송 성공 (채널: ${data.result.channel})</span>`;
     } else {
       const msg = data.result?.error || data.error || '알 수 없는 오류';
-      resultEl.innerHTML = `<span class="text-danger">❌ ${msg}</span>`;
+      resultEl.innerHTML = `<span class="text-danger"><i class="bi bi-x-circle"></i> ${msg}</span>`;
     }
   } catch (e) {
-    resultEl.innerHTML = `<span class="text-danger">❌ 네트워크 오류</span>`;
+    resultEl.innerHTML = `<span class="text-danger"><i class="bi bi-x-circle"></i> 네트워크 오류</span>`;
   } finally {
     btn.disabled = false;
   }
@@ -182,7 +182,7 @@ async function refreshLog() {
         </tr></thead><tbody>`;
       for (const row of [...data.log].reverse()) {
         const sentAt = (row.sent_at || '').slice(0, 16);
-        const statusIcon = row.status === 'ok' ? '✅' : `<span class="text-danger" title="${row.error||''}">❌</span>`;
+        const statusIcon = row.status === 'ok' ? '<i class="bi bi-check-circle text-success"></i>' : `<span class="text-danger" title="${row.error||''}"><i class="bi bi-x-circle"></i></span>`;
         html += `<tr>
           <td class="ps-3 text-muted" style="white-space:nowrap;">${sentAt||'-'}</td>
           <td><span class="badge bg-light text-dark border">${row.channel}</span></td>

--- a/src/seller_console/templates/mobile_home.html
+++ b/src/seller_console/templates/mobile_home.html
@@ -29,7 +29,7 @@
 </head>
 <body>
 <div class="m-top">
-  <span style="font-size:1.3rem">🛒</span>
+  <span style="font-size:1.3rem"><i class="bi bi-bag-check"></i></span>
   <span class="brand">코고가네</span>
   <span class="m-beta">BETA</span>
   <a href="/seller/dashboard" class="ms-auto text-decoration-none small" style="color:#c9bda6">데스크톱 →</a>
@@ -42,7 +42,7 @@
   <form action="/seller/collect/quick" method="get" class="m-card p-3 mb-3">
     <label class="form-label small fw-semibold" for="mUrl">상품 URL</label>
     <input id="mUrl" name="u" type="url" class="form-control mb-2" placeholder="https://..." required inputmode="url">
-    <button type="submit" class="btn btn-cta w-100">📥 수집하기</button>
+    <button type="submit" class="btn btn-cta w-100"><i class="bi bi-download"></i> 수집하기</button>
   </form>
   <div class="d-flex justify-content-between align-items-center mb-2">
     <h3 class="h6 fw-bold mb-0">최근 수집</h3>
@@ -53,7 +53,7 @@
     {% for it in recent %}
     <a href="/seller/collect/preview/{{ it.id }}" class="m-card p-2 d-flex align-items-center gap-2 text-decoration-none text-dark">
       {% if it.thumb %}<img src="{{ it.thumb }}" alt="" style="width:48px;height:48px;object-fit:cover;border-radius:8px;background:#eee" onerror="this.style.visibility='hidden'">
-      {% else %}<span class="d-inline-flex align-items-center justify-content-center" style="width:48px;height:48px;border-radius:8px;background:#f1f3f5">🖼️</span>{% endif %}
+      {% else %}<span class="d-inline-flex align-items-center justify-content-center" style="width:48px;height:48px;border-radius:8px;background:#f1f3f5"><i class="bi bi-image"></i></span>{% endif %}
       <span class="flex-grow-1 text-truncate">
         <span class="d-block text-truncate fw-semibold">{{ it.title }}</span>
         <span class="small text-muted">{% if it.price %}{{ it.price }} {{ it.currency }}{% else %}{{ it.domain }}{% endif %}</span>
@@ -95,15 +95,15 @@
 <!-- 더보기 탭 -->
 <section class="m-tabpane" id="pane-more">
   <h2 class="h5 fw-bold mb-3">더보기</h2>
-  <button id="installBtn" class="btn btn-cta w-100 mb-2 d-none" onclick="installApp()">📲 코고가네 앱 설치</button>
+  <button id="installBtn" class="btn btn-cta w-100 mb-2 d-none" onclick="installApp()"><i class="bi bi-phone"></i> 코고가네 앱 설치</button>
   <div class="vstack gap-2">
-    <a href="/seller/start" class="m-card p-3 text-decoration-none text-dark">✨ For Beginners · 시작 가이드</a>
-    <a href="/seller/markets/connect" class="m-card p-3 text-decoration-none text-dark">🛍️ 마켓 연동</a>
-    <a href="/seller/dashboard" class="m-card p-3 text-decoration-none text-dark">🖥️ 데스크톱 전체 콘솔</a>
+    <a href="/seller/start" class="m-card p-3 text-decoration-none text-dark"><i class="bi bi-stars"></i> For Beginners · 시작 가이드</a>
+    <a href="/seller/markets/connect" class="m-card p-3 text-decoration-none text-dark"><i class="bi bi-shop"></i> 마켓 연동</a>
+    <a href="/seller/dashboard" class="m-card p-3 text-decoration-none text-dark"><i class="bi bi-display"></i> 데스크톱 전체 콘솔</a>
     <a href="/seller/about" class="m-card p-3 text-decoration-none text-dark">ℹ️ 코고가네란?</a>
   </div>
   <div class="m-card p-3 mt-3 small text-muted">
-    📲 <strong>홈 화면에 추가</strong>하면 앱처럼 쓸 수 있어요. iOS: 공유 → ‘홈 화면에 추가’, 안드로이드: 메뉴 → ‘앱 설치’.
+    <i class="bi bi-phone"></i> <strong>홈 화면에 추가</strong>하면 앱처럼 쓸 수 있어요. iOS: 공유 → ‘홈 화면에 추가’, 안드로이드: 메뉴 → ‘앱 설치’.
     <br>대량 편집·마켓 설정 등 풀기능은 데스크톱에서 더 편해요.
   </div>
 </section>

--- a/src/seller_console/templates/notifications.html
+++ b/src/seller_console/templates/notifications.html
@@ -3,18 +3,18 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h4 class="mb-0 fw-bold">🔔 알림 설정</h4>
+  <h4 class="mb-0 fw-bold"><i class="bi bi-bell"></i> 알림 설정</h4>
 </div>
 
 <!-- 텔레그램 상태 -->
 <div class="card border-0 shadow-sm mb-3">
   <div class="card-body">
     <div class="d-flex justify-content-between align-items-center mb-2">
-      <h6 class="fw-semibold mb-0">📨 텔레그램 알림</h6>
+      <h6 class="fw-semibold mb-0"><i class="bi bi-telegram"></i> 텔레그램 알림</h6>
       {% if telegram_active %}
-        <span class="badge bg-success">✅ 활성</span>
+        <span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span>
       {% else %}
-        <span class="badge bg-warning text-dark">⚠️ 미설정</span>
+        <span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> 미설정</span>
       {% endif %}
     </div>
     <p class="text-muted small mb-3">
@@ -23,12 +23,12 @@
     </p>
     {% if telegram_active %}
     <button class="btn btn-outline-primary btn-sm" id="btnTestTelegram" onclick="testTelegram()">
-      📤 테스트 메시지 전송
+      <i class="bi bi-send"></i> 테스트 메시지 전송
     </button>
     <span id="telegramTestResult" class="ms-2 small text-muted"></span>
     {% else %}
     <a href="https://core.telegram.org/bots#6-botfather" target="_blank" class="btn btn-outline-secondary btn-sm">
-      📋 BotFather에서 토큰 발급 →
+      <i class="bi bi-clipboard"></i> BotFather에서 토큰 발급 →
     </a>
     {% endif %}
   </div>
@@ -38,11 +38,11 @@
 <div class="card border-0 shadow-sm mb-3">
   <div class="card-body">
     <div class="d-flex justify-content-between align-items-center mb-2">
-      <h6 class="fw-semibold mb-0">📧 이메일 알림 (Resend)</h6>
+      <h6 class="fw-semibold mb-0"><i class="bi bi-envelope"></i> 이메일 알림 (Resend)</h6>
       {% if resend_active %}
-        <span class="badge bg-success">✅ 활성</span>
+        <span class="badge bg-success"><i class="bi bi-check-circle"></i> 활성</span>
       {% else %}
-        <span class="badge bg-warning text-dark">⚠️ 미설정</span>
+        <span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> 미설정</span>
       {% endif %}
     </div>
     <p class="text-muted small mb-3">
@@ -51,14 +51,14 @@
     </p>
     {% if not resend_active %}
     <a href="https://resend.com/api-keys" target="_blank" class="btn btn-outline-secondary btn-sm">
-      📋 Resend에서 API 키 발급 →
+      <i class="bi bi-clipboard"></i> Resend에서 API 키 발급 →
     </a>
     {% endif %}
   </div>
 </div>
 
 <div class="mt-3 p-3 bg-light rounded text-muted small">
-  <strong>📌 알림 훅 포인트</strong>
+  <strong><i class="bi bi-pin-angle"></i> 알림 훅 포인트</strong>
   <ul class="mb-0 mt-1">
     <li>새 주문 sync 시: "신규 주문 N건 (마켓별 집계)"</li>
     <li><code>/health/deep</code> fail 시: "❌ [서비스명] 체크 실패"</li>
@@ -76,11 +76,11 @@ function testTelegram() {
   fetch('/seller/notifications/test', {method: 'POST'})
     .then(r => r.json())
     .then(data => {
-      result.textContent = data.ok ? '✅ ' + data.message : '❌ ' + (data.message || data.error);
+      result.textContent = data.ok ? data.message : (data.message || data.error);
       result.className = 'ms-2 small ' + (data.ok ? 'text-success' : 'text-danger');
     })
     .catch(() => {
-      result.textContent = '❌ 요청 실패';
+      result.textContent = '요청 실패';
       result.className = 'ms-2 small text-danger';
     })
     .finally(() => { btn.disabled = false; });

--- a/src/seller_console/templates/onboarding_wizard.html
+++ b/src/seller_console/templates/onboarding_wizard.html
@@ -35,7 +35,7 @@
 <div class="ob-shell">
   <!-- 좌측 스텝퍼 -->
   <aside class="ob-steps">
-    <div class="ob-brand mb-4">🛒 코고가네</div>
+    <div class="ob-brand mb-4"><i class="bi bi-shop"></i> 코고가네</div>
     <div class="small text-uppercase" style="letter-spacing:.1em;color:#8a7f6c;">시작하기</div>
     <div id="stepper" class="mt-2"></div>
     <div class="mt-4 pt-3" style="border-top:1px solid #38322a;">
@@ -53,30 +53,30 @@
 const LOGGED_IN = {{ _logged_in }};
 const MARKETS = {{ _markets }};
 const STEPS = [
-  { key: 'intro', title: '코고가네에 오신 걸 환영해요', emoji: '👋',
+  { key: 'intro', title: '코고가네에 오신 걸 환영해요', icon: 'bi-emoji-smile',
     lead: '해외 상품을 <b>수집</b> → 한국어로 <b>다듬기</b> → 쿠팡·스마트스토어 같은 우리 마켓에 <b>등록</b>까지 한 곳에서 해요.<br><br>' +
           '<b>‘마켓 연동’이란?</b> 내가 파는 쇼핑몰(쿠팡·네이버 등)에 코고가네를 연결하는 거예요. 연결해 두면 수집한 상품을 ' +
           '그 쇼핑몰에 <b>자동으로 올릴 수</b> 있어요. 그래서 꼭 한 번은 연결이 필요해요 — 차근차근 같이 해봐요.',
     primary: { label: '시작하기', cls: 'btn-cta', act: 'next' } },
-  { key: 'business', title: '사업자 등록부터', emoji: '🪪',
+  { key: 'business', title: '사업자 등록부터', icon: 'bi-person-badge',
     lead: '구매대행은 보통 사업자등록 → 통신판매업 신고가 필요해요. 가이드를 보고 천천히 준비하세요.',
     primary: { label: '사업자 가이드 보기', cls: 'btn-primary', href: '/seller/guide/business' },
     secondary: { label: '나중에 · 다음', cls: 'btn-ghost', act: 'next' } },
-  { key: 'google', title: '소셜 계정으로 시작', emoji: '🔑',
+  { key: 'google', title: '소셜 계정으로 시작', icon: 'bi-key',
     lead: '구글·네이버·카카오·애플 중 편한 걸로 1초 로그인하세요. 내 수집·마켓·주문이 안전하게 개인화됩니다.',
     social: !LOGGED_IN,
     primary: LOGGED_IN ? { label: '로그인 완료 · 다음', cls: 'btn-primary', act: 'next' } : null,
     autoDone: LOGGED_IN },
-  { key: 'market', title: '마켓 연동하기', emoji: '🛍️',
+  { key: 'market', title: '마켓 연동하기', icon: 'bi-shop',
     lead: '쿠팡·스마트스토어·11번가 등 판매할 마켓을 연결하세요. 키를 붙여넣고 연결 테스트까지 한 번에. <b>연결을 마치면 이 단계가 자동으로 체크됩니다.</b>',
     primary: { label: '마켓 연결하러 가기', cls: 'btn-cta', href: '/seller/markets/connect' },
     secondary: { label: '다음', cls: 'btn-ghost', act: 'next' },
     autoDone: MARKETS > 0 },
-  { key: 'extension', title: '크롬 확장 설치', emoji: '🧩',
+  { key: 'extension', title: '크롬 확장 설치', icon: 'bi-puzzle',
     lead: '상품 페이지에서 버튼 한 번으로 수집되는 확장을 설치하세요. 모바일은 공유로 수집해요.',
     primary: { label: '확장 설치 안내 보기', cls: 'btn-primary', href: '/seller/extension' },
     secondary: { label: '다음', cls: 'btn-ghost', act: 'next' } },
-  { key: 'first', title: '첫 상품 수집하기 🎉', emoji: '🚀',
+  { key: 'first', title: '첫 상품 수집하기', icon: 'bi-rocket-takeoff',
     lead: '이제 상품을 수집해 보세요. 수집 → 편집 → 마켓 등록까지, 여기서 다 됩니다.',
     primary: { label: '상품 수집 시작', cls: 'btn-cta', href: '/seller/manual-collect' },
     secondary: { label: '대시보드로', cls: 'btn-ghost', href: '/seller/dashboard' } },
@@ -122,7 +122,7 @@ function socialHtml() {
 function renderPanel() {
   const s = STEPS[cur];
   document.getElementById('panel').innerHTML =
-    `<div class="ob-emoji">${s.emoji}</div>
+    `<div class="ob-emoji"><i class="bi ${s.icon}"></i></div>
      <h1>${s.title}</h1>
      <p class="lead">${s.lead}</p>
      ${s.social ? socialHtml() : ''}

--- a/src/seller_console/templates/orders.html
+++ b/src/seller_console/templates/orders.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-  <h4 class="mb-0 fw-bold">🛍 주문 관리</h4>
+  <h4 class="mb-0 fw-bold"><i class="bi bi-bag"></i> 주문 관리</h4>
   <button id="ordersSyncButton" class="btn btn-primary btn-sm" onclick="syncNow()" aria-label="주문 즉시 동기화">
     <span id="sync-spinner" class="spinner-border spinner-border-sm d-none" role="status"></span>
     ⟳ 지금 동기화

--- a/src/seller_console/templates/pccc.html
+++ b/src/seller_console/templates/pccc.html
@@ -2,10 +2,10 @@
 {% block title %}통관고유부호 관리{% endblock %}
 {% block content %}
 <div class="container-fluid py-4" style="max-width: 900px;">
-  <h1 class="h3 mb-1">🛃 개인통관고유부호(PCCC) 관리</h1>
+  <h1 class="h3 mb-1"><i class="bi bi-card-checklist"></i> 개인통관고유부호(PCCC) 관리</h1>
   <p class="text-muted mb-4">해외 구매대행 통관 시 구매자의 <strong>개인통관고유부호(P+12자리)</strong>가 필요합니다. 고객별로 입력·검색·조회하세요.</p>
 
-  <div class="alert alert-warning small">⚠️ 통관고유부호는 개인정보입니다. 본인(셀러) 계정에만 저장되며, 목적 외 사용·외부 공유에 주의하세요. 고객은 <a href="https://unipass.customs.go.kr" target="_blank" rel="noopener">관세청 UNI-PASS</a>에서 발급받을 수 있습니다.</p>
+  <div class="alert alert-warning small"><i class="bi bi-exclamation-triangle"></i> 통관고유부호는 개인정보입니다. 본인(셀러) 계정에만 저장되며, 목적 외 사용·외부 공유에 주의하세요. 고객은 <a href="https://unipass.customs.go.kr" target="_blank" rel="noopener">관세청 UNI-PASS</a>에서 발급받을 수 있습니다.</p>
 
   <!-- 추가 폼 -->
   <div class="card mb-3">

--- a/src/seller_console/templates/personal_tokens.html
+++ b/src/seller_console/templates/personal_tokens.html
@@ -4,7 +4,7 @@
 <div class="container-fluid py-4">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <div>
-      <h1 class="h3 mb-0">🔑 Personal Access Token 관리</h1>
+      <h1 class="h3 mb-0"><i class="bi bi-key"></i> Personal Access Token 관리</h1>
       <small class="text-muted">크롬 확장 / 북마클릿이 “내 계정”으로 수집하도록 인증하는 열쇠입니다.</small>
     </div>
     <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#generateModal">
@@ -15,10 +15,10 @@
   <!-- 토큰이 무엇인지 / 어떻게 동작하는지 설명 -->
   <div class="card border-primary-subtle bg-primary-subtle mb-4">
     <div class="card-body">
-      <h2 class="h6 mb-2">🔑 토큰이 무엇이고, 무슨 일을 하나요?</h2>
+      <h2 class="h6 mb-2"><i class="bi bi-key"></i> 토큰이 무엇이고, 무슨 일을 하나요?</h2>
       <p class="small mb-2">
         Personal Access Token(개인 액세스 토큰)은 <strong>비밀번호 대신 쓰는 긴 열쇠 문자열</strong>입니다.
-        크롬 확장이나 북마클릿(🛒)으로 상품을 수집할 때, 이 토큰이 “이 수집은 <strong>당신 계정</strong>의 것”이라고
+        크롬 확장이나 북마클릿(<i class="bi bi-cart"></i>)으로 상품을 수집할 때, 이 토큰이 “이 수집은 <strong>당신 계정</strong>의 것”이라고
         서버에 알려줍니다. 토큰이 없으면 수집 요청이 거부돼요.
       </p>
       <div class="row g-2 small">
@@ -104,7 +104,7 @@
 
   <!-- 사용 가이드 -->
   <div class="card">
-    <div class="card-header"><strong>📋 사용 방법</strong></div>
+    <div class="card-header"><strong><i class="bi bi-card-list"></i> 사용 방법</strong></div>
     <div class="card-body">
       <h6>크롬 확장에서</h6>
       <ol>
@@ -151,7 +151,7 @@
         </div>
         <div id="tokenResult" class="d-none">
           <div class="alert alert-warning">
-            ⚠️ 이 토큰은 <strong>지금 한 번만</strong> 표시됩니다. 안전한 곳에 복사해두세요.
+            <i class="bi bi-exclamation-triangle"></i> 이 토큰은 <strong>지금 한 번만</strong> 표시됩니다. 안전한 곳에 복사해두세요.
           </div>
           <div class="input-group">
             <input type="text" class="form-control font-monospace" id="rawToken" readonly>
@@ -185,7 +185,7 @@ document.getElementById('generateBtn').addEventListener('click', async () => {
       document.getElementById('rawToken').value = data.raw_token;
       document.getElementById('tokenResult').classList.remove('d-none');
       btn.classList.replace('btn-primary', 'btn-success');
-      btn.textContent = '✅ 발급 완료';
+      btn.textContent = '발급 완료';
     } else {
       pcToast('토큰 발급 실패: ' + (data.error || '알 수 없는 오류'), 'error');
       btn.disabled = false;

--- a/src/seller_console/templates/pricing_competitors.html
+++ b/src/seller_console/templates/pricing_competitors.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
   <div>
-    <h4 class="mb-1">🕵️ 경쟁사 가격 모니터링</h4>
+    <h4 class="mb-1"><i class="bi bi-binoculars"></i> 경쟁사 가격 모니터링</h4>
     <small class="text-muted">본사 상품과 경쟁사 URL을 1:N으로 연결해 가격/재고/배송비를 추적합니다.</small>
   </div>
   <div class="d-flex gap-2">

--- a/src/seller_console/templates/pricing_console.html
+++ b/src/seller_console/templates/pricing_console.html
@@ -2,14 +2,14 @@
 {% block title %}마진 계산기{% endblock %}
 
 {% block content %}
-<h4 class="fw-bold mb-4">💰 마진 계산기</h4>
+<h4 class="fw-bold mb-4"><i class="bi bi-cash-coin"></i> 마진 계산기</h4>
 
 <div class="row g-4">
   <!-- 입력 패널 (좌측) -->
   <div class="col-md-5">
     <div class="card border-0 shadow-sm">
       <div class="card-body">
-        <h6 class="fw-semibold mb-3">📥 입력</h6>
+        <h6 class="fw-semibold mb-3"><i class="bi bi-download"></i> 입력</h6>
 
         <!-- 매입가 + 통화 -->
         <div class="mb-3">
@@ -114,7 +114,7 @@
           </div>
         </div>
 
-        <button class="btn btn-primary w-100" id="calcBtn" onclick="runCompare()">🧮 비교 계산</button>
+        <button class="btn btn-primary w-100" id="calcBtn" onclick="runCompare()"><i class="bi bi-calculator"></i> 비교 계산</button>
       </div>
     </div>
   </div>
@@ -136,7 +136,7 @@
     <!-- 비교 차트 -->
     <div class="card border-0 shadow-sm mb-3" id="chartCard" style="display:none!important;">
       <div class="card-body">
-        <h6 class="fw-semibold mb-3">📊 마진율 비교</h6>
+        <h6 class="fw-semibold mb-3"><i class="bi bi-bar-chart"></i> 마진율 비교</h6>
         <canvas id="marginChart" height="120"></canvas>
       </div>
     </div>
@@ -144,7 +144,7 @@
     <!-- 랜딩 코스트 요약 -->
     <div class="card border-0 shadow-sm" id="landedCostCard" style="display:none!important;">
       <div class="card-body">
-        <h6 class="fw-semibold mb-2">📦 원가 상세</h6>
+        <h6 class="fw-semibold mb-2"><i class="bi bi-box-seam"></i> 원가 상세</h6>
         <div id="landedCostDetail"></div>
       </div>
     </div>
@@ -228,7 +228,7 @@ function runCompare() {
   .then(r => r.json())
   .then(data => {
     btn.disabled = false;
-    btn.textContent = '🧮 비교 계산';
+    btn.textContent = '비교 계산';
     if (!data.ok) {
       showError(data.error);
       return;
@@ -237,7 +237,7 @@ function runCompare() {
   })
   .catch(err => {
     btn.disabled = false;
-    btn.textContent = '🧮 비교 계산';
+    btn.textContent = '비교 계산';
     showError('서버 오류가 발생했습니다.');
   });
 }
@@ -257,7 +257,7 @@ function renderResults(results, targetMarginPct) {
     const currency = document.getElementById('currency').value;
     const rate = fxInfo[currency] || '';
     const badge = document.getElementById('fxBadgeText');
-    badge.innerHTML = `💱 환율 출처: <strong>${srcLabel}</strong>${rate ? ` &nbsp;|&nbsp; 1 ${currency} = ₩${parseFloat(rate).toLocaleString()}` : ''}`;
+    badge.innerHTML = `<i class="bi bi-currency-exchange"></i> 환율 출처: <strong>${srcLabel}</strong>${rate ? ` &nbsp;|&nbsp; 1 ${currency} = ₩${parseFloat(rate).toLocaleString()}` : ''}`;
     document.getElementById('fxBadgeRow').classList.remove('d-none');
   }
 
@@ -301,7 +301,7 @@ function renderResults(results, targetMarginPct) {
               <div class="fw-semibold">₩${r.breakeven_price.toLocaleString()}</div>
             </div>
           </div>
-          ${r.warnings && r.warnings.length > 0 ? `<div class="text-warning small mb-2">⚠️ ${r.warnings.join(' ')}</div>` : ''}
+          ${r.warnings && r.warnings.length > 0 ? `<div class="text-warning small mb-2"><i class="bi bi-exclamation-triangle"></i> ${r.warnings.join(' ')}</div>` : ''}
           <button class="btn btn-outline-secondary btn-sm w-100"
             onclick="applyPrice('${r.marketplace}', ${r.recommended_price})">
             이 가격으로 적용

--- a/src/seller_console/templates/pricing_fx_impact.html
+++ b/src/seller_console/templates/pricing_fx_impact.html
@@ -4,12 +4,12 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
   <div>
-    <h4 class="mb-1">💱 환율 영향 분석</h4>
+    <h4 class="mb-1"><i class="bi bi-currency-exchange"></i> 환율 영향 분석</h4>
     <small class="text-muted">USD/JPY/CNY 변동이 임계치를 넘으면 영향 상품을 추출합니다.</small>
   </div>
   <div class="d-flex gap-2">
     <button class="btn btn-outline-primary btn-sm" onclick="location.reload()">새로고침</button>
-    <button class="btn btn-warning btn-sm" onclick="bulkReprice()">⚡ 일괄 재가격</button>
+    <button class="btn btn-warning btn-sm" onclick="bulkReprice()"><i class="bi bi-lightning-charge"></i> 일괄 재가격</button>
   </div>
 </div>
 

--- a/src/seller_console/templates/pricing_history.html
+++ b/src/seller_console/templates/pricing_history.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
   <div>
-    <h4 class="mb-1">📜 가격 변동 이력</h4>
+    <h4 class="mb-1"><i class="bi bi-clock-history"></i> 가격 변동 이력</h4>
     <small class="text-muted">자동/수동 가격 변경 이력을 조회하고 롤백하세요.</small>
   </div>
   <div class="d-flex gap-2">
@@ -24,7 +24,7 @@
     <input type="date" class="form-control form-control-sm" name="date_to" value="{{ filters.date_to }}" placeholder="종료일">
   </div>
   <div class="col-md-3">
-    <button type="submit" class="btn btn-primary btn-sm">🔍 조회</button>
+    <button type="submit" class="btn btn-primary btn-sm"><i class="bi bi-search"></i> 조회</button>
     <a href="/seller/pricing/history" class="btn btn-outline-secondary btn-sm">초기화</a>
   </div>
 </form>
@@ -80,7 +80,7 @@
 </div>
 {% else %}
 <div class="text-center py-5 text-muted">
-  <div style="font-size: 3rem">📜</div>
+  <div style="font-size: 3rem"><i class="bi bi-clock-history"></i></div>
   <p class="mt-2">가격 변동 이력이 없습니다.</p>
 </div>
 {% endif %}

--- a/src/seller_console/templates/pricing_rules.html
+++ b/src/seller_console/templates/pricing_rules.html
@@ -4,20 +4,20 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
   <div>
-    <h4 class="mb-1">💰 가격 정책 룰 관리</h4>
+    <h4 class="mb-1"><i class="bi bi-cash-coin"></i> 가격 정책 룰 관리</h4>
     <small class="text-muted">자동 가격 조정 룰을 설정하고 시뮬레이션하세요.</small>
   </div>
   <div class="d-flex gap-2">
     {% if dry_run_active %}
-      <span class="badge bg-info fs-6">🔵 DRY_RUN 모드 (시뮬레이션 전용)</span>
+      <span class="badge bg-info fs-6"><i class="bi bi-circle-fill"></i> DRY_RUN 모드 (시뮬레이션 전용)</span>
     {% else %}
-      <span class="badge bg-success fs-6">🟢 실제 적용 모드</span>
+      <span class="badge bg-success fs-6"><i class="bi bi-circle-fill"></i> 실제 적용 모드</span>
     {% endif %}
-    <a href="/seller/pricing/competitors" class="btn btn-outline-secondary btn-sm">🕵️ 경쟁사</a>
-    <a href="/seller/pricing/fx-impact" class="btn btn-outline-secondary btn-sm">💱 환율 영향</a>
-    <a href="/seller/pricing/history" class="btn btn-outline-secondary btn-sm">📜 변동 이력</a>
-    <button class="btn btn-outline-primary btn-sm" id="btnSimulate">🔍 시뮬레이션</button>
-    <button class="btn btn-warning btn-sm" id="btnRunNow">⚡ 지금 실행</button>
+    <a href="/seller/pricing/competitors" class="btn btn-outline-secondary btn-sm"><i class="bi bi-people"></i> 경쟁사</a>
+    <a href="/seller/pricing/fx-impact" class="btn btn-outline-secondary btn-sm"><i class="bi bi-currency-exchange"></i> 환율 영향</a>
+    <a href="/seller/pricing/history" class="btn btn-outline-secondary btn-sm"><i class="bi bi-clock-history"></i> 변동 이력</a>
+    <button class="btn btn-outline-primary btn-sm" id="btnSimulate"><i class="bi bi-search"></i> 시뮬레이션</button>
+    <button class="btn btn-warning btn-sm" id="btnRunNow"><i class="bi bi-lightning-charge"></i> 지금 실행</button>
     <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#modalCreate">+ 새 룰</button>
   </div>
 </div>
@@ -66,7 +66,7 @@
 </div>
 {% else %}
 <div class="text-center py-5 text-muted">
-  <div style="font-size: 3rem">💰</div>
+  <div style="font-size: 3rem"><i class="bi bi-cash-coin"></i></div>
   <p class="mt-2">등록된 룰이 없습니다.<br>+ 새 룰 버튼을 클릭하여 첫 가격 정책 룰을 만드세요.</p>
 </div>
 {% endif %}
@@ -74,7 +74,7 @@
 <!-- 시뮬레이션 결과 -->
 <div id="simulateResult" class="d-none mt-4">
   <div class="card border-info">
-    <div class="card-header bg-info text-white">🔍 시뮬레이션 결과</div>
+    <div class="card-header bg-info text-white"><i class="bi bi-search"></i> 시뮬레이션 결과</div>
     <div class="card-body" id="simulateResultBody">
       <div class="spinner-border spinner-border-sm me-2"></div> 평가 중...
     </div>
@@ -86,7 +86,7 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">➕ 새 가격 정책 룰</h5>
+        <h5 class="modal-title"><i class="bi bi-plus-circle"></i> 새 가격 정책 룰</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
@@ -177,7 +177,7 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">✏️ 룰 수정</h5>
+        <h5 class="modal-title"><i class="bi bi-pencil-square"></i> 룰 수정</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">

--- a/src/seller_console/templates/sourcing.html
+++ b/src/seller_console/templates/sourcing.html
@@ -101,7 +101,7 @@
                     {% if openness == 'open' %}
                     <span class="badge text-bg-success" title="OG/JSON-LD 확인 — 수집 가능">open</span>
                     {% elif openness == 'restricted' %}
-                    <span class="badge text-bg-danger" title="접근 차단/폐쇄형 — 수집 어려움">restricted ⚠</span>
+                    <span class="badge text-bg-danger" title="접근 차단/폐쇄형 — 수집 어려움">restricted <i class="bi bi-exclamation-triangle"></i></span>
                     {% else %}
                     <span class="badge text-bg-warning text-dark" title="부분 수집 가능 — OG 미확인">partial</span>
                     {% endif %}
@@ -128,7 +128,7 @@
                     <input type="hidden" name="action" value="remove">
                     <input type="hidden" name="keyword" value="{{ keyword }}">
                     <input type="hidden" name="domain" value="{{ source.domain }}">
-                    <button class="btn btn-sm btn-outline-danger" type="submit" title="삭제" aria-label="삭제" style="padding:1px 6px;">✕</button>
+                    <button class="btn btn-sm btn-outline-danger" type="submit" title="삭제" aria-label="삭제" style="padding:1px 6px;"><i class="bi bi-x-lg"></i></button>
                   </form>
                 </div>
               </div>
@@ -155,7 +155,7 @@
   <!-- 메인 CTA: 키워드 → AI 상품 추천(콘텐츠 중앙 전면) -->
   <form class="card console-card mb-3 border-primary" method="get" action="/seller/sourcing">
     <div class="card-body">
-      <label for="keywordInput" class="form-label fw-semibold mb-1">🔎 무슨 상품을 팔까요? 키워드를 넣어보세요</label>
+      <label for="keywordInput" class="form-label fw-semibold mb-1"><i class="bi bi-search"></i> 무슨 상품을 팔까요? 키워드를 넣어보세요</label>
       <div class="input-group input-group-lg mb-2">
         <input id="keywordInput" class="form-control" name="keyword" value="{{ keyword }}" placeholder="예: 요가 레깅스, 보틀, 강아지 장난감">
         <input type="hidden" name="period" value="{{ period }}">
@@ -357,13 +357,13 @@ function renderQuickFailure(data, url) {
   quickResult.classList.remove('d-none');
   quickResult.innerHTML = `
     <div class="border rounded-3 p-3 ${manual ? 'border-warning bg-warning-subtle' : 'border-danger bg-danger-subtle'}">
-      <div class="fw-semibold mb-1">${manual ? '⚠️ 자동 수집이 어려운 페이지예요' : '❌ 수집 실패'}</div>
+      <div class="fw-semibold mb-1">${manual ? '<i class="bi bi-exclamation-triangle"></i> 자동 수집이 어려운 페이지예요' : '<i class="bi bi-x-circle"></i> 수집 실패'}</div>
       <div class="small mb-2">${msg}</div>
       <div class="small text-muted mb-2">
         <strong>다음 중 하나로 진행하세요</strong>
         <ul class="mb-0 mt-1">
           <li>상품 <em>상세 페이지</em> 주소가 맞는지 확인하고 다시 시도(목록·검색 페이지는 수집되지 않습니다).</li>
-          <li>로그인·봇 차단 사이트라면 <strong>크롬 확장 🛒 수집</strong>으로 브라우저에서 직접 수집하세요.</li>
+          <li>로그인·봇 차단 사이트라면 <strong>크롬 확장 수집</strong>으로 브라우저에서 직접 수집하세요.</li>
           <li>그래도 안 되면 <strong>직접 입력</strong>으로 제목·가격·이미지를 넣어 등록하세요.</li>
         </ul>
       </div>
@@ -391,11 +391,11 @@ async function saveToRegistry(e) {
     });
     const data = await resp.json();
     if (data.ok) {
-      const badges = {'open':'<span class="badge text-bg-success">open</span>','partial':'<span class="badge text-bg-warning text-dark">partial</span>','restricted':'<span class="badge text-bg-danger">restricted ⚠</span>'};
+      const badges = {'open':'<span class="badge text-bg-success">open</span>','partial':'<span class="badge text-bg-warning text-dark">partial</span>','restricted':'<span class="badge text-bg-danger">restricted <i class="bi bi-exclamation-triangle"></i></span>'};
       const badge = badges[data.openness_status] || '';
       resultEl.classList.remove('d-none');
       resultEl.innerHTML = `<div class="text-success small">소싱처로 저장됨: <strong>${data.domain}</strong> ${badge} — <a href="/seller/sourcing">목록 보기</a></div>`;
-      btn.textContent = '✓ 저장됨';
+      btn.textContent = '저장됨';
     } else {
       throw new Error(data.error || '저장 실패');
     }
@@ -471,7 +471,7 @@ document.querySelectorAll('.registry-recollect-btn').forEach(btn => {
     try {
       const resp = await fetch(`/seller/sourcing/registry/${encodeURIComponent(domain)}/recollect`, {method: 'POST'});
       const data = await resp.json();
-      btn.textContent = data.ok ? '✓' : '!';
+      btn.textContent = data.ok ? '저장됨' : '!';
       if (data.ok) {
         const detail = btn.closest('li')?.querySelector('.registry-detail');
         if (detail) {

--- a/src/seller_console/templates/sourcing_monitor.html
+++ b/src/seller_console/templates/sourcing_monitor.html
@@ -4,7 +4,7 @@
 <div class="container-fluid py-3">
   <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-2">
     <div>
-      <h1 class="h4 mb-1">📡 소싱처 변화 모니터링</h1>
+      <h1 class="h4 mb-1"><i class="bi bi-broadcast"></i> 소싱처 변화 모니터링</h1>
       <p class="text-muted mb-0">내가 수집한 상품의 <strong>소싱처(원본 페이지)</strong>를 다시 확인해
         <strong>가격·품절·옵션/사이즈</strong> 변화를 알려줍니다.</p>
     </div>

--- a/src/seller_console/templates/word_rules.html
+++ b/src/seller_console/templates/word_rules.html
@@ -2,11 +2,11 @@
 {% block title %}금지어·치환 규칙{% endblock %}
 {% block content %}
 <div class="container-fluid py-4" style="max-width: 820px;">
-  <h1 class="h3 mb-1">🚫 금지어 · 단어 치환 규칙</h1>
-  <p class="text-muted mb-4">상품명에서 빼야 할 <strong>금지어</strong>와, 바꿔 쓸 <strong>치환 규칙</strong>을 설정하세요. 수집 이력에서 <strong>‘✨ 상품명 정제’</strong>로 선택 상품에 일괄 적용됩니다.</p>
+  <h1 class="h3 mb-1"><i class="bi bi-slash-circle"></i> 금지어 · 단어 치환 규칙</h1>
+  <p class="text-muted mb-4">상품명에서 빼야 할 <strong>금지어</strong>와, 바꿔 쓸 <strong>치환 규칙</strong>을 설정하세요. 수집 이력에서 <strong>‘ 상품명 정제’</strong>로 선택 상품에 일괄 적용됩니다.</p>
 
   <div class="card mb-3">
-    <div class="card-header"><strong>🚫 금지어</strong> <span class="text-muted small">— 제목에 있으면 제거됩니다</span></div>
+    <div class="card-header"><strong><i class="bi bi-slash-circle"></i> 금지어</strong> <span class="text-muted small">— 제목에 있으면 제거됩니다</span></div>
     <div class="card-body">
       <textarea id="bannedInput" class="form-control" rows="5"
                 placeholder="한 줄에 하나씩 또는 쉼표로 구분&#10;예) 정품&#10;최저가&#10;특가">{{ rules.banned | join('\n') }}</textarea>
@@ -15,7 +15,7 @@
 
   <div class="card mb-3">
     <div class="card-header d-flex justify-content-between align-items-center">
-      <span><strong>🔁 치환 규칙</strong> <span class="text-muted small">— A를 B로 바꿉니다</span></span>
+      <span><strong><i class="bi bi-arrow-repeat"></i> 치환 규칙</strong> <span class="text-muted small">— A를 B로 바꿉니다</span></span>
       <button type="button" class="btn btn-ghost btn-sm" onclick="addSubRow()">＋ 행 추가</button>
     </div>
     <div class="card-body">
@@ -24,7 +24,7 @@
     </div>
   </div>
 
-  <button type="button" class="btn btn-primary" id="saveBtn" onclick="saveRules()">💾 규칙 저장</button>
+  <button type="button" class="btn btn-primary" id="saveBtn" onclick="saveRules()"> 규칙 저장</button>
   <a href="/seller/collect/history" class="btn btn-outline-secondary">수집 이력으로</a>
 </div>
 
@@ -39,7 +39,7 @@ function addSubRow(frm, to) {
     '<div class="col"><input class="form-control form-control-sm sub-from" placeholder="찾을 단어" value="' + (frm ? frm.replace(/"/g,'&quot;') : '') + '"></div>' +
     '<div class="col-auto">→</div>' +
     '<div class="col"><input class="form-control form-control-sm sub-to" placeholder="바꿀 단어(비우면 삭제)" value="' + (to ? to.replace(/"/g,'&quot;') : '') + '"></div>' +
-    '<div class="col-auto"><button type="button" class="btn btn-ghost btn-sm" onclick="this.closest(\'.sub-row\').remove()">✕</button></div>';
+    '<div class="col-auto"><button type="button" class="btn btn-ghost btn-sm" onclick="this.closest(\'.sub-row\').remove()"><i class="bi bi-x-lg"></i></button></div>';
   wrap.appendChild(row);
 }
 (INIT_SUBS && INIT_SUBS.length ? INIT_SUBS : [{}]).forEach(s => addSubRow(s.from, s.to));


### PR DESCRIPTION
v18 디자인 마무리 — **셀러 콘솔 전 화면 이모지 → 단일 아이콘셋(`bi-*`) 교체 완료.**

## 범위
영속 chrome + 수집(페이지/이력/편집) + 마켓(연결/현황/가이드) + 메시징/알림 + 마이페이지/소개/모바일홈/소싱 + 온보딩/설치 스텝 + 가격(룰/콘솔/이력/환율/경쟁사) + 분석/결제/CS(faq/inbox/mobile/stats/quality)/디스커버리/통관/api상태 — **전 화면**.

## 처리 원칙(회귀 0)
- HTML 라벨 → `bi-*`, `<option>`/JS `textContent` → 텍스트, JS `innerHTML` → `bi-*` 스팬, Jinja 조건부 → `{% if %}`.
- 영향 테스트(8건)는 아이콘 기준으로 갱신.

## 의도적 예외(이모지 아이콘 아님)
- 북마클릿 **🧤 드래그 버튼**(`javascript:` 북마클릿은 폰트 아이콘 불가).
- `markets_guide` **SVG `<text>` 다이어그램 일러스트**.
- **✓ dingbat**(본문 설명·스테퍼 체크 — 이모지 아님).
- 알림 페이지의 **실제 발송 메시지 예시** 텍스트.

## 테스트
- 전체 `pytest` **10248 passed**, 무회귀. 단일 아이콘셋 = 이미 로드된 Bootstrap Icons.

> v18 §8 “이모지 아이콘 0” 충족(콘솔 전 화면). 디자인 토큰(PART B)·게이트(PART A)와 함께 v18 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)