### PR TITLE
v26: 네오-클래식 디자인 리프레시 (토큰 단일소스 + 미세 그레인)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,14 @@
   `collected_count` 옵션 추가(하위호환 — None이면 기존 3단계) → **수집→연동→소싱처→첫 업로드(🎯 아하-모먼트)** 4단계.
   대시보드가 본인 스코프 collect summary로 collected_count 주입. 거짓 성공 금지(편집은 추적 불가라 별도 단계로 안 만들고
   수집 설명에 '확인·편집' 포함). 가드 test_v25_p1_amazon_activation(국가/통화/기억 + 퍼널 4단계/아하/하위호환). 전체 10289 passed.
-- ⏳ 다음: v26(네오-클래식 에디토리얼 디자인 리프레시).
+- ✅ **v26 네오-클래식 디자인 리프레시 (Phase 303):** "디지털 한지 위의 금속활자" — app.css :root에 v26 토큰 단일소스
+  확장: 깊이(`--ink-2`/`--gold-soft`)·대형 세리프(`--display-2-size` clamp(44,7vw,84)/-0.025em)·`--space-10`(128)·금
+  헤어라인(`--hairline-color`)·미세 그레인(`--grain-opacity` .035). opt-in 유틸 추가(.pc-display-2/overline/hairline/
+  num/section/lift/link/enter) + **전역 미세 그레인**(body::before SVG fractalNoise, 이미지 의존 0) + 진입 페이드.
+  prefers-reduced-motion에서 그레인·모션 전부 정지. 랜딩 히어로 헤드라인을 v26 토큰(대형 세리프)으로 교체(쇼케이스).
+  기존 v18 --display-size(40/6vw/72)는 불변(회귀 0). 하드코딩 hex 0(토큰 var만). 가드 test_design_tokens_v26.
+  전체 10294 passed. ※이모지 제거·화면별 적용은 v18 선례대로 점진 후속(저회귀).
+- → **v24~v27 통합 마스터 완주**(v24 P0·v25 P0/P1·v27·v26 + v28 OG). 남은 건 오너 콘솔 액션(네이버 검색키·스마트스토어 IP·11번가 키).
 
 ## 🟦 v24 브리프 (오너 2026-06-25 — "수집 이력 버그 · 마켓 Mock 정리 · 초보 흐름 · 아이콘 최종")
 - ✅ **아이콘 최종본 적용:** 오너 최종 마스터(현수교 2선 다리)로 교체, v=176/확장 1.5.11(아래 v23 파이프라인 재실행).

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -56,6 +56,18 @@
   --dur-fast: 120ms; --dur: 200ms; --dur-slow: 320ms; --ease: cubic-bezier(.2, .8, .2, 1);
 
   /* ========================================================================
+     v26 네오-클래식 리프레시 — "디지털 한지 위의 금속활자". 단일 소스 토큰만 확장.
+     깊이(--ink-2/--gold-soft) · 대형 세리프(--display-2) · 128 여백 · 금 헤어라인 · 미세 그레인.
+     ======================================================================== */
+  --ink-2: #2A241E;                       /* 레이어드 다크(깊이) */
+  --gold-soft: #E0C588;                   /* 부드러운 금(헤어라인/하이라이트) */
+  --display-2-size: clamp(44px, 7vw, 84px); --display-2-lh: 1.05; --display-tracking: -0.025em;
+  --space-10: 128px;                      /* 대형 섹션 여백 */
+  --hairline-color: rgba(201, 162, 75, .28);   /* 금 헤어라인(절제) */
+  --grain-opacity: 0.035;                 /* 미세 그레인 2~4% */
+  --lift: translateY(-2px);               /* 카드 호버 상승 */
+
+  /* ========================================================================
      하위호환 별칭: 기존 --pc-* 는 v18 토큰을 가리킨다(단일 소스 유지).
      ※ 신규 코드는 v18 토큰을 직접 쓰고, --pc-* 는 점진적으로 정리.
      ======================================================================== */
@@ -452,3 +464,53 @@ a:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(17, 154, 142, .35); 
 .form-control:focus, .form-select:focus { border-color: var(--teal); box-shadow: 0 0 0 3px rgba(17, 154, 142, .18); }
 /* 카드: 두꺼운 보더 대신 얕은 그림자 + 1px 가는 구분선(여백 우선) */
 .console-card, .card { box-shadow: var(--shadow-sm); }
+
+/* ============================================================================
+   v26 네오-클래식 유틸리티 — 토큰 기반(하드코딩 0). opt-in 클래스라 저회귀.
+   "디지털 한지 위의 금속활자": 대형 세리프 · 오버라인 라벨 · 금 헤어라인 · 미세 그레인 · 모션.
+   ============================================================================ */
+/* 대형 디스플레이(랜딩 히어로 등) */
+.pc-display-2 {
+  font-family: var(--font-display); font-weight: var(--w-semi);
+  font-size: var(--display-2-size); line-height: var(--display-2-lh);
+  letter-spacing: var(--display-tracking); color: var(--text-strong);
+}
+/* 오버라인 라벨 — 대문자 + 자간(에디토리얼 키커) */
+.pc-overline {
+  font-family: var(--font-ui); text-transform: uppercase;
+  letter-spacing: .18em; font-size: var(--caption); font-weight: var(--w-semi);
+  color: var(--gold-ink);
+}
+/* 금 헤어라인 디바이더(두꺼운 보더 대신) */
+.pc-hairline { border: 0; border-top: 1px solid var(--hairline-color); margin: var(--space-6) 0; }
+/* 대형 세리프 숫자(대시보드 KPI) */
+.pc-num { font-family: var(--font-display); font-weight: var(--w-semi); letter-spacing: -.01em; line-height: 1; }
+/* 대형 섹션 여백(럭셔리한 공간) */
+.pc-section { padding-top: var(--space-9); padding-bottom: var(--space-9); }
+@media (min-width: 992px) { .pc-section { padding-top: var(--space-10); padding-bottom: var(--space-10); } }
+/* 카드 호버 상승 + 얕은 3단 그림자(opt-in) */
+.pc-lift { transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease); }
+.pc-lift:hover { transform: var(--lift); box-shadow: var(--shadow-lg); }
+/* 링크 밑줄 슬라이드(opt-in) */
+.pc-link { position: relative; text-decoration: none; color: var(--teal); }
+.pc-link::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -2px; height: 1px;
+  background: currentColor; transform: scaleX(0); transform-origin: left;
+  transition: transform var(--dur) var(--ease);
+}
+.pc-link:hover::after { transform: scaleX(1); }
+/* 진입 페이드 + 8px(절제) */
+.pc-enter { animation: pcEnter var(--dur-slow) var(--ease) both; }
+@keyframes pcEnter { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+/* 미세 그레인 — 디지털 한지 질감(2~4%, 전역 오버레이·클릭 통과) */
+body::before {
+  content: ""; position: fixed; inset: 0; z-index: 0; pointer-events: none;
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+/* 모션 최소화 존중 — 모든 v26 모션/그레인 정지 */
+@media (prefers-reduced-motion: reduce) {
+  .pc-lift, .pc-link::after, .pc-enter { transition: none; animation: none; }
+  .pc-lift:hover { transform: none; }
+  body::before { display: none; }
+}

--- a/src/templates/landing.html
+++ b/src/templates/landing.html
@@ -19,8 +19,10 @@
   .scene.dark { background: radial-gradient(1000px 420px at 50% -8%, rgba(201,162,75,.16), transparent 60%), linear-gradient(180deg,#1a1714,#14110e); color: #f5efe3; }
   .scene.cream { background: var(--pc-color-bg); color: var(--pc-color-text); }
   .eyebrow { font-size: .82rem; letter-spacing: .18em; text-transform: uppercase; font-weight: 700; color: #119a8e; margin-bottom: .8rem; }
-  .scene h1, .scene h2 { font-family: var(--pc-font-display, serif); font-weight: 700; letter-spacing: -.02em; line-height: 1.05;
-    font-size: clamp(40px, 6vw, 72px); margin: 0 0 1rem; }
+  /* v26: 대형 세리프 헤드라인 — 디자인 토큰 단일소스(clamp 44~84·자간 -.025em) */
+  .scene h1, .scene h2 { font-family: var(--pc-font-display, serif); font-weight: 700;
+    letter-spacing: var(--display-tracking, -.025em); line-height: var(--display-2-lh, 1.05);
+    font-size: var(--display-2-size, clamp(44px, 7vw, 84px)); margin: 0 0 1rem; }
   .scene .sub { font-size: clamp(1rem, 2.2vw, 1.3rem); color: var(--pc-color-text-muted); margin: 0 auto 2rem; max-width: 520px; }
   .scene.dark .sub { color: #c9bda6; }
   .scene .visual { font-size: clamp(4rem, 12vw, 8rem); line-height: 1; margin-bottom: 1.4rem; }

--- a/tests/test_design_tokens_v26.py
+++ b/tests/test_design_tokens_v26.py
@@ -1,0 +1,62 @@
+"""tests/test_design_tokens_v26.py — v26 네오-클래식 리프레시 토큰/유틸 단일소스 가드."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+CSS = Path("src/static/app.css").read_text(encoding="utf-8")
+
+
+def test_v26_tokens_defined_in_root():
+    for tok, val in {
+        "--ink-2": "#2A241E",
+        "--gold-soft": "#E0C588",
+        "--display-2-size": "clamp(44px, 7vw, 84px)",
+        "--space-10": "128px",
+        "--grain-opacity": "0.035",
+    }.items():
+        assert re.search(rf"{re.escape(tok)}\s*:\s*{re.escape(val)}\s*;", CSS, re.I), f"{tok}:{val} 누락"
+    assert "--hairline-color:" in CSS
+    assert "--lift:" in CSS
+
+
+def test_v26_utilities_present():
+    for cls in (".pc-display-2", ".pc-overline", ".pc-hairline", ".pc-num",
+                ".pc-section", ".pc-lift", ".pc-link", ".pc-enter"):
+        assert cls in CSS, f"{cls} 유틸 누락"
+
+
+def test_v26_grain_and_reduced_motion_guard():
+    assert "body::before" in CSS                 # 미세 그레인 전역 오버레이
+    assert "fractalNoise" in CSS                  # SVG 노이즈(이미지 의존 0)
+    assert "prefers-reduced-motion: reduce" in CSS
+    # reduced-motion에서 그레인/모션 정지
+    rm = CSS[CSS.index("prefers-reduced-motion: reduce"):]
+    assert "body::before { display: none" in rm
+
+
+def test_v18_display_size_unchanged_no_regression():
+    # v26은 --display-2-size를 새로 추가(별도). 기존 v18 --display-size는 그대로(회귀 0).
+    assert "--display-size: clamp(40px, 6vw, 72px)" in CSS
+
+
+def _outside_root() -> str:
+    spans, css = [], CSS
+    for m in re.finditer(r":root\s*\{", css):
+        i = m.end(); d = 1
+        while i < len(css) and d > 0:
+            if css[i] == "{": d += 1
+            elif css[i] == "}": d -= 1
+            i += 1
+        spans.append((m.start(), i))
+    out, p = "", 0
+    for a, b in spans:
+        out += css[p:a]; p = b
+    return out + css[p:]
+
+
+def test_v26_utilities_use_tokens_not_hardcoded_hex():
+    body = _outside_root().lower()
+    # v26 신규 브랜드 음영도 :root 밖 하드코딩 금지(토큰 var()만)
+    for hx in ("#2a241e", "#e0c588"):
+        assert hx not in body, f"v26 hex {hx} 가 :root 밖에 하드코딩됨"


### PR DESCRIPTION
## v26 — 네오-클래식 에디토리얼 디자인 리프레시

컨셉 **"디지털 한지 위의 금속활자"**. app.css 토큰 **단일소스**로만 확장 — React 전환 없음, 회귀 0.

### 토큰 (app.css :root 확장)
- **깊이:** `--ink-2`(#2A241E) · `--gold-soft`(#E0C588)
- **대형 세리프:** `--display-2-size` clamp(44px,7vw,84px) · `--display-2-lh` 1.05 · `--display-tracking` -0.025em
- **여백:** `--space-10`(128px)
- **금 헤어라인:** `--hairline-color`(rgba gold .28)
- **미세 그레인:** `--grain-opacity`(0.035)

### 유틸리티 (opt-in, 토큰 var()만 — 하드코딩 hex 0)
`.pc-display-2` · `.pc-overline`(대문자 키커) · `.pc-hairline`(금 1px 디바이더) · `.pc-num`(세리프 대형 숫자) · `.pc-section`(128 여백) · `.pc-lift`(카드 호버 상승) · `.pc-link`(밑줄 슬라이드) · `.pc-enter`(진입 페이드+8px)

### 전역 적용
- **미세 그레인** — `body::before` SVG `fractalNoise`(이미지 파일 의존 0), 클릭 통과, 2~4%
- **랜딩 히어로 헤드라인** → v26 대형 세리프 토큰으로 교체(쇼케이스)
- **`prefers-reduced-motion`** 에서 그레인·모션 전부 정지

### 정직성 / 회귀
- 기존 v18 `--display-size`(40/6vw/72)는 **불변** → 회귀 0
- 이모지 제거·화면별 전면 적용은 v18 선례대로 **점진 후속**(저회귀 우선)
- 가드 `test_design_tokens_v26`, 기존 v18 토큰 가드 유지
- 전체 **10294 passed**, 0 regressions

---
이로써 **v24~v27 통합 마스터 완주** (v24 P0 · v25 P0/P1 · v27 · v26 + v28 OG). 남은 건 오너 콘솔 액션(네이버 검색키 · 스마트스토어 IP · 11번가 키).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_