### PR TITLE
v32 PART1: 일괄 삭제 영속성 + 일괄 버튼 가짜 성공 수정 (스코프 단일소스)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 > 이 파일은 매 세션 시작 시 로드된다. 오너(Kohgane) 지시·검증된 팩트를 누적 기록한다.
 
+## 🟥 v32 브리프 (오너 2026-06-27 — "버튼 전수조사 + 삭제 영속성 + 벤치마크 + 디자인 실집행")
+- ✅ **PART1 P0 일괄 삭제 영속성(재진입 부활) + 일괄 버튼 가짜성공 (Phase 308):** v30과 동형 — 삭제/일괄수정이
+  exact `seller_id=_seller_id()`로만 매칭 → 별칭(user_id↔email) 불일치 시 **삭제 0건·수정 무변경**인데 낙관적 UI로
+  성공처럼 보이고 재진입하면 부활. **수정:** ①`collect_history_store.delete`에 seller_ids(관용집합) 지원 + 시트·인메모리
+  **양쪽** 삭제(시트 분기 early-return로 폴백행 못 지우던 것도 수정) ②`update`에 seller_ids 지원(스코프 헬퍼) ③7개 일괄
+  버튼(카테고리/번역/그룹/정제/가격/상태/복제)의 get·update를 전부 `seller_ids=_seller_identities()`로(복제 새 행 append는
+  본인 sid 유지) ④삭제 JS를 낙관적 제거→**서버 재조회(location.reload)**+삭제 0건 정직 경고(가짜 성공 0). E2E 가드
+  test_v32_delete_persist(별칭 삭제 영속·타셀러 보존·인메모리 폴백·일괄수정 실반영) — CI 게이트. 전체 10319 passed.
+- ⏳ 다음: PART2(상품명/카테고리/번역/금지어/마진 버튼 실동작 점검) → PART3(콘솔 디자인 실집행).
+
 ## 🟧 v29~v31 묶음 (오너 2026-06-27 — 순서: v30 404→v31 P0 실값/메타→v29 토큰/디자인)
 - ✅ **v30 P0 수집한 상품 클릭 404 회귀 (Phase 304):** 원인=목록(list_items)은 관용 식별자(seller_ids=user_id+email)로
   보여주는데 상세(`collect_preview_by_id`)·저장(`collect_preview_save`)은 **exact `seller_id=_seller_id()`**로 조회 →

--- a/src/seller_console/collect_history_store.py
+++ b/src/seller_console/collect_history_store.py
@@ -219,11 +219,13 @@ def get(item_id: str, seller_id: Optional[str] = None, seller_ids: Optional[set]
     return None
 
 
-def update(item_id: str, *, seller_id: Optional[str] = None, **fields) -> bool:
+def update(item_id: str, *, seller_id: Optional[str] = None,
+           seller_ids: Optional[set] = None, **fields) -> bool:
     """수집 이력 단건의 필드를 갱신 (Phase 201 — 중간 편집 저장).
 
     허용 필드: title, image_url, price, currency, status, extra_json.
-    seller_id 지정 시 해당 셀러 항목만 갱신(타 셀러 차단).
+    seller_id/seller_ids로 본인 항목만 갱신(타 셀러 차단). v32: seller_ids(관용 식별자
+    집합)를 주면 별칭(user_id↔email) 불일치로 갱신 0건(가짜 성공)되던 일괄 버튼 버그 방지.
 
     Returns:
         갱신 성공 여부.
@@ -232,6 +234,14 @@ def update(item_id: str, *, seller_id: Optional[str] = None, **fields) -> bool:
     updates = {k: ("" if v is None else str(v)) for k, v in fields.items() if k in allowed}
     if not updates:
         return False
+
+    def _scope_ok(row_sid) -> bool:
+        rsid = str(row_sid or "")
+        if seller_ids is not None:
+            return rsid in seller_ids
+        if seller_id is not None:
+            return rsid == str(seller_id)
+        return True
 
     if _SHEET_ID:
         try:
@@ -246,9 +256,9 @@ def update(item_id: str, *, seller_id: Optional[str] = None, **fields) -> bool:
                 for r, row in enumerate(values[1:], start=2):
                     if id_i is None or id_i >= len(row) or row[id_i] != item_id:
                         continue
-                    if seller_id is not None and sid_i is not None:
+                    if sid_i is not None:
                         row_sid = row[sid_i] if sid_i < len(row) else ""
-                        if str(row_sid or "") != str(seller_id):
+                        if not _scope_ok(row_sid):
                             return False
                     for field, val in updates.items():
                         ci = col_idx.get(field)
@@ -262,17 +272,19 @@ def update(item_id: str, *, seller_id: Optional[str] = None, **fields) -> bool:
 
     for row in _in_memory:
         if row.get("id") == item_id:
-            if seller_id is not None and str(row.get("seller_id", "") or "") != str(seller_id):
+            if not _scope_ok(row.get("seller_id", "")):
                 return False
             row.update(updates)
             return True
     return False
 
 
-def delete(item_ids, *, seller_id: Optional[str] = None) -> int:
+def delete(item_ids, *, seller_id: Optional[str] = None, seller_ids: Optional[set] = None) -> int:
     """수집 이력에서 여러 항목을 삭제 (일괄 삭제 — Phase 237).
 
-    seller_id 지정 시 해당 셀러 항목만 삭제(타 셀러 차단).
+    seller_id/seller_ids로 본인 항목만 삭제(타 셀러 차단). v32: seller_ids(관용 식별자
+    집합)를 주면 별칭(user_id↔email) 불일치로 삭제 0건 → 재진입 시 부활하던 버그 방지.
+    시트와 인메모리(시트 쓰기 실패 폴백분) 양쪽에서 삭제한다.
 
     Returns:
         삭제된 건수.
@@ -281,12 +293,21 @@ def delete(item_ids, *, seller_id: Optional[str] = None) -> int:
     if not ids:
         return 0
 
+    def _scope_ok(row_sid) -> bool:
+        rsid = str(row_sid or "")
+        if seller_ids is not None:
+            return rsid in seller_ids
+        if seller_id is not None:
+            return rsid == str(seller_id)
+        return True
+
+    deleted = 0
+    # 1) 시트에서 삭제(설정 시)
     if _SHEET_ID:
         try:
             ws = _get_worksheet()
             _ensure_headers(ws)
             values = ws.get_all_values()
-            deleted = 0
             if values:
                 header = values[0]
                 col_idx = {h: i for i, h in enumerate(header)}
@@ -297,31 +318,27 @@ def delete(item_ids, *, seller_id: Optional[str] = None) -> int:
                 for r, row in enumerate(values[1:], start=2):
                     if id_i is None or id_i >= len(row) or row[id_i] not in ids:
                         continue
-                    if seller_id is not None and sid_i is not None:
-                        row_sid = row[sid_i] if sid_i < len(row) else ""
-                        if str(row_sid or "") != str(seller_id):
-                            continue
+                    row_sid = row[sid_i] if (sid_i is not None and sid_i < len(row)) else ""
+                    if not _scope_ok(row_sid):
+                        continue
                     to_delete.append(r)
                 for r in sorted(to_delete, reverse=True):
                     ws.delete_rows(r)
                     deleted += 1
             if deleted:
                 _invalidate_cache()
-                logger.info("수집 이력 삭제: %d건", deleted)
-            return deleted
         except Exception as exc:
             logger.warning("수집 이력 Sheets 삭제 실패: %s", exc)
 
+    # 2) 인메모리에서도 삭제(시트 쓰기 실패 폴백분 포함 — v24 합집합과 짝)
     before = len(_in_memory)
-    kept = []
-    for row in _in_memory:
-        if row.get("id") in ids and (
-            seller_id is None or str(row.get("seller_id", "") or "") == str(seller_id)
-        ):
-            continue
-        kept.append(row)
-    _in_memory[:] = kept
-    return before - len(_in_memory)
+    _in_memory[:] = [row for row in _in_memory
+                     if not (str(row.get("id")) in ids and _scope_ok(row.get("seller_id", "")))]
+    deleted += before - len(_in_memory)
+
+    if deleted:
+        logger.info("수집 이력 삭제: %d건", deleted)
+    return deleted
 
 
 def summary(days: int = 30, seller_id: Optional[str] = None, seller_ids: Optional[set] = None) -> dict:

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -789,15 +789,14 @@ async function runBulkDelete() {
     }
     const data = await resp.json();
     if (!data.ok) { pcToast(data.error || '삭제 실패', 'error'); return; }
-    // 삭제된 행을 화면에서 제거
-    ids.forEach(id => {
-      const chk = document.querySelector(`.row-chk[value="${id}"]`);
-      const tr = chk && chk.closest('tr');
-      if (tr) tr.remove();
-    });
     bootstrap.Modal.getInstance(document.getElementById('bulkDeleteModal'))?.hide();
-    refreshSelCount();
+    // v32: 낙관적 제거만 믿지 않는다 — 실제 삭제 0건이면 정직 안내, 1건+이면 서버 재조회로 영속 반영.
+    if (!data.deleted) {
+      pcToast('삭제된 항목이 없습니다. 새로고침 후 다시 시도해 주세요.', 'warning');
+      return;
+    }
     pcToast(`${data.deleted}개 항목을 삭제했습니다.`, 'success');
+    setTimeout(() => location.reload(), 600);   // 서버에서 목록 재조회(재진입해도 유지)
   } catch (err) {
     pcToast('삭제 요청 실패: ' + err.message, 'error');
   } finally {

--- a/src/seller_console/views.py
+++ b/src/seller_console/views.py
@@ -1874,7 +1874,8 @@ def collect_bulk_delete():
 
     try:
         from . import collect_history_store
-        deleted = collect_history_store.delete(item_ids, seller_id=_seller_id())
+        # v32: 목록과 동일한 관용 스코프로 삭제 → 별칭 불일치로 삭제 0건(재진입 부활) 방지.
+        deleted = collect_history_store.delete(item_ids, seller_ids=_seller_identities())
     except Exception as exc:
         logger.warning("일괄 삭제 오류: %s", exc)
         return jsonify({"ok": False, "error": "일괄 삭제 중 오류가 발생했습니다."}), 500
@@ -1911,7 +1912,7 @@ def collect_bulk_category():
     results = []
     try:
         for item_id in item_ids:
-            item = collect_history_store.get(item_id, seller_id=sid)
+            item = collect_history_store.get(item_id, seller_ids=_seller_identities())
             if not item:
                 results.append({"id": item_id, "ok": False, "error": "항목 없음"})
                 continue
@@ -1927,7 +1928,7 @@ def collect_bulk_category():
                 code = _classify(title, extra.get("description_ko") or extra.get("description") or "", kw).get("code", "GEN")
             extra["category_code"] = code
             ok = collect_history_store.update(
-                item_id, seller_id=sid, extra_json=_json.dumps(extra, ensure_ascii=False)
+                item_id, seller_ids=_seller_identities(), extra_json=_json.dumps(extra, ensure_ascii=False)
             )
             if ok:
                 updated += 1
@@ -1987,7 +1988,7 @@ def collect_bulk_translate():
     results = []
     try:
         for item_id in item_ids:
-            item = collect_history_store.get(item_id, seller_id=sid)
+            item = collect_history_store.get(item_id, seller_ids=_seller_identities())
             if not item:
                 results.append({"id": item_id, "ok": False, "error": "항목 없음"})
                 continue
@@ -2018,7 +2019,7 @@ def collect_bulk_translate():
             # 실제 번역된 경우에만 표시 제목을 한국어로 갱신(가짜 번역으로 덮어쓰지 않음).
             if real and title_ko and title_ko != item.get("title"):
                 fields["title"] = title_ko
-            ok = collect_history_store.update(item_id, seller_id=sid, **fields)
+            ok = collect_history_store.update(item_id, seller_ids=_seller_identities(), **fields)
             if ok:
                 updated += 1
             if real:
@@ -2119,7 +2120,7 @@ def collect_bulk_group():
     updated = 0
     try:
         for item_id in item_ids:
-            item = collect_history_store.get(item_id, seller_id=sid)
+            item = collect_history_store.get(item_id, seller_ids=_seller_identities())
             if not item:
                 continue
             try:
@@ -2130,7 +2131,7 @@ def collect_bulk_group():
                 extra["group_id"] = group_id
             else:
                 extra.pop("group_id", None)  # 그룹 해제
-            if collect_history_store.update(item_id, seller_id=sid,
+            if collect_history_store.update(item_id, seller_ids=_seller_identities(),
                                             extra_json=_json.dumps(extra, ensure_ascii=False)):
                 updated += 1
     except Exception as exc:
@@ -2239,7 +2240,7 @@ def collect_bulk_clean():
     results = []
     try:
         for item_id in item_ids:
-            item = collect_history_store.get(item_id, seller_id=sid)
+            item = collect_history_store.get(item_id, seller_ids=_seller_identities())
             if not item:
                 continue
             title = item.get("title") or ""
@@ -2253,7 +2254,7 @@ def collect_bulk_clean():
             except (TypeError, ValueError):
                 extra = {}
             extra["title_ko"] = res["text"]
-            ok = collect_history_store.update(item_id, seller_id=sid, title=res["text"],
+            ok = collect_history_store.update(item_id, seller_ids=_seller_identities(), title=res["text"],
                                               extra_json=_json.dumps(extra, ensure_ascii=False))
             if ok:
                 updated += 1
@@ -2345,7 +2346,7 @@ def collect_bulk_price():
     results = []
     try:
         for item_id in item_ids:
-            item = collect_history_store.get(item_id, seller_id=sid)
+            item = collect_history_store.get(item_id, seller_ids=_seller_identities())
             if not item:
                 results.append({"id": item_id, "ok": False, "error": "항목 없음"})
                 continue
@@ -2369,7 +2370,7 @@ def collect_bulk_price():
             if not fields:
                 results.append({"id": item_id, "ok": False, "error": "적용할 변경 없음(가격 비숫자)"})
                 continue
-            ok = collect_history_store.update(item_id, seller_id=sid, **fields)
+            ok = collect_history_store.update(item_id, seller_ids=_seller_identities(), **fields)
             if ok:
                 updated += 1
             results.append({"id": item_id, "ok": bool(ok), "price": new_price})
@@ -2407,7 +2408,7 @@ def collect_bulk_status():
     updated = 0
     try:
         for item_id in item_ids:
-            if collect_history_store.update(item_id, seller_id=sid, status=status):
+            if collect_history_store.update(item_id, seller_ids=_seller_identities(), status=status):
                 updated += 1
     except Exception as exc:
         logger.warning("일괄 상태변경 오류: %s", exc)
@@ -2438,7 +2439,7 @@ def collect_bulk_duplicate():
     new_ids = []
     try:
         for item_id in item_ids:
-            item = collect_history_store.get(item_id, seller_id=sid)
+            item = collect_history_store.get(item_id, seller_ids=_seller_identities())
             if not item:
                 continue
             try:
@@ -6349,7 +6350,7 @@ def sourcing_monitor_check():
     sid = _seller_id()
     results = []
     for item_id in ids:
-        item = collect_history_store.get(item_id, seller_id=sid)
+        item = collect_history_store.get(item_id, seller_ids=_seller_identities())
         if not item:
             results.append({"id": item_id, "ok": False, "summary": "항목을 찾을 수 없습니다."})
             continue

--- a/tests/test_v32_delete_persist.py
+++ b/tests/test_v32_delete_persist.py
@@ -1,0 +1,90 @@
+"""tests/test_v32_delete_persist.py — v32 P0: 일괄 삭제 영속성(재진입 시 부활) 회귀 가드.
+
+원인(v30과 동형): 삭제가 exact seller_id로만 매칭 → 별칭(user_id↔email) 불일치 시 삭제 0건
+→ 낙관적 UI로 지워진 듯 보이나 재진입하면 그대로. 수정: 관용 식별자(seller_ids)로 삭제.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    os.environ["SELLER_CONSOLE_AUTH"] = "0"
+    from src.order_webhook import app
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    from src.seller_console import collect_history_store as store
+    store._in_memory[:] = []
+    yield
+    store._in_memory[:] = []
+
+
+def _collect(seller_id):
+    from src.seller_console import collect_history_store as store
+    return store.append(source="extension", url="https://taobao.com/i", title="t", seller_id=seller_id)
+
+
+def test_bulk_delete_persists_across_alias(client):
+    from src.seller_console import collect_history_store as store
+    a = _collect("u1@example.com")     # 이메일 별칭으로 저장
+    b = _collect("u1@example.com")
+    with client.session_transaction() as s:
+        s["user_id"] = "u1"            # 세션은 user_id 별칭
+        s["user_email"] = "u1@example.com"
+    r = client.post("/seller/collect/bulk-delete",
+                    data=json.dumps({"item_ids": [a, b]}), content_type="application/json")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["ok"] is True
+    assert body["deleted"] == 2, "별칭 불일치로 삭제 0건(재진입 부활 버그)"
+    # 영속: 같은 본인 스코프로 재조회해도 사라진 상태 유지
+    ids = {"u1", "u1@example.com"}
+    assert store.list_items(days=30, seller_ids=ids) == []
+
+
+def test_bulk_delete_does_not_touch_other_seller(client):
+    from src.seller_console import collect_history_store as store
+    mine = _collect("u1")
+    theirs = _collect("someone@else.com")
+    with client.session_transaction() as s:
+        s["user_id"] = "u1"
+    r = client.post("/seller/collect/bulk-delete",
+                    data=json.dumps({"item_ids": [mine, theirs]}), content_type="application/json")
+    assert r.get_json()["deleted"] == 1     # 본인 것만 삭제(타 셀러 보존)
+    # 타 셀러 항목은 그대로
+    remaining = [i["id"] for i in store.list_items(days=30, seller_ids={"someone@else.com"})]
+    assert theirs in remaining
+
+
+def test_bulk_update_works_across_alias_not_silent_noop(client):
+    # 일괄 버튼(예: 상태 변경)도 별칭 불일치로 가짜 성공(무변경)되지 않아야 함
+    from src.seller_console import collect_history_store as store
+    iid = _collect("u1@example.com")
+    with client.session_transaction() as s:
+        s["user_id"] = "u1"
+        s["user_email"] = "u1@example.com"
+    r = client.post("/seller/collect/bulk-status",
+                    data=json.dumps({"item_ids": [iid], "status": "archived"}),
+                    content_type="application/json")
+    assert r.status_code == 200 and r.get_json().get("ok") is True
+    # 실제로 반영됐는지(재조회) — 무변경이면 가짜 성공
+    item = store.get(iid, seller_ids={"u1", "u1@example.com"})
+    assert item is not None and item.get("status") == "archived"
+
+
+def test_store_delete_removes_inmemory_fallback_rows():
+    # 시트 쓰기 실패 폴백 행도 삭제돼야(시트 분기 early-return 버그 수정)
+    from src.seller_console import collect_history_store as store
+    store._in_memory[:] = []
+    iid = store.append(source="extension", url="https://x.com/p", title="t", seller_id="u1")
+    n = store.delete([iid], seller_ids={"u1"})
+    assert n == 1
+    assert store.list_items(days=30, seller_ids={"u1"}) == []


### PR DESCRIPTION
## v32 PART 1 — 일괄 삭제 영속성 + 일괄 버튼 가짜 성공 수정

**증상:** 수집 목록 전체선택 → 선택 삭제 → 지워진 듯 보이나 **다시 들어가면 그대로**.

**원인(v30과 동형, 코드로 확정):** 삭제·일괄수정이 **exact `seller_id=_seller_id()`**로만 매칭 → 별칭(user_id ↔ email) 불일치 시 **삭제 0건 / 수정 무변경**인데, UI는 낙관적으로 지운 듯 보이고 재진입하면 부활. (+ `delete`가 시트 분기에서 early-return해 인메모리 폴백 행을 못 지움.)

**수정:**
- `collect_history_store.delete` — `seller_ids`(관용 식별자 집합) 지원 + **시트·인메모리 양쪽** 삭제
- `collect_history_store.update` — `seller_ids` 지원(스코프 헬퍼, 하위호환)
- **일괄 버튼 7종**(카테고리·번역·그룹·정제·가격·상태·복제)의 `get`·`update`를 전부 `seller_ids=_seller_identities()`로 통일 → 별칭 불일치 silent no-op(가짜 성공) 제거. (복제 새 행 `append`는 본인 `sid` 유지)
- 삭제 JS — 낙관적 제거 대신 **서버 재조회(`location.reload`)** + 삭제 0건이면 정직 경고(가짜 성공 0)

### 검증 (CI 게이트 — 재발 차단)
- `test_v32_delete_persist` — 별칭 삭제 **영속**(재조회 빈 목록), 타 셀러 보존(누출 0), 인메모리 폴백 행 삭제, **일괄수정 실반영**(무변경=가짜성공 아님)
- 전체 **10319 passed**, 0 regressions

### DoD
- [x] 전체선택 삭제가 재진입해도 유지(영속)
- [x] 일괄 버튼 실동작(별칭 불일치 silent no-op 제거)
- [x] 낙관적 UI만 믿지 않고 서버 재조회
- [x] 수집→삭제 E2E 테스트 CI 게이트

---
다음: PART2(상품명/카테고리/번역/금지어/마진 버튼 실동작 점검) → PART3(콘솔 디자인 실집행 — 세리프 KPI·오버라인·금 헤어라인·편집 폼 2열).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_