### PR TITLE
v32 PART3: 콘솔 디자인 실집행 — 대시보드 KPI 격상 (세리프 대형·오버라인·금 헤어라인)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,14 @@
   (target_margin_pct 저장 + price_multiplier 실반영 100→110, 빈값 환산 금지 v31) ③카테고리 자동분류(실 code 반환).
   전부 별칭 스코프(저장 email·세션 user_id)에서도 실반영(가짜 성공 0). 가드 test_v32_part2_buttons(4). 전체 10323 passed.
   ※금칙어 사전 대량 확장(3천+)·번역 무료 N회 표기는 기존 정직 처리 유지, 사전 확장은 후속 데이터 작업.
-- ⏳ 다음: PART3(콘솔 디자인 실집행 — 세리프 KPI·오버라인·금 헤어라인·편집 폼 2열, before/after 명확).
+- ✅ **PART3 콘솔 디자인 실집행 #1 대시보드 KPI 격상 (Phase 310):** "토큰만 바꾸지 말고 화면에 보이게" — 대시보드 KPI를
+  **세리프 대형 숫자**(console-stat-value: var(--font-display)·clamp(2~2.7rem)·잡지 통계) + **오버라인 라벨**(console-kpi-label:
+  대문자 자간·금) + **두꺼운 4px 보더→얇은 2px 토큰 악센트**(보라/인디고 하드코딩 → var(--teal/warn/danger/success)) +
+  토큰 그림자(var(--shadow-lg)) + 헤더 아래 **금 헤어라인**(pc-hairline) + reduced-motion 가드. kw-mini-bars 잔여 보라도
+  토큰화. 편집 폼은 이미 2열(col-md-8 에디터+이미지 사이드바)이라 구조 유지. 하드코딩 hex 0(토큰 var만). before/after
+  명확(1.6rem 굵은숫자→세리프 대형·금 악센트). 가드 test_design_console_v32_part3(5). 전체 10328 passed.
+  ※orders/markets 등 화면별 동일 격상은 v18 선례대로 점진 후속(저회귀).
+- → **v32 완주**(PART1 삭제영속·일괄버튼 / PART2 출시필수 버튼 실동작 / PART3 콘솔 디자인 실집행). 남은 건 오너 콘솔 액션.
 
 ## 🟧 v29~v31 묶음 (오너 2026-06-27 — 순서: v30 404→v31 P0 실값/메타→v29 토큰/디자인)
 - ✅ **v30 P0 수집한 상품 클릭 404 회귀 (Phase 304):** 원인=목록(list_items)은 관용 식별자(seller_ids=user_id+email)로

--- a/src/seller_console/static/console.css
+++ b/src/seller_console/static/console.css
@@ -117,9 +117,22 @@
   color: var(--console-muted);
 }
 
+/* v26 PART3: 잡지 통계식 세리프 대형 KPI 숫자(단일소스 토큰). */
 .console-stat-value {
-  font-size: 1.6rem;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 2.7rem);
   font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  color: var(--text-strong);
+}
+/* 오버라인 라벨(대문자 자간·금) — 에디토리얼 키커 */
+.console-kpi-label {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--gold-ink);
 }
 
 .console-status-banner {
@@ -150,32 +163,27 @@
 
 .console-kpi-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 12px 28px rgba(17, 24, 39, 0.08);
+  box-shadow: var(--shadow-lg);
 }
 
 .console-kpi-card:active {
   transform: translateY(-1px);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .console-kpi-card { transition: none; }
+  .console-kpi-card:hover, .console-kpi-card:active { transform: none; }
+}
+
+/* 두꺼운 보더 금지(v26) → 얇은 2px 토큰 악센트만 */
 .console-kpi-card .card-body {
-  border-left: 4px solid transparent;
+  border-left: 2px solid transparent;
 }
 
-.console-kpi-primary .card-body {
-  border-left-color: #5b3df5;
-}
-
-.console-kpi-warning .card-body {
-  border-left-color: #f59e0b;
-}
-
-.console-kpi-danger .card-body {
-  border-left-color: #ef4444;
-}
-
-.console-kpi-success .card-body {
-  border-left-color: #10b981;
-}
+.console-kpi-primary .card-body { border-left-color: var(--teal); }
+.console-kpi-warning .card-body { border-left-color: var(--warn); }
+.console-kpi-danger .card-body { border-left-color: var(--danger); }
+.console-kpi-success .card-body { border-left-color: var(--success); }
 
 .console-kpi-icon {
   width: 2rem;
@@ -184,8 +192,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: #4338ca;
-  background: #eef2ff;
+  color: var(--teal);
+  background: color-mix(in srgb, var(--teal) 12%, transparent);
 }
 
 .console-trend {
@@ -270,7 +278,7 @@
   width: 4px;
   min-height: 4px;
   border-radius: 2px;
-  background: #5b3df5;
+  background: var(--teal);
   opacity: 0.75;
 }
 

--- a/src/seller_console/templates/dashboard.html
+++ b/src/seller_console/templates/dashboard.html
@@ -5,11 +5,13 @@
 <section class="mb-4">
   <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
     <div>
+      <div class="console-kpi-label mb-1">대시보드</div>
       <h1 class="h4 mb-1">통합 셀러 대시보드</h1>
       <p class="text-muted mb-0">오늘 핵심 지표와 주요 작업을 한 번에 확인하세요.</p>
     </div>
     <a href="/seller/start" class="btn btn-cta btn-lg"><i class="bi bi-stars"></i> For Beginners · 처음이신가요?</a>
   </div>
+  <hr class="pc-hairline mt-0 mb-4">
 
   {% if onboarding.show_completion_notice %}
   <div class="alert alert-success d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3" role="status">
@@ -102,7 +104,7 @@
         <article class="card console-card console-kpi-card h-100 console-kpi-{{ card.accent }}">
           <div class="card-body">
             <div class="d-flex align-items-start justify-content-between gap-2 mb-2">
-              <div class="text-muted small fw-semibold">{{ card.label }}</div>
+              <div class="console-kpi-label">{{ card.label }}</div>
               <span class="console-kpi-icon"><i class="bi {{ card.icon }}"></i></span>
             </div>
             <div class="console-stat-value">{{ card.value if card.value is not none else '—' }}</div>

--- a/tests/test_design_console_v32_part3.py
+++ b/tests/test_design_console_v32_part3.py
@@ -1,0 +1,40 @@
+"""tests/test_design_console_v32_part3.py — v32 PART3: 콘솔 디자인 실집행(대시보드 KPI 격상)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+CSS = Path("src/seller_console/static/console.css").read_text(encoding="utf-8")
+DASH = Path("src/seller_console/templates/dashboard.html").read_text(encoding="utf-8")
+
+
+def test_kpi_value_is_serif_large_number():
+    block = CSS[CSS.index(".console-stat-value"):CSS.index(".console-stat-value") + 320]
+    assert "var(--font-display)" in block          # 세리프(잡지 통계)
+    assert "clamp(" in block                        # 대형(반응형)
+
+
+def test_overline_kpi_label_defined_and_used():
+    assert ".console-kpi-label" in CSS
+    lbl = CSS[CSS.index(".console-kpi-label"):CSS.index(".console-kpi-label") + 220]
+    assert "uppercase" in lbl and "letter-spacing" in lbl
+    assert "var(--gold-ink)" in lbl
+    assert "console-kpi-label" in DASH              # 템플릿에서 실제 사용
+
+
+def test_no_thick_borders_or_hardcoded_brand_hex_in_kpi():
+    # v26: 두꺼운 보더 금지(4px) → 얇은 2px, 하드코딩 보라/인디고 제거 → 토큰
+    assert "border-left: 4px" not in CSS
+    assert "border-left: 2px solid transparent" in CSS
+    for hx in ("#5b3df5", "#4338ca", "#eef2ff"):
+        assert hx not in CSS, f"하드코딩 hex {hx} 잔존(토큰으로 치환 필요)"
+    for tok in ("var(--teal)", "var(--warn)", "var(--danger)", "var(--success)"):
+        assert tok in CSS
+
+
+def test_kpi_uses_token_shadow_and_reduced_motion():
+    assert "box-shadow: var(--shadow-lg)" in CSS
+    assert "prefers-reduced-motion: reduce" in CSS
+
+
+def test_dashboard_has_gold_hairline_divider():
+    assert "pc-hairline" in DASH                    # 금 헤어라인 구분선


### PR DESCRIPTION
## v32 PART 3 — 콘솔 디자인 실집행 #1: 대시보드 KPI 격상

> "토큰만 바꾸고 레이아웃 그대로면 실패. before→after가 명백히 달라야 한다." → 대시보드 KPI를 눈에 띄게 격상.

### 변경 (before → after)
- **KPI 숫자** — 1.6rem 굵은 산세 → **세리프 대형**(`var(--font-display)`, `clamp(2~2.7rem)`, 잡지 통계 느낌)
- **KPI 라벨** — 회색 small → **오버라인 라벨**(`console-kpi-label`: 대문자 자간 + 금 `var(--gold-ink)`)
- **두꺼운 4px 보더 → 얇은 2px 토큰 악센트** — 하드코딩 보라(#5b3df5)/인디고 제거 → `var(--teal/warn/danger/success)`
- 토큰 그림자(`var(--shadow-lg)`) + 헤더 아래 **금 헤어라인**(`pc-hairline`) + 헤더 오버라인
- `kw-mini-bars` 잔여 보라도 토큰화 → **console.css 하드코딩 브랜드 hex 0**
- **reduced-motion** 가드(호버 정지)

### 편집 폼
- 이미 2열 구조(`col-md-8` 에디터 + 이미지 사이드바)라 유지

### 검증
- `test_design_console_v32_part3`(5) — 세리프 대형 KPI·오버라인 라벨·얇은 보더/토큰색·토큰 그림자·reduced-motion·금 헤어라인
- 전체 **10328 passed**, 0 regressions
- ※ 라이브 스크린샷은 이 환경에 Playwright 미설치라 미확보 — 렌더 200·구조·테스트로 검증(정직). orders/markets 등 화면별 동일 격상은 v18 선례대로 **점진 후속**(저회귀).

---
이로써 **v32 완주**(PART1 삭제 영속·일괄 버튼 / PART2 출시 필수 버튼 실동작 / PART3 콘솔 디자인 실집행). 남은 건 오너 콘솔 액션(스마트스토어 IP·11번가 키·WC 키·네이버 검색키).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_