### PR TITLE
콘솔 디자인 격상 #4: 소싱 허브 분석 패널 에디토리얼 통일

### DIFF
--- a/src/seller_console/templates/sourcing.html
+++ b/src/seller_console/templates/sourcing.html
@@ -4,7 +4,8 @@
 <div class="container-fluid py-3">
   <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-2">
     <div>
-      <h1 class="h4 mb-1">AI 소싱·등록</h1>
+      <div class="console-kpi-label mb-1">AI 소싱·등록</div>
+      <h1 class="h4 mb-1">무엇을 팔지, 데이터로</h1>
       <p class="text-muted mb-0">키워드 → 국내에서 뭐가 팔리나 → 비슷한 소싱처 상품 찾기 → 바로 수집·등록.</p>
     </div>
     <div class="d-flex gap-2">
@@ -224,18 +225,19 @@
   <!-- 분석 패널 — 계산 가능한 것만 실데이터, 없으면 '데이터 없음' -->
   <div class="card console-card mb-3">
     <div class="card-body">
-      <h2 class="h6 mb-3">분석</h2>
+      <div class="console-kpi-label mb-1">소싱 분석</div>
+      <h2 class="h6 mb-3">국내 시장 한눈에</h2>
       <div class="row g-2">
         {% for m in analysis.metrics %}
         <div class="col-6 col-md-4">
-          <div class="border rounded p-2 h-100">
-            <div class="text-muted small">{{ m.label }}</div>
+          <div class="rounded p-3 h-100" style="border:1px solid var(--border);">
+            <div class="console-kpi-label mb-1">{{ m.label }}</div>
             {% if m.value is not none %}
-            <div class="fw-bold">{{ m.value }}</div>
+            <div style="font-family:var(--font-display);font-size:1.45rem;font-weight:700;letter-spacing:-.01em;line-height:1.1;">{{ m.value }}</div>
             {% else %}
             <div class="text-muted">데이터 없음</div>
             {% endif %}
-            <div class="text-muted" style="font-size:.7rem">{{ m.note }}</div>
+            <div class="text-muted mt-1" style="font-size:.7rem">{{ m.note }}</div>
           </div>
         </div>
         {% endfor %}

--- a/tests/test_design_console_v32_part3b.py
+++ b/tests/test_design_console_v32_part3b.py
@@ -44,3 +44,10 @@ def test_collect_history_summary_editorial(client):
         assert "fs-4 fw-bold" not in html         # 옛 마크업 제거
     finally:
         store._in_memory[:] = []
+
+
+def test_sourcing_hub_editorial(client):
+    html = client.get("/seller/sourcing?keyword=에코백").get_data(as_text=True)
+    assert "console-kpi-label" in html       # 헤더/분석 오버라인
+    assert "var(--font-display)" in html      # 분석 수치 세리프
+    assert "AI 소싱·등록" in html              # 기존 식별 문구 보존(무회귀)


### PR DESCRIPTION
## 콘솔 디자인 격상 #4 — 소싱 허브 분석 패널

대시보드·orders/markets·수집이력에 이어 **소싱 허브**를 같은 에디토리얼 톤으로. (오너가 네이버 검색키를 설정해 실데이터가 들어오는 화면이라 우선)

### 변경
- 헤더 → 오버라인 라벨(`AI 소싱·등록`) + 세리프 헤드라인("무엇을 팔지, 데이터로")
- **소싱 분석 패널** — 메트릭 라벨 → 오버라인(`console-kpi-label`), 수치 → **세리프**(`var(--font-display)`). 네이버 검색 실데이터(국내 검색 결과 수·판매처 수·최저/평균가)가 에디토리얼 톤으로 표시
- 실데이터/빈 상태('데이터 없음') 로직·기존 식별 문구는 **보존**(무회귀)

### 검증
- `test_design_console_v32_part3b` 확장(4) — 오버라인·세리프 수치·식별 문구 보존
- 전체 **10331 passed**, 0 regressions, 토큰 단일소스

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_