### PR TITLE
콘솔 디자인 격상 #3: 수집 이력 summary 카드 에디토리얼 통일

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@
   헤어라인, `⟳` 글리프→bi-arrow-clockwise(단일 아이콘셋). markets 헤더 오버라인 라벨. 가드 test_design_console_v32_part3b(2).
   전체 10328 passed. ※소싱 분석은 오너가 네이버 검색키 Render 설정 완료 — 단 변수명은 검색용 `NAVER_SEARCH_CLIENT_ID/SECRET`
   (로그인 OAuth `NAVER_CLIENT_ID/SECRET`과 다름) 확인 필요.
-- → **v32 완주**(PART1 삭제영속·일괄버튼 / PART2 출시필수 버튼 실동작 / PART3 콘솔 디자인 실집행, 화면별 점진 확장 중). 남은 건 오너 콘솔 액션.
+- ✅ **PART3 #3 수집이력 summary 격상 (Phase 312):** 수집이력 summary 카드 4종(총수집/오늘/도메인=세리프 대형 KPI+오버라인+토큰 좌악센트, 수집경로=오버라인 라벨)도 대시보드/orders와 동일 에디토리얼로. 가드 test_design_console_v32_part3b 확장(3). 전체 10330 passed.
+- → **v32 완주**(PART1 삭제영속·일괄버튼 / PART2 출시필수 버튼 실동작 / PART3 콘솔 디자인 실집행: 대시보드·orders·markets·수집이력 격상, settlement/sourcing 등 점진 확장 중). 남은 건 오너 콘솔 액션.
 
 ## 🟧 v29~v31 묶음 (오너 2026-06-27 — 순서: v30 404→v31 P0 실값/메타→v29 토큰/디자인)
 - ✅ **v30 P0 수집한 상품 클릭 404 회귀 (Phase 304):** 원인=목록(list_items)은 관용 식별자(seller_ids=user_id+email)로

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -20,32 +20,33 @@
   <!-- 요약 카드 -->
   <div class="row g-3 mb-4">
     <div class="col-6 col-md-3">
-      <div class="card text-center">
-        <div class="card-body py-3">
-          <div class="fs-4 fw-bold text-primary">{{ summary.total }}</div>
-          <div class="small text-muted">총 수집</div>
+      <div class="card console-card console-kpi-card console-kpi-primary h-100">
+        <div class="card-body">
+          <div class="console-kpi-label mb-1">총 수집</div>
+          <div class="console-stat-value">{{ summary.total }}</div>
         </div>
       </div>
     </div>
     <div class="col-6 col-md-3">
-      <div class="card text-center">
-        <div class="card-body py-3">
-          <div class="fs-4 fw-bold text-success">{{ summary.today }}</div>
-          <div class="small text-muted">오늘</div>
+      <div class="card console-card console-kpi-card console-kpi-success h-100">
+        <div class="card-body">
+          <div class="console-kpi-label mb-1">오늘</div>
+          <div class="console-stat-value">{{ summary.today }}</div>
         </div>
       </div>
     </div>
     <div class="col-6 col-md-3">
-      <div class="card text-center">
-        <div class="card-body py-3">
-          <div class="fs-4 fw-bold text-info">{{ summary.domains }}</div>
-          <div class="small text-muted">도메인</div>
+      <div class="card console-card console-kpi-card console-kpi-warning h-100">
+        <div class="card-body">
+          <div class="console-kpi-label mb-1">도메인</div>
+          <div class="console-stat-value">{{ summary.domains }}</div>
         </div>
       </div>
     </div>
     <div class="col-6 col-md-3">
-      <div class="card text-center">
-        <div class="card-body py-3">
+      <div class="card console-card h-100">
+        <div class="card-body">
+          <div class="console-kpi-label mb-2">수집 경로</div>
           <div class="small">
             확장 <strong>{{ summary.by_source.extension }}</strong> /
             북마클릿 <strong>{{ summary.by_source.bookmarklet }}</strong>

--- a/tests/test_design_console_v32_part3b.py
+++ b/tests/test_design_console_v32_part3b.py
@@ -29,3 +29,18 @@ def test_orders_kpi_editorial_upgrade(client):
 def test_markets_header_overline(client):
     html = client.get("/seller/markets").get_data(as_text=True)
     assert "console-kpi-label" in html   # 오버라인 라벨(에디토리얼 키커)
+
+
+def test_collect_history_summary_editorial(client):
+    from src.seller_console import collect_history_store as store
+    store._in_memory[:] = []
+    store.append(source="extension", url="https://x.com/p", title="t", seller_id="u1")
+    try:
+        with client.session_transaction() as s:
+            s["user_id"] = "u1"
+        html = client.get("/seller/collect/history").get_data(as_text=True)
+        assert "console-stat-value" in html      # 세리프 대형 KPI
+        assert "console-kpi-label" in html        # 오버라인 라벨
+        assert "fs-4 fw-bold" not in html         # 옛 마크업 제거
+    finally:
+        store._in_memory[:] = []


### PR DESCRIPTION
## 콘솔 디자인 격상 #3 — 수집 이력 summary 카드

대시보드·orders·markets에 이어 **수집 이력(가장 자주 쓰는 화면)** summary를 같은 에디토리얼 패턴으로 통일.

### 변경
- 총 수집 / 오늘 / 도메인 → **세리프 대형 KPI**(`console-stat-value`) + **오버라인 금 라벨**(`console-kpi-label`) + 얇은 토큰 좌악센트(`console-kpi-card` primary/success/warning)
- 수집 경로 카드 → 오버라인 라벨로 정돈
- before: `fs-4 fw-bold text-primary` 굵은 산세 숫자 + 회색 라벨 → after: 대시보드와 동일 룩

### 검증
- `test_design_console_v32_part3b` 확장(3) — 세리프 KPI·오버라인·옛 마크업 제거
- 전체 **10330 passed**, 0 regressions, 토큰 단일소스·이모지 0

---
다음: settlement(정산)·sourcing(소싱 허브) 등 KPI/통계 헤더 화면을 순차 격상(화면군마다 PR + 가드).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_