### PR TITLE
v25 P0: 아마존 전체수집 실제 상품만 (광고·미디어 제외)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 > 이 파일은 매 세션 시작 시 로드된다. 오너(Kohgane) 지시·검증된 팩트를 누적 기록한다.
 
+## 🟩 v25~v27 통합 마스터 (오너 2026-06-26 — 순서: v24✅→v25P0→v27→v25P1→v26)
+- ✅ **v25 P0 아마존 '전체 수집' 실제 상품만 (Phase 299):** 증상=전체선택 시 Amazon Music·광고(스폰서)·미디어
+  카드까지 선택됨. 원인=어댑터가 s-search-result+/dp/+가격만 보고 스폰서/비-ASIN 위젯도 통과. **수정:**
+  `_kgpAmazonCards`에 **유효 ASIN(`/^[A-Z0-9]{10}$/`, data-asin) 필수** + `_kgpAmazonSponsored()`(s-sponsored-label-text/
+  sp-sponsored-result 등 클래스 기반) 제외 → 뮤직/앱/프로모(ASIN 없음)·광고 0 선택. 툴바에 정직한 '전체 N개 중 상품
+  M개' 표기(`_kgpScannedCount`). manifest 1.5.11→1.5.12. 가드 test_extension_amazon_products_v25(ASIN 정규식 node 실검증).
+  전체 10276 passed.
+- ⏳ 다음: v27(네이버 검색 API 실데이터/미설정=빈상태) → v25 P1(아마존 국가선택·초보 활성화) → v26(네오-클래식 디자인).
+
 ## 🟦 v24 브리프 (오너 2026-06-25 — "수집 이력 버그 · 마켓 Mock 정리 · 초보 흐름 · 아이콘 최종")
 - ✅ **아이콘 최종본 적용:** 오너 최종 마스터(현수교 2선 다리)로 교체, v=176/확장 1.5.11(아래 v23 파이프라인 재실행).
 - ✅ **P0 수집 성공인데 이력 0 (Phase 298):** 원인=`collect_history_store.append`가 시트 쓰기 실패 시 `_in_memory`로

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -448,6 +448,7 @@ const KGP_TOOLBAR_ID = "kgp-listing-toolbar";
 const KGP_SELECTED = new Set();   // 선택된 상품 url 집합(재스캔에도 유지)
 let _kgpCards = [];
 let _kgpCardByUrl = {};           // url → 카드 데이터(el 포함) — 재스캔 시 '병합'(절대 비우지 않음)
+let _kgpScannedCount = 0;         // 마지막 스캔에서 본 후보 카드 총수(상품 M개 / 전체 N개 표기용)
 let _kgpClosed = false;           // 사용자가 툴바를 닫았으면 자동 재생성 안 함(같은 URL 동안)
 
 function _kgpPrice(text) {
@@ -532,12 +533,29 @@ function _kgpInBadRegion(el) {
   return false;
 }
 
-// 아마존 검색결과 어댑터 — 실제 제품 카드 컨테이너만.
+// 스폰서(광고) 카드 판별 — 클래스/라벨 기반(보수적, 오탐 최소).
+function _kgpAmazonSponsored(el) {
+  try {
+    if (el.querySelector('.s-sponsored-label-text, .puis-sponsored-label-text, [data-component-type="sp-sponsored-result"], [aria-label*="Sponsored"], [data-component-type="s-sponsored-label-info-icon"]')) {
+      return true;
+    }
+  } catch (e) { /* noop */ }
+  return false;
+}
+
+// 아마존 검색결과 어댑터 — 실제 '상품' 카드만(유효 ASIN + 가격 + 상품URL). 스폰서/뮤직/앱/미디어 제외.
+// v25 P0: 전체선택 시 광고·미디어 카드까지 잡히던 문제 → data-asin(10자) 필수 + 스폰서 제외.
 function _kgpAmazonCards() {
   const cards = [], seen = {};
-  document.querySelectorAll('[data-component-type="s-search-result"]').forEach((el) => {
+  const all = document.querySelectorAll('[data-component-type="s-search-result"]');
+  _kgpScannedCount = all.length;                          // '전체 N개' (상품/비상품 합)
+  all.forEach((el) => {
     try {
       if (_kgpInBadRegion(el)) return;
+      // 유효 ASIN(B0… 등 10자 영숫자)만 = 실제 상품. 뮤직/앱/프로모 위젯은 ASIN이 없거나 비정상.
+      const asin = (el.getAttribute("data-asin") || "").trim();
+      if (!/^[A-Z0-9]{10}$/.test(asin)) return;
+      if (_kgpAmazonSponsored(el)) return;                 // 스폰서(광고) 제외
       const a = el.querySelector('a.a-link-normal[href*="/dp/"], h2 a, a.a-link-normal.s-no-outline');
       const href = a && a.href ? a.href.split("?")[0].split("#")[0] : "";
       if (!href || href.indexOf("http") !== 0 || seen[href]) return;
@@ -545,7 +563,7 @@ function _kgpAmazonCards() {
       const titleEl = el.querySelector("h2 span") || el.querySelector("h2");
       const priceEl = el.querySelector(".a-price .a-offscreen") || el.querySelector(".a-price");
       const pr = _kgpPrice(priceEl ? priceEl.textContent : (el.innerText || ""));
-      if (!img || !titleEl || !pr.price) return;            // 제목+가격+링크+이미지 모두 있어야 제품
+      if (!img || !titleEl || !pr.price) return;            // 제목+가격+링크+이미지 모두 있어야 상품
       seen[href] = 1;
       cards.push({
         url: href, title: (titleEl.innerText || titleEl.textContent || "").trim().slice(0, 200),
@@ -590,6 +608,7 @@ function _kgpGenericCards() {
 
 function kgpFindCards() {
   const host = (location.hostname || "").toLowerCase();
+  _kgpScannedCount = 0;            // 매 스캔 초기화(어댑터가 '전체 N개'를 설정)
   let cards = [];
   try { if (/(^|\.)amazon\.[a-z.]+$/.test(host)) cards = _kgpAmazonCards(); } catch (e) { cards = []; }
   if (!cards.length) { try { cards = _kgpGenericCards(); } catch (e) { cards = []; } }
@@ -631,7 +650,13 @@ function kgpSetStatus(msg) {
 
 function kgpUpdateToolbar() {
   const c = document.getElementById("kgp-tb-count");
-  if (c) c.textContent = `${_kgpCards.length}개 발견 · ${KGP_SELECTED.size}개 선택`;
+  if (!c) return;
+  // 광고·미디어를 걸러냈을 때 정직하게 '전체 N개 중 상품 M개'로 표기.
+  if (_kgpScannedCount > _kgpCards.length) {
+    c.textContent = `전체 ${_kgpScannedCount}개 중 상품 ${_kgpCards.length}개 · ${KGP_SELECTED.size}개 선택`;
+  } else {
+    c.textContent = `${_kgpCards.length}개 발견 · ${KGP_SELECTED.size}개 선택`;
+  }
 }
 
 async function kgpCollect(urls) {

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "고가수집기",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "지정 소싱처(타오바오·아마존 등)에서 한 클릭에 고가브릿지로 수집 (인페이지 수집 + 리스팅 다중 선택 수집 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/tests/test_extension_amazon_products_v25.py
+++ b/tests/test_extension_amazon_products_v25.py
@@ -1,0 +1,62 @@
+"""tests/test_extension_amazon_products_v25.py — v25 P0: 아마존 '전체 수집' 실제 상품만.
+
+전체선택 시 Amazon Music·광고(스폰서)·미디어 카드까지 잡히던 문제 →
+아마존 어댑터가 유효 ASIN(10자) + 비-스폰서 + 가격/이미지/제목을 모두 갖춘 카드만 상품으로.
+(JS 런타임은 브라우저 전용 → 소스 계약을 정적으로 핀 + ASIN 정규식은 node로 실동작 검증.)
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CS = Path("extensions/chrome-collector/content_script.js").read_text(encoding="utf-8")
+
+
+def test_amazon_requires_valid_asin_and_excludes_sponsored():
+    # 유효 ASIN 필수 + 스폰서 제외 함수 + 호출
+    assert "function _kgpAmazonSponsored" in CS
+    assert "/^[A-Z0-9]{10}$/.test(asin)" in CS
+    assert "_kgpAmazonSponsored(el)" in CS
+    # 스폰서 라벨 셀렉터(클래스/컴포넌트 기반)
+    assert "s-sponsored-label-text" in CS
+    assert "sp-sponsored-result" in CS
+
+
+def test_scanned_vs_product_count_surfaced():
+    # 정직한 '전체 N개 중 상품 M개' 표기
+    assert "_kgpScannedCount" in CS
+    assert "전체 ${_kgpScannedCount}개 중 상품 ${_kgpCards.length}개" in CS
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node 미설치")
+def test_asin_regex_distinguishes_products():
+    """ASIN 정규식이 실제 상품(B0…10자)만 통과시키고 뮤직/광고/빈값은 거른다."""
+    script = r"""
+    const re = /^[A-Z0-9]{10}$/;
+    const cases = {
+      "B08N5WRWNW": true,    // 정상 상품 ASIN
+      "B0CHX1W1XY": true,
+      "": false,             // ASIN 없음(프로모 위젯)
+      "amazon-music": false, // 미디어 위젯
+      "AD": false,           // 광고 슬롯
+      "TOOLONGASIN12": false
+    };
+    let ok = true;
+    for (const [k, exp] of Object.entries(cases)) {
+      if (re.test(k) !== exp) { console.log("FAIL", k); ok = false; }
+    }
+    console.log(ok ? "PASS" : "FAIL");
+    """
+    out = subprocess.run(["node", "-e", script], capture_output=True, text=True, timeout=20)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip().endswith("PASS"), out.stdout
+
+
+def test_manifest_version_bumped():
+    import json
+    mf = json.loads(Path("extensions/chrome-collector/manifest.json").read_text(encoding="utf-8"))
+    parts = [int(x) for x in mf["version"].split(".")]
+    assert parts >= [1, 5, 12], mf["version"]


### PR DESCRIPTION
## v25 P0 — 아마존 '전체 수집'은 실제 상품만

**증상:** Amazon 검색 목록에서 전체선택 시 **Amazon Music·광고(스폰서)·미디어 카드**까지 선택됨.
**원인:** 어댑터가 `s-search-result` + `/dp/` + 가격만 보고, 스폰서/비-ASIN 위젯도 통과시킴.

**수정 (`extensions/chrome-collector/content_script.js`):**
- `_kgpAmazonCards`에 **유효 ASIN 필수** — `data-asin`이 `/^[A-Z0-9]{10}$/` 일 때만 상품. 뮤직/앱/프로모 위젯(ASIN 없음/비정상)은 제외.
- `_kgpAmazonSponsored()` — `s-sponsored-label-text` / `sp-sponsored-result` 등 클래스 기반으로 **광고(스폰서) 제외**.
- 정직 표기: 툴바에 **"전체 N개 중 상품 M개"**(`_kgpScannedCount`)로 걸러낸 수 노출.
- manifest `1.5.11 → 1.5.12`.

**DoD:** 전체선택 → 비품목(광고/뮤직/앱) **0 선택**.

**검증:** `test_extension_amazon_products_v25` — 계약 정적 핀 + **ASIN 정규식 node 실동작 검증**(B0…10자만 통과, 빈값/`amazon-music`/`AD` 거름). 전체 **10276 passed**, 0 regressions.

---
다음 단계(마스터 순서): v27 네이버 검색 API → v25 P1 아마존 국가선택·활성화 → v26 디자인 리프레시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_