### PR TITLE
v27: 네이버 검색 API 소싱 분석 실데이터 (미설정=빈상태)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,13 @@
   sp-sponsored-result 등 클래스 기반) 제외 → 뮤직/앱/프로모(ASIN 없음)·광고 0 선택. 툴바에 정직한 '전체 N개 중 상품
   M개' 표기(`_kgpScannedCount`). manifest 1.5.11→1.5.12. 가드 test_extension_amazon_products_v25(ASIN 정규식 node 실검증).
   전체 10276 passed.
-- ⏳ 다음: v27(네이버 검색 API 실데이터/미설정=빈상태) → v25 P1(아마존 국가선택·초보 활성화) → v26(네오-클래식 디자인).
+- ✅ **v27 네이버 검색 API 실데이터 (Phase 300):** 소싱 분석 '데이터 없음'을 **검색 API만으로** 실데이터화.
+  `naver_shopping.search_domestic()`(items+total 동시 반환, 키 env 전용·미설정/실패=`{items:[],total:None}`·키 로그 0).
+  `_build_sourcing_analysis`에 실데이터 2종 추가 — **국내 검색 결과 수**(전국 total) + **판매처(쇼핑몰) 수**(고유 몰=경쟁
+  강도). 상품수/최저·평균가(기존 실데이터)와 함께. 검색광고(관심도/경쟁도)·해외직구·리뷰는 검색 API로 못 구해 None 유지
+  (날조 금지). 미연결 시 전 수치 None(가짜 0 금지). 가드 test_v27_naver_sourcing(미설정 빈상태/실데이터 매핑/페이지 렌더).
+  전체 10280 passed. 오너 액션: developers.naver.com 앱(검색) → NAVER_SEARCH_CLIENT_ID/SECRET을 Render Env에.
+- ⏳ 다음: v25 P1(아마존 국가선택·초보 활성화) → v26(네오-클래식 디자인).
 
 ## 🟦 v24 브리프 (오너 2026-06-25 — "수집 이력 버그 · 마켓 Mock 정리 · 초보 흐름 · 아이콘 최종")
 - ✅ **아이콘 최종본 적용:** 오너 최종 마스터(현수교 2선 다리)로 교체, v=176/확장 1.5.11(아래 v23 파이프라인 재실행).

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -489,22 +489,31 @@ def _sourcing_search_links(query: str) -> "list[dict[str, str]]":
 
 def _build_sourcing_analysis(domestic_products: "list[dict[str, Any]]",
                              keyword_context: "dict[str, Any] | None",
-                             keyword: str) -> "dict[str, Any]":
+                             keyword: str,
+                             domestic_total: "int | None" = None) -> "dict[str, Any]":
     """소싱 분석 패널 — 계산 가능한 것만 실데이터, 불가하면 None('데이터 없음').
 
     날조 금지: 해외직구 비율·리뷰 지수 등 우리가 계산 못 하는 지표는 None으로 두고
-    템플릿이 '데이터 없음'으로 표시한다.
+    템플릿이 '데이터 없음'으로 표시한다. domestic_total = 네이버 '검색' API 전국 결과 수(실데이터).
     """
     metrics: "list[dict[str, Any]]" = []
     products = domestic_products or []
     prices = [p["price"] for p in products if isinstance(p.get("price"), int) and p["price"] > 0]
 
-    # 국내 판매 상품 수(네이버 쇼핑 실데이터)
+    # 전국 검색 결과 수(네이버 쇼핑 '검색' API total — 시장 규모/노출량 실데이터)
+    metrics.append({"label": "국내 검색 결과 수",
+                    "value": (f"{domestic_total:,}개" if isinstance(domestic_total, int) and domestic_total > 0 else None),
+                    "note": "네이버 쇼핑 전국 검색"})
+    # 국내 판매 상품 수(이번 조회 표본)
     metrics.append({"label": "국내 판매 상품 수", "value": (f"{len(products)}개" if products else None),
                     "note": "네이버 쇼핑 검색 결과"})
     # 최저가 / 평균가(실데이터 계산)
     metrics.append({"label": "국내 최저가", "value": (f"₩{min(prices):,}" if prices else None), "note": "검색 결과 기준"})
     metrics.append({"label": "국내 평균가", "value": (f"₩{round(sum(prices) / len(prices)):,}" if prices else None), "note": "검색 결과 기준"})
+    # 판매처(쇼핑몰) 수 — 검색 결과의 고유 몰 수 = 경쟁 강도 실데이터 신호
+    _malls = {(p.get("mall") or "").strip() for p in products if (p.get("mall") or "").strip()}
+    metrics.append({"label": "판매처(쇼핑몰) 수", "value": (f"{len(_malls)}곳" if _malls else None),
+                    "note": "검색 결과 기준"})
 
     # 검색 관심도·경쟁도(네이버 검색광고 실데이터 — 있을 때만)
     kw_lower = (keyword or "").strip().lower()
@@ -5955,14 +5964,18 @@ def sourcing_hub():
     # v12: 국내 베스트셀러(네이버 쇼핑 실데이터) + 소싱처 검색 딥링크 + 분석(실데이터/없으면 '데이터 없음')
     domestic_products: list[dict[str, Any]] = []
     domestic_enabled = False
+    domestic_total: int | None = None
     try:
         from src.sourcing import naver_shopping
         domestic_enabled = naver_shopping.is_configured()
         if keyword and domestic_enabled:
-            domestic_products = naver_shopping.search_domestic_products(keyword, limit=12)
+            _res = naver_shopping.search_domestic(keyword, limit=12)
+            domestic_products = _res.get("items") or []
+            domestic_total = _res.get("total")
     except Exception as exc:
         logger.debug("국내 베스트셀러 조회 스킵: %s", exc)
-    analysis = _build_sourcing_analysis(domestic_products, keyword_context, keyword)
+    analysis = _build_sourcing_analysis(domestic_products, keyword_context, keyword,
+                                        domestic_total=domestic_total)
 
     return render_template(
         "sourcing.html",

--- a/src/sourcing/naver_shopping.py
+++ b/src/sourcing/naver_shopping.py
@@ -32,20 +32,21 @@ def _strip_tags(s: str) -> str:
     return _TAG_RE.sub("", s or "").strip()
 
 
-def search_domestic_products(keyword: str, *, limit: int = 12, sort: str = "sim") -> List[Dict[str, Any]]:
-    """키워드로 국내 판매 상품을 검색해 카드용 dict 리스트로 반환.
+def search_domestic(keyword: str, *, limit: int = 12, sort: str = "sim") -> Dict[str, Any]:
+    """키워드로 국내 판매 상품 검색 — items + total(전국 검색 결과 수)을 함께 반환.
 
-    반환 각 항목: {title, image, price(int KRW), mall, link, brand}.
-    키 미설정/실패/dry-run → [] (정직).
-    sort: sim(정확도)·date·asc·dsc(가격). 베스트셀러 느낌은 'sim'(기본) 또는 별도 정렬.
+    반환: {"items": [{title, image, price(int KRW), mall, link, brand}, ...], "total": int|None}.
+    키 미설정/실패/dry-run → {"items": [], "total": None} (정직·날조 금지).
+    total = 네이버 쇼핑 '검색' API의 전국 검색 결과 수 = 시장 규모/노출량 실데이터 신호.
     """
+    empty = {"items": [], "total": None}
     kw = (keyword or "").strip()
     if not kw:
-        return []
+        return dict(empty)
     if os.getenv("ADAPTER_DRY_RUN") == "1":
-        return []
+        return dict(empty)
     if not is_configured():
-        return []
+        return dict(empty)
 
     cid = os.getenv("NAVER_SEARCH_CLIENT_ID", "").strip()
     csec = os.getenv("NAVER_SEARCH_CLIENT_SECRET", "").strip()
@@ -55,17 +56,18 @@ def search_domestic_products(keyword: str, *, limit: int = 12, sort: str = "sim"
         display = 12
 
     qs = urllib.parse.urlencode({"query": kw, "display": display, "sort": sort})
+    # 인증 헤더는 env에서만 — 키는 로그에 남기지 않는다(키워드만 기록).
     req = urllib.request.Request(_ENDPOINT + "?" + qs, headers={
         "X-Naver-Client-Id": cid,
         "X-Naver-Client-Secret": csec,
-        "User-Agent": "KOHgogane/1.0",
+        "User-Agent": "Goga Bridj/1.0",
     })
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             data = json.loads(resp.read().decode("utf-8"))
     except Exception as exc:
         logger.warning("네이버 쇼핑 검색 실패(키워드=%r): %s", kw, exc)
-        return []
+        return dict(empty)
 
     out: List[Dict[str, Any]] = []
     for it in (data.get("items") or []):
@@ -84,4 +86,13 @@ def search_domestic_products(keyword: str, *, limit: int = 12, sort: str = "sim"
             "brand": (it.get("brand") or it.get("maker") or "").strip(),
             "link": (it.get("link") or "").strip(),
         })
-    return out
+    try:
+        total = int(data.get("total")) if data.get("total") is not None else None
+    except (TypeError, ValueError):
+        total = None
+    return {"items": out, "total": total}
+
+
+def search_domestic_products(keyword: str, *, limit: int = 12, sort: str = "sim") -> List[Dict[str, Any]]:
+    """하위호환 래퍼 — items만 반환(기존 호출부용)."""
+    return search_domestic(keyword, limit=limit, sort=sort)["items"]

--- a/tests/test_v27_naver_sourcing.py
+++ b/tests/test_v27_naver_sourcing.py
@@ -1,0 +1,58 @@
+"""tests/test_v27_naver_sourcing.py — v27: 네이버 검색 API 소싱 분석 실데이터.
+
+키 연결 시 실수치(검색 결과 수·상품 수·최저/평균가·판매처 수), 미연결 시 빈 상태(가짜 0 금지).
+키는 env 전용. 검색광고(관심도/경쟁도)·해외직구·리뷰는 우리가 못 구하면 None('데이터 없음').
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def test_naver_search_env_only_and_empty_when_unset(monkeypatch):
+    from src.sourcing import naver_shopping
+    monkeypatch.delenv("NAVER_SEARCH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("NAVER_SEARCH_CLIENT_SECRET", raising=False)
+    assert naver_shopping.is_configured() is False
+    # 미설정 → 빈 결과(네트워크 호출 안 함, 가짜 데이터 0)
+    res = naver_shopping.search_domestic("에코백", limit=12)
+    assert res == {"items": [], "total": None}
+    assert naver_shopping.search_domestic_products("에코백") == []
+
+
+def test_analysis_empty_state_no_fake_numbers():
+    from src.seller_console.views import _build_sourcing_analysis
+    a = _build_sourcing_analysis([], None, "에코백", domestic_total=None)
+    # 데이터 없으면 모든 수치 None(가짜 0 금지)
+    assert all(m["value"] is None for m in a["metrics"])
+    assert a["has_any"] is False
+
+
+def test_analysis_real_values_when_data_present():
+    from src.seller_console.views import _build_sourcing_analysis
+    products = [
+        {"price": 1000, "mall": "스토어A"},
+        {"price": 3000, "mall": "스토어B"},
+        {"price": 2000, "mall": "스토어A"},  # 같은 몰 → 고유 2곳
+    ]
+    a = _build_sourcing_analysis(products, None, "에코백", domestic_total=12345)
+    vals = {m["label"]: m["value"] for m in a["metrics"]}
+    assert vals["국내 검색 결과 수"] == "12,345개"
+    assert vals["국내 판매 상품 수"] == "3개"
+    assert vals["국내 최저가"] == "₩1,000"
+    assert vals["국내 평균가"] == "₩2,000"
+    assert vals["판매처(쇼핑몰) 수"] == "2곳"
+    # 우리가 못 구하는 지표는 여전히 None(날조 금지)
+    assert vals["해외직구 비율"] is None
+    assert a["has_any"] is True
+
+
+def test_sourcing_page_renders_without_keys(monkeypatch):
+    monkeypatch.delenv("NAVER_SEARCH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("NAVER_SEARCH_CLIENT_SECRET", raising=False)
+    os.environ["SELLER_CONSOLE_AUTH"] = "0"
+    from src.order_webhook import app
+    with app.test_client() as c:
+        r = c.get("/seller/sourcing?keyword=에코백")
+        assert r.status_code == 200


### PR DESCRIPTION
## v27 — 네이버 검색 API 소싱 분석 실데이터

소싱 분석의 "데이터 없음"을 **검색 API만으로** 실데이터화. (오너 전제: 사용 API="검색"만.)

### 변경
- `naver_shopping.search_domestic()` 신규 — items + **total(전국 검색 결과 수)** 동시 반환. 키는 **env 전용**(`NAVER_SEARCH_CLIENT_ID/SECRET`), 미설정/실패/dry-run → `{items:[], total:None}`(가짜 0 금지). **키는 로그에 남기지 않음**(키워드만). 기존 `search_domestic_products`는 래퍼로 유지(무회귀).
- `_build_sourcing_analysis`에 실데이터 2종 추가:
  - **국내 검색 결과 수** = 검색 API `total`(시장 규모/노출량 신호)
  - **판매처(쇼핑몰) 수** = 검색 결과의 고유 몰 수(경쟁 강도 신호)
  - 기존 상품 수 / 최저가 / 평균가(실데이터)와 함께
- 검색광고 기반 관심도·경쟁도, 해외직구 비율, 리뷰 지수는 **검색 API로 못 구하므로 None 유지**(날조 금지).
- **미연결 시 전 수치 None**(빈 상태), 가짜 0 없음.

### DoD
- 키 연결 시 분석 실수치 표시 / 미연결 시 빈 상태(가짜 0 없음) / 키 env 전용·로그 노출 0 ✅

### 검증
- `test_v27_naver_sourcing` — 미설정 빈 상태, 실데이터 매핑(검색수/상품수/최저·평균가/판매처수), 페이지 렌더
- 전체 **10280 passed**, 0 regressions

### 오너 액션
- developers.naver.com 앱 등록(사용 API "검색") → Client ID/Secret을 **Render Environment**에 입력 → Manual Deploy

---
다음(마스터): v25 P1 아마존 국가선택·초보 활성화 → v26 디자인 리프레시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_