### PR TITLE
v25 P1: 아마존 국가선택 확장 + 초보 활성화 퍼널(아하=첫 업로드)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,13 @@
   _base_app.html og:image/twitter:image를 og-card.png**?v=2**(캐시 bump)로 교체. 옛 글러브 생성 스크립트
   (gen_favicon_glove.py·gen_extension_icons.py) 제거(잔재 0). 가드 test_v28_og_image(1200×630·메타·서빙·글러브 스크립트 0).
   전체 10284 passed.
-- ⏳ 다음: v25 P1(아마존 국가선택·초보 활성화) → v26(네오-클래식 디자인).
+- ✅ **v25 P1 아마존 국가선택 확장 + 초보 활성화 퍼널 (Phase 302):** ①아마존 칩 드롭다운 10→**14개국**(싱가포르.sg/
+  멕시코.com.mx/UAE.ae/브라질.com.br 추가) + 각 국가 **통화 표기**(USD/JPY/SGD/BRL…) + **선택 기억**(localStorage
+  kgp_amazon_country — 마지막 국가를 버튼 라벨 '아마존 · 미국' + 메뉴 상단으로). ②활성화 퍼널: `compute_onboarding_state`에
+  `collected_count` 옵션 추가(하위호환 — None이면 기존 3단계) → **수집→연동→소싱처→첫 업로드(🎯 아하-모먼트)** 4단계.
+  대시보드가 본인 스코프 collect summary로 collected_count 주입. 거짓 성공 금지(편집은 추적 불가라 별도 단계로 안 만들고
+  수집 설명에 '확인·편집' 포함). 가드 test_v25_p1_amazon_activation(국가/통화/기억 + 퍼널 4단계/아하/하위호환). 전체 10289 passed.
+- ⏳ 다음: v26(네오-클래식 에디토리얼 디자인 리프레시).
 
 ## 🟦 v24 브리프 (오너 2026-06-25 — "수집 이력 버그 · 마켓 Mock 정리 · 초보 흐름 · 아이콘 최종")
 - ✅ **아이콘 최종본 적용:** 오너 최종 마스터(현수교 2선 다리)로 교체, v=176/확장 1.5.11(아래 v23 파이프라인 재실행).

--- a/src/seller_console/onboarding.py
+++ b/src/seller_console/onboarding.py
@@ -16,14 +16,31 @@ def compute_onboarding_state(
     source_count: Any,
     product_count: Any,
     *,
+    collected_count: Any = None,
     dismissed: bool = False,
 ) -> dict[str, Any]:
-    """마켓 연동 → 소싱처 등록 → 상품 등록 온보딩 진행 상태를 계산한다."""
+    """활성화 퍼널 진행 상태를 계산한다.
+
+    collected_count 제공 시(v25 P1) '상품 수집'을 첫 단계로 prepend해
+    수집 → 마켓 연동 → 소싱처 → 첫 업로드(아하-모먼트) 퍼널을 만든다.
+    None이면(레거시) 기존 마켓 연동 → 소싱처 → 상품 등록 3단계.
+    """
     connected_count = _safe_count(connected_markets)
     sources = _safe_count(source_count)
     products = _safe_count(product_count)
 
-    steps = [
+    steps = []
+    if collected_count is not None:
+        collected = _safe_count(collected_count)
+        steps.append({
+            "key": "collect",
+            "title": "첫 상품 수집",
+            "description": "고가수집기로 해외 상품을 가져오고 ‘수집한 상품’에서 확인·편집하세요.",
+            "href": "/seller/collect",
+            "cta_label": "상품 수집하기",
+            "completed": collected > 0,
+        })
+    steps += [
         {
             "key": "market",
             "title": "마켓 연동",
@@ -42,10 +59,10 @@ def compute_onboarding_state(
         },
         {
             "key": "product",
-            "title": "첫 상품 등록",
-            "description": "AI 상품등록으로 첫 상품을 마켓에 올려보세요.",
-            "href": "/seller/listing/ai-create",
-            "cta_label": "AI 상품등록 열기",
+            "title": "🎯 첫 마켓 업로드",
+            "description": "수집한 상품을 내 마켓에 올리면 끝! (가장 중요한 한 걸음)",
+            "href": "/seller/collect/history",
+            "cta_label": "수집한 상품 업로드",
             "completed": products > 0,
         },
     ]

--- a/src/seller_console/templates/manual_collect.html
+++ b/src/seller_console/templates/manual_collect.html
@@ -49,14 +49,17 @@
     <div class="d-flex flex-wrap gap-2" id="oneclickMarkets">
       {% for m in oneclick_markets %}
       {% if m.countries %}
-      <div class="dropdown oneclick-market">
-        <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" title="{{ m.name }}">
-          {{ favicon(m.domain) }}{{ m.name }}
+      <div class="dropdown oneclick-market" data-amazon-dropdown>
+        <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" title="{{ m.name }}" data-amazon-btn data-default-label="{{ m.name }}">
+          {{ favicon(m.domain) }}<span data-amazon-label>{{ m.name }}</span>
         </button>
         <ul class="dropdown-menu">
-          <li><h6 class="dropdown-header">국가 선택</h6></li>
+          <li><h6 class="dropdown-header">국가 선택 (통화)</h6></li>
           {% for ctry in m.countries %}
-          <li><a class="dropdown-item" href="{{ mk(ctry.url) }}" target="_blank" rel="noopener noreferrer">{{ ctry.name }}</a></li>
+          <li><a class="dropdown-item d-flex justify-content-between align-items-center gap-3" href="{{ mk(ctry.url) }}" target="_blank" rel="noopener noreferrer"
+                 data-amazon-country data-country-name="{{ ctry.name }}">
+            <span>{{ ctry.name }}</span><span class="text-muted small">{{ ctry.currency }}</span>
+          </a></li>
           {% endfor %}
         </ul>
       </div>
@@ -216,6 +219,35 @@
 
 {% block extra_js %}
 <script>
+// v25 P1: 아마존 국가 선택 기억 — 마지막에 고른 국가를 버튼에 표시하고 메뉴 상단으로 올림.
+(function () {
+  try {
+    var KEY = "kgp_amazon_country";
+    var dd = document.querySelector("[data-amazon-dropdown]");
+    if (!dd) return;
+    var label = dd.querySelector("[data-amazon-label]");
+    var menu = dd.querySelector(".dropdown-menu");
+    var saved = localStorage.getItem(KEY);
+    if (saved && label) {
+      label.textContent = "아마존 · " + saved;
+      // 저장된 국가를 헤더 바로 아래로 이동(기억 반영)
+      var items = dd.querySelectorAll("[data-amazon-country]");
+      for (var i = 0; i < items.length; i++) {
+        if (items[i].getAttribute("data-country-name") === saved) {
+          var hdr = menu.querySelector(".dropdown-header");
+          var li = items[i].closest("li");
+          if (hdr && li && hdr.parentElement) hdr.parentElement.insertBefore(li, hdr.nextSibling);
+          break;
+        }
+      }
+    }
+    dd.addEventListener("click", function (e) {
+      var a = e.target.closest && e.target.closest("[data-amazon-country]");
+      if (a) { try { localStorage.setItem(KEY, a.getAttribute("data-country-name") || ""); } catch (x) {} }
+    });
+  } catch (e) { /* noop */ }
+})();
+
 let currentDraft = null;
 let localizedDrafts = {};
 

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -808,12 +808,20 @@ def _build_dashboard_home_context(widgets: list[dict[str, Any]], dismissed: bool
         logger.debug("온보딩 소싱처 수 조회 스킵: %s", exc)
 
     product_count = sum(max(0, _to_int(row.get("total_registered"))) for row in market_grid_rows)
+    # v25 P1: 활성화 퍼널 첫 단계 = 상품 수집(실데이터). 본인 스코프로 집계.
+    collected_count = 0
+    try:
+        from src.seller_console import collect_history_store as _chs
+        collected_count = _to_int(_chs.summary(seller_ids=_seller_identities()).get("total"))
+    except Exception as exc:
+        logger.debug("온보딩 수집 수 조회 스킵: %s", exc)
     try:
         from src.seller_console.onboarding import compute_onboarding_state
         onboarding = compute_onboarding_state(
             connected_markets=connected_count,
             source_count=source_count,
             product_count=product_count,
+            collected_count=collected_count,
             dismissed=dismissed,
         )
     except Exception as exc:
@@ -1114,18 +1122,22 @@ def collect():
         {"name": "큐텐", "url": "https://www.qoo10.com", "domain": "qoo10.com"},
         {"name": "메루카리", "url": "https://jp.mercari.com", "domain": "mercari.com"},
         {"name": "라쿠텐", "url": "https://www.rakuten.co.jp", "domain": "rakuten.co.jp"},
-        # 아마존은 국가별 사이트가 달라 드롭다운으로 선택
+        # 아마존은 국가별 사이트가 달라 드롭다운으로 선택(v25 P1: 주요국 확장 + 통화 표기)
         {"name": "아마존", "domain": "amazon.com", "countries": [
-            {"name": "미국 (.com)", "url": "https://www.amazon.com"},
-            {"name": "일본 (.co.jp)", "url": "https://www.amazon.co.jp"},
-            {"name": "독일 (.de)", "url": "https://www.amazon.de"},
-            {"name": "영국 (.co.uk)", "url": "https://www.amazon.co.uk"},
-            {"name": "프랑스 (.fr)", "url": "https://www.amazon.fr"},
-            {"name": "캐나다 (.ca)", "url": "https://www.amazon.ca"},
-            {"name": "이탈리아 (.it)", "url": "https://www.amazon.it"},
-            {"name": "스페인 (.es)", "url": "https://www.amazon.es"},
-            {"name": "호주 (.com.au)", "url": "https://www.amazon.com.au"},
-            {"name": "인도 (.in)", "url": "https://www.amazon.in"},
+            {"name": "미국 (.com)", "url": "https://www.amazon.com", "currency": "USD"},
+            {"name": "일본 (.co.jp)", "url": "https://www.amazon.co.jp", "currency": "JPY"},
+            {"name": "영국 (.co.uk)", "url": "https://www.amazon.co.uk", "currency": "GBP"},
+            {"name": "독일 (.de)", "url": "https://www.amazon.de", "currency": "EUR"},
+            {"name": "프랑스 (.fr)", "url": "https://www.amazon.fr", "currency": "EUR"},
+            {"name": "이탈리아 (.it)", "url": "https://www.amazon.it", "currency": "EUR"},
+            {"name": "스페인 (.es)", "url": "https://www.amazon.es", "currency": "EUR"},
+            {"name": "캐나다 (.ca)", "url": "https://www.amazon.ca", "currency": "CAD"},
+            {"name": "호주 (.com.au)", "url": "https://www.amazon.com.au", "currency": "AUD"},
+            {"name": "싱가포르 (.sg)", "url": "https://www.amazon.sg", "currency": "SGD"},
+            {"name": "멕시코 (.com.mx)", "url": "https://www.amazon.com.mx", "currency": "MXN"},
+            {"name": "인도 (.in)", "url": "https://www.amazon.in", "currency": "INR"},
+            {"name": "UAE (.ae)", "url": "https://www.amazon.ae", "currency": "AED"},
+            {"name": "브라질 (.com.br)", "url": "https://www.amazon.com.br", "currency": "BRL"},
         ]},
     ]
 

--- a/tests/test_seller_console.py
+++ b/tests/test_seller_console.py
@@ -487,8 +487,10 @@ class TestDashboardHomeContext:
             context = _build_dashboard_home_context(widgets)
 
         onboarding = context["onboarding"]
+        # v25 P1: 활성화 퍼널 4단계(수집·연동·소싱처·업로드). 연동+업로드 완료, 수집/소싱처 미완 → 2/4=50%.
         assert onboarding["completed_steps"] == 2
-        assert onboarding["progress_percent"] == 66
+        assert onboarding["total_steps"] == 4
+        assert onboarding["progress_percent"] == 50
         assert onboarding["visible"] is True
 
 

--- a/tests/test_v25_p1_amazon_activation.py
+++ b/tests/test_v25_p1_amazon_activation.py
@@ -1,0 +1,64 @@
+"""tests/test_v25_p1_amazon_activation.py — v25 P1: 아마존 국가선택 확장 + 초보 활성화 퍼널."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    os.environ["SELLER_CONSOLE_AUTH"] = "0"
+    from src.order_webhook import app
+    with app.test_client() as c:
+        yield c
+
+
+def test_amazon_country_dropdown_expanded_with_currency(client):
+    html = client.get("/seller/collect").get_data(as_text=True)
+    # 주요국 + v25 신규(싱가포르/멕시코/UAE/브라질)
+    for name in ("미국 (.com)", "일본 (.co.jp)", "싱가포르 (.sg)", "멕시코 (.com.mx)",
+                 "UAE (.ae)", "브라질 (.com.br)"):
+        assert name in html, f"아마존 국가 {name} 누락"
+    # 통화 표기 + 선택 기억 훅
+    for cur in ("USD", "JPY", "SGD", "BRL", "AED"):
+        assert cur in html
+    assert "data-amazon-country" in html
+    assert "kgp_amazon_country" in html       # 선택 기억(localStorage)
+
+
+# ---- 활성화 퍼널(compute_onboarding_state) ----
+def test_funnel_prepends_collect_when_collected_count_given():
+    from src.seller_console.onboarding import compute_onboarding_state
+    s = compute_onboarding_state(connected_markets=0, source_count=0, product_count=0,
+                                 collected_count=0)
+    assert s["total_steps"] == 4
+    assert s["steps"][0]["key"] == "collect"
+    assert s["steps"][0]["is_next"] is True       # 첫 할 일 = 수집
+    # 마지막 = 첫 업로드(아하-모먼트)
+    assert s["steps"][-1]["key"] == "product"
+    assert "업로드" in s["steps"][-1]["title"]
+
+
+def test_funnel_collect_done_next_is_market():
+    from src.seller_console.onboarding import compute_onboarding_state
+    s = compute_onboarding_state(connected_markets=0, source_count=0, product_count=0,
+                                 collected_count=3)
+    assert s["steps"][0]["completed"] is True
+    nxt = next(st for st in s["steps"] if st["is_next"])
+    assert nxt["key"] == "market"
+
+
+def test_funnel_upload_is_aha_completes_all():
+    from src.seller_console.onboarding import compute_onboarding_state
+    s = compute_onboarding_state(connected_markets=1, source_count=1, product_count=1,
+                                 collected_count=1)
+    assert s["completed_steps"] == 4 and s["is_completed"] is True
+
+
+def test_legacy_3step_unchanged_without_collected_count():
+    # 하위호환: collected_count 미전달 시 기존 3단계 그대로(회귀 0)
+    from src.seller_console.onboarding import compute_onboarding_state
+    s = compute_onboarding_state(connected_markets=0, source_count=0, product_count=0)
+    assert s["total_steps"] == 3
+    assert s["steps"][0]["key"] == "market"


### PR DESCRIPTION
## v25 P1 — 아마존 국가선택 확장 + 초보 활성화 퍼널

### 🌍 아마존 국가별 마켓플레이스
- 드롭다운 **10 → 14개국** — 싱가포르(.sg)·멕시코(.com.mx)·UAE(.ae)·브라질(.com.br) 추가
- 각 국가 **통화 표기**(USD/JPY/GBP/EUR/CAD/AUD/SGD/MXN/INR/AED/BRL)
- **선택 기억**(`localStorage`) — 마지막에 고른 국가를 버튼 라벨("아마존 · 미국")에 표시 + 메뉴 상단으로 이동
- 진입 마커(`kgpsrc=app`, v17)로 도착 페이지에 고가수집기 보장 유지

### 🚀 초보 활성화 퍼널 (아하-모먼트 = 첫 업로드)
- `compute_onboarding_state`에 `collected_count` 옵션 추가 — **하위호환**(None이면 기존 3단계 그대로, 회귀 0)
- 제공 시 퍼널: **첫 상품 수집 → 마켓 연동 → 소싱처 → 🎯 첫 마켓 업로드(가장 중요한 한 걸음)**
- 대시보드가 **본인 스코프** collect summary로 `collected_count` 주입(실데이터)
- 정직성: '편집'은 신뢰성 있게 추적 불가 → 별도 단계로 만들지 않고(거짓 성공 금지) 수집 단계 설명에 "확인·편집" 포함

### 검증
- `test_v25_p1_amazon_activation` — 14개국/통화/선택기억 + 퍼널 4단계/아하/하위호환
- 기존 온보딩·대시보드 테스트 갱신(4단계 50% 반영)
- 전체 **10289 passed**, 0 regressions

---
다음(마스터 마지막): v26 네오-클래식 에디토리얼 디자인 리프레시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_