### PR TITLE
v30 P0: 수집한 상품 클릭 404 회귀 수정 (스코프 단일소스 + E2E CI 게이트)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 > 이 파일은 매 세션 시작 시 로드된다. 오너(Kohgane) 지시·검증된 팩트를 누적 기록한다.
 
+## 🟧 v29~v31 묶음 (오너 2026-06-27 — 순서: v30 404→v31 P0 실값/메타→v29 토큰/디자인)
+- ✅ **v30 P0 수집한 상품 클릭 404 회귀 (Phase 304):** 원인=목록(list_items)은 관용 식별자(seller_ids=user_id+email)로
+  보여주는데 상세(`collect_preview_by_id`)·저장(`collect_preview_save`)은 **exact `seller_id=_seller_id()`**로 조회 →
+  별칭(user_id↔email) 불일치 시 목록엔 보이는데 클릭하면 404. **수정:** 신규 `_get_owned_item(item_id)`(목록과 동일
+  seller_ids 스코프) 단일소스로 상세·저장 통일 + 저장 update 쓰기가드를 항목의 실제 stored seller_id로 일치. 타 셀러
+  404(누출 0) 유지. E2E 가드 test_v30_collected_detail(별칭 200/타셀러 404/4경로/저장) — CI 게이트(pytest) 등록. 전체 10301 passed.
+- ⏳ 다음: v31 P0(상세·가격 실값+빈값 환산 금지, 원본 메타/플레이스홀더 숨김) → v29(토큰 본인전용·상시이력·죽은버튼) → 랜딩 전면 재설계.
+
 ## 🟩 v25~v27 통합 마스터 (오너 2026-06-26 — 순서: v24✅→v25P0→v27→v25P1→v26)
 - ✅ **v25 P0 아마존 '전체 수집' 실제 상품만 (Phase 299):** 증상=전체선택 시 Amazon Music·광고(스폰서)·미디어
   카드까지 선택됨. 원인=어댑터가 s-search-result+/dp/+가격만 보고 스폰서/비-ASIN 위젯도 통과. **수정:**

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -3690,6 +3690,21 @@ def _seller_identities() -> set:
     return ids
 
 
+def _get_owned_item(item_id: str) -> "dict | None":
+    """수집 항목 단건 — 목록과 동일한 관용 식별자 스코프로 조회(v30 단일소스).
+
+    목록(list_items)은 seller_ids 집합으로 보여주는데 상세/저장이 exact seller_id로
+    조회하면 별칭(user_id vs email) 불일치 시 목록엔 보이는데 클릭하면 404가 났다(v30 회귀).
+    같은 스코프(seller_ids)로 통일해 재발을 막는다.
+    """
+    try:
+        from .collect_history_store import get as history_get
+        return history_get(item_id, seller_ids=_seller_identities())
+    except Exception as exc:
+        logger.warning("수집 항목 조회 실패(id=%s): %s", item_id, exc)
+        return None
+
+
 def _diag_market_key(market: str) -> str:
     """자격증명 마켓 키 → 진단 서브시스템 키 (11번가만 상이)."""
     return "11st" if market == "elevenst" else market
@@ -5164,13 +5179,8 @@ def collect_preview_by_id(item_id: str):
     from flask import abort
     if not _check_auth():
         return redirect(url_for("auth.login", next=request.url))
-    item = None
-    try:
-        from .collect_history_store import get as history_get
-        item = history_get(item_id, seller_id=_seller_id())
-    except Exception as exc:
-        logger.warning("미리보기 조회 실패: %s", exc)
-
+    # v30: 목록과 동일한 관용 스코프로 조회 → 별칭 불일치 404 회귀 방지.
+    item = _get_owned_item(item_id)
     if not item:
         abort(404)
 
@@ -5265,7 +5275,7 @@ def collect_preview_save(item_id: str):
     data = request.get_json(force=True, silent=True) or {}
     from . import collect_history_store
 
-    item = collect_history_store.get(item_id, seller_id=_seller_id())
+    item = _get_owned_item(item_id)        # v30: 목록과 동일 스코프
     if not item:
         return jsonify({"ok": False, "error": "항목을 찾을 수 없습니다."}), 404
 
@@ -5347,7 +5357,8 @@ def collect_preview_save(item_id: str):
 
     ok = collect_history_store.update(
         item_id,
-        seller_id=_seller_id(),
+        # v30: 저장 항목의 실제 seller_id로 쓰기 가드 일치(별칭 불일치로 저장 실패 방지)
+        seller_id=item.get("seller_id") or _seller_id(),
         title=title or item.get("title") or "",
         price=price or item.get("price") or "",
         currency=currency or item.get("currency") or "",

--- a/tests/test_v30_collected_detail.py
+++ b/tests/test_v30_collected_detail.py
@@ -1,0 +1,77 @@
+"""tests/test_v30_collected_detail.py — v30 P0: 수집한 상품 클릭 시 404 회귀 가드.
+
+원인: 목록은 관용 식별자(seller_ids=user_id+email)로 보여주는데 상세/저장은 exact
+seller_id로 조회 → 별칭(user_id vs email) 불일치 시 목록엔 보이는데 클릭하면 404.
+수정: _get_owned_item으로 상세·저장을 목록과 같은 스코프로 통일.
+이 테스트를 CI 게이트(pytest)에 둬 재발(회귀) 차단.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    os.environ["SELLER_CONSOLE_AUTH"] = "0"
+    from src.order_webhook import app
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clean_store():
+    from src.seller_console import collect_history_store as store
+    store._in_memory[:] = []
+    yield
+    store._in_memory[:] = []
+
+
+def _collect(seller_id: str, *, source: str = "extension") -> str:
+    from src.seller_console import collect_history_store as store
+    return store.append(source=source, url="https://taobao.com/item/1",
+                        title="테스트 상품", price="100", currency="CNY", seller_id=seller_id)
+
+
+def test_detail_200_when_stored_under_email_alias(client):
+    # 저장 seller_id = 이메일, 세션 user_id = 다른 별칭 → 목록과 같은 본인 → 상세 200(404 아님)
+    item_id = _collect("u1@example.com")
+    with client.session_transaction() as s:
+        s["user_id"] = "u1"
+        s["user_email"] = "u1@example.com"
+    r = client.get(f"/seller/collect/preview/{item_id}")
+    assert r.status_code == 200, "별칭 불일치로 본인 상품이 404 (v30 회귀)"
+
+
+@pytest.mark.parametrize("source", ["extension", "bookmarklet", "manual", "bulk"])
+def test_detail_200_for_every_collect_source(client, source):
+    item_id = _collect("u1", source=source)
+    with client.session_transaction() as s:
+        s["user_id"] = "u1"
+    r = client.get(f"/seller/collect/preview/{item_id}")
+    assert r.status_code == 200, f"{source} 경로 수집 항목 클릭 404"
+
+
+def test_other_sellers_item_not_leaked(client):
+    # 타 셀러 항목은 404(누출 0) — 권한 분리 유지
+    item_id = _collect("someone-else@example.com")
+    with client.session_transaction() as s:
+        s["user_id"] = "u1"
+        s["user_email"] = "u1@example.com"
+    r = client.get(f"/seller/collect/preview/{item_id}")
+    assert r.status_code == 404
+
+
+def test_save_200_across_alias(client):
+    item_id = _collect("u1@example.com")
+    with client.session_transaction() as s:
+        s["user_id"] = "u1"
+        s["user_email"] = "u1@example.com"
+    r = client.post(f"/seller/collect/preview/{item_id}/save",
+                    data=json.dumps({"title": "수정됨", "price": "100", "currency": "CNY"}),
+                    content_type="application/json")
+    assert r.status_code == 200, "별칭 불일치로 저장 404/실패 (v30)"
+    body = r.get_json()
+    assert body.get("ok") is True


### PR DESCRIPTION
## v30 P0 — 수집한 상품 클릭 시 404 회귀 수정

**원인(로그/코드로 확정, 추측 0):** 목록(`list_items`)은 **관용 식별자**(`seller_ids` = user_id + email)로 본인 항목을 보여주는데, 상세(`collect_preview_by_id`)·저장(`collect_preview_save`)은 **exact `seller_id=_seller_id()`**로 조회 → 별칭(user_id ↔ email) 불일치 시 **목록엔 보이는데 클릭하면 404**. (v16에서 한 번 잡혔다가 스코프 불일치로 재발.)

**수정 (단일소스 통일):**
- 신규 `_get_owned_item(item_id)` — 목록과 **동일한 `seller_ids` 스코프**로 단건 조회
- `collect_preview_by_id`(상세) + `collect_preview_save`(저장) 둘 다 이 헬퍼로 통일
- 저장 `update` 쓰기가드를 **항목의 실제 stored seller_id**로 일치(별칭 불일치 저장 실패 방지)
- 타 셀러 항목은 **404 유지**(누출 0) — 권한 분리 보존

### 검증 (CI 게이트 — 재발 차단)
- `test_v30_collected_detail` — 별칭 저장→클릭 **200**, 타 셀러 **404**, **4개 수집 경로**(확장/북마클릿/수동/벌크) 각각 클릭 200, 저장 200
- pytest는 `python-guard` CI에서 돌아 **재발 시 머지 차단**
- 전체 **10301 passed**, 0 regressions

### DoD
- [x] 수집한 상품/이력 클릭 시 상세 200, 404 0
- [x] 목록 링크 ↔ 상세 라우트 단일소스 일치, 스코프 통일
- [x] 수집→클릭 E2E 테스트 CI 게이트 등록

---
다음(우선순위): v31 P0 상세·가격 실값 + 메타/플레이스홀더 숨김 → v29 토큰 보안/죽은버튼 → 랜딩 전면 재설계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_