### PR TITLE
v33 2-1: 이미지 PDP 컨테이너 스코프 한정 (추천·리뷰·타상품 이미지 차단)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 > 이 파일은 매 세션 시작 시 로드된다. 오너(Kohgane) 지시·검증된 팩트를 누적 기록한다.
 
+## 🟪 v33/마스터 브리프 (오너 2026-06-27 — v24~v33 통합 마스터, 1달 출시 로드맵)
+- (1~4주차 대부분은 이번 세션에서 v24~v32로 완료됨 — 404·삭제영속·이력·토큰·전체수집·메타숨김·Mock·네이버·디자인·랜딩·버튼·아마존·활성화.)
+- ✅ **2주차 2-1 이미지 PDP 스코프 한정 (Phase 313):** 엉뚱한 이미지(추천·리뷰·푸터·타 상품) 혼입 차단 강화 —
+  `_NON_PRODUCT_REGION_RE`에 review/comment/reply/qna/feedback/testimonial 추가, 신규 `_find_product_scope`
+  (itemtype Product·product-detail/goods 컨테이너로 이미지 수집 스코프 한정, **보수적**: 이미지 2장+ & 비-상품영역 아닐 때만
+  채택→ recall 보존, 못 찾으면 전체 폴백). `_collect_dom_images`가 스코프 내 img/source만 수집. 확장 `_kgpNonProductRe`도
+  리뷰/댓글 추가, manifest 1.5.12→1.5.13. 가드 test_v33_image_scope(컨테이너 한정·추천/리뷰/푸터 0·폴백·보수적). 전체 10335 passed.
+
 ## 🟥 v32 브리프 (오너 2026-06-27 — "버튼 전수조사 + 삭제 영속성 + 벤치마크 + 디자인 실집행")
 - ✅ **PART1 P0 일괄 삭제 영속성(재진입 부활) + 일괄 버튼 가짜성공 (Phase 308):** v30과 동형 — 삭제/일괄수정이
   exact `seller_id=_seller_id()`로만 매칭 → 별칭(user_id↔email) 불일치 시 **삭제 0건·수정 무변경**인데 낙관적 UI로

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -37,7 +37,7 @@ function extractProductMeta() {
   const _seenImg = new Set();
   const _pushImg = (s) => { if (_isProductImg(s) && !_seenImg.has(s)) { _seenImg.add(s); images.push(s); } };
   // v16 P0: 추천/연관/함께 본/스폰서/푸터 등 '다른 상품' 영역의 이미지는 제외(PDD 스코프, 혼입 방지).
-  const _kgpNonProductRe = /(recommend|related|similar|also[-_ ]?(bought|viewed|like)|you[-_ ]?may|frequently[-_ ]?bought|sponsored|advert|promotion|ranking|best[-_ ]?seller|recently[-_ ]?viewed|carousel|slider|cross[-_ ]?sell|up[-_ ]?sell|comparison|footer|navbar|breadcrumb|other[-_ ]?products|popular|trending)/i;
+  const _kgpNonProductRe = /(recommend|related|similar|also[-_ ]?(bought|viewed|like)|you[-_ ]?may|frequently[-_ ]?bought|sponsored|advert|promotion|ranking|best[-_ ]?seller|recently[-_ ]?viewed|carousel|slider|cross[-_ ]?sell|up[-_ ]?sell|comparison|footer|navbar|breadcrumb|other[-_ ]?products|popular|trending|review|comment|reply|qna|feedback|testimonial)/i;
   const _kgpInNonProductRegion = (el) => {
     let cur = el && el.parentElement, depth = 0;
     while (cur && depth < 8) {

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "고가수집기",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "지정 소싱처(타오바오·아마존 등)에서 한 클릭에 고가브릿지로 수집 (인페이지 수집 + 리스팅 다중 선택 수집 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/src/collectors/universal_scraper.py
+++ b/src/collectors/universal_scraper.py
@@ -295,9 +295,43 @@ _NON_PRODUCT_REGION_RE = re.compile(
     r"frequently[-_ ]?bought|sponsored|advert|promotion|ranking|best[-_ ]?seller|"
     r"recently[-_ ]?viewed|history|carousel|slider|cross[-_ ]?sell|up[-_ ]?sell|"
     r"comparison|footer|site[-_ ]?footer|navbar|header[-_ ]?nav|breadcrumb|"
-    r"more[-_ ]?to[-_ ]?explore|other[-_ ]?products|popular|trending)",
+    r"more[-_ ]?to[-_ ]?explore|other[-_ ]?products|popular|trending|"
+    # v33: 리뷰/문의/댓글 영역의 썸네일도 '상품 이미지' 아님 → 제외
+    r"review|comment|reply|\bqna\b|q[-_ ]?and[-_ ]?a|feedback|testimonial)",
     re.IGNORECASE,
 )
+
+# v33: 상품 상세(PDP) 메인 컨테이너 후보 — 여기로 이미지 수집 스코프를 좁혀 '엉뚱한' 이미지 차단.
+_PRODUCT_SCOPE_SELECTORS = (
+    '[itemtype*="Product"]', '[itemtype*="product"]',
+    '#productDetail', '#product-detail', '#productInfo', '#goods_detail',
+    '.product-detail', '.product-info', '.product-gallery', '.product-images',
+    '.goods-detail', '.goodsDetail', '.pdp', '.detail-gallery',
+    '[class*="product-detail"]', '[class*="productDetail"]', '[class*="goodsView"]',
+)
+
+
+def _find_product_scope(soup):
+    """상품 상세 메인 컨테이너를 찾으면 그걸 반환(이미지 수집 스코프 한정), 못 찾으면 soup 전체.
+
+    보수적: 컨테이너가 비-상품 영역이 아니고 이미지를 2장 이상 가질 때만 스코프로 채택
+    (recall 손실 방지 — 명확할 때만 좁힌다).
+    """
+    for sel in _PRODUCT_SCOPE_SELECTORS:
+        try:
+            el = soup.select_one(sel)
+        except Exception:
+            el = None
+        if el is None:
+            continue
+        try:
+            if _in_non_product_region(el, max_depth=4):
+                continue
+            if len(el.find_all("img")) >= 2:
+                return el
+        except Exception:
+            continue
+    return soup
 
 
 def _in_non_product_region(node, max_depth: int = 8) -> bool:
@@ -329,6 +363,7 @@ def _collect_dom_images(soup, base_url: str) -> list:
     """
     out: list = []
     seen = set()
+    scope = _find_product_scope(soup)   # v33: PDP 컨테이너로 스코프 한정(엉뚱 이미지 차단)
 
     def _abs(s: str) -> str:
         s = (s or "").strip()
@@ -360,7 +395,7 @@ def _collect_dom_images(soup, base_url: str) -> list:
                 pass
         return False
 
-    for img in soup.find_all("img"):
+    for img in scope.find_all("img"):
         cand = ""
         for attr in ("src", "data-src", "data-original", "data-lazy",
                      "data-lazy-src", "data-image", "data-zoom-image"):
@@ -384,8 +419,8 @@ def _collect_dom_images(soup, base_url: str) -> list:
         seen.add(url)
         out.append(url)
 
-    # <source srcset> (picture 요소) 도 수집
-    for src in soup.find_all("source"):
+    # <source srcset> (picture 요소) 도 수집 — 동일 PDP 스코프
+    for src in scope.find_all("source"):
         ss = src.get("srcset") or src.get("data-srcset")
         url = _abs(_from_srcset(ss)) if ss else ""
         if url and url not in seen and not _NON_PRODUCT_IMG_RE.search(url):

--- a/tests/test_v33_image_scope.py
+++ b/tests/test_v33_image_scope.py
@@ -1,0 +1,59 @@
+"""tests/test_v33_image_scope.py — v33 2-1: 이미지 PDP 컨테이너 스코프 한정(엉뚱 이미지 0)."""
+from __future__ import annotations
+
+from src.collectors.universal_scraper import _collect_dom_images, _find_product_scope
+from bs4 import BeautifulSoup
+
+
+def _soup(html: str):
+    return BeautifulSoup(html, "html.parser")
+
+
+def test_scopes_to_product_container_and_excludes_recommend_and_review():
+    html = """
+    <html><body>
+      <div class="product-detail">
+        <img src="https://cdn.shop.com/main-1.jpg">
+        <img src="https://cdn.shop.com/detail-2.jpg">
+        <img src="https://cdn.shop.com/detail-3.jpg">
+      </div>
+      <section class="recommend">
+        <img src="https://cdn.shop.com/other-product-a.jpg">
+        <img src="https://cdn.shop.com/other-product-b.jpg">
+      </section>
+      <section class="review-list">
+        <img src="https://cdn.shop.com/review-thumb-1.jpg">
+      </section>
+      <footer><img src="https://cdn.shop.com/footer-banner.jpg"></footer>
+    </body></html>
+    """
+    imgs = _collect_dom_images(_soup(html), "https://shop.com/p/1")
+    assert any("main-1" in u for u in imgs)
+    assert any("detail-2" in u for u in imgs)
+    # 추천/리뷰/푸터 이미지는 0
+    assert not any("other-product" in u for u in imgs)
+    assert not any("review-thumb" in u for u in imgs)
+    assert not any("footer-banner" in u for u in imgs)
+
+
+def test_falls_back_to_whole_page_when_no_clear_container():
+    # 명확한 PDP 컨테이너가 없으면 기존 동작(전체 페이지-제외) 유지(회귀 0)
+    html = """
+    <html><body>
+      <img src="https://cdn.shop.com/a.jpg">
+      <img src="https://cdn.shop.com/b.jpg">
+      <div class="related"><img src="https://cdn.shop.com/other.jpg"></div>
+    </body></html>
+    """
+    imgs = _collect_dom_images(_soup(html), "https://shop.com/p/1")
+    assert any("a.jpg" in u for u in imgs) and any("b.jpg" in u for u in imgs)
+    assert not any("other.jpg" in u for u in imgs)   # related 영역 제외 유지
+
+
+def test_product_scope_requires_multiple_images_conservative():
+    # 컨테이너에 이미지 1장뿐이면 스코프로 채택하지 않음(recall 보존)
+    html = '<div class="product-info"><img src="https://x.com/one.jpg"></div><img src="https://x.com/two.jpg">'
+    scope = _find_product_scope(_soup(html))
+    # 전체(soup)로 폴백 → two.jpg도 보임
+    imgs = _collect_dom_images(_soup(html), "https://x.com/p")
+    assert any("two.jpg" in u for u in imgs)


### PR DESCRIPTION
## v33 2-1 — 이미지 PDP 컨테이너 스코프 한정 (엉뚱 이미지 차단)

마스터 로드맵 2주차의 새 P0. (1주차·2주차 대부분·3·4주차는 이번 세션 v24~v32로 이미 완료.)

**증상:** 수집 시 **추천·광고·리뷰 썸네일·타 상품** 이미지가 섞임.

**수정 (`universal_scraper`):**
- `_NON_PRODUCT_REGION_RE`에 **review/comment/reply/qna/feedback/testimonial** 추가 → 리뷰·문의 영역 썸네일 제외
- 신규 `_find_product_scope` — `itemtype=Product` · `product-detail/product-info/goods` 등 **PDP 메인 컨테이너로 이미지 수집 스코프 한정**. **보수적**: 컨테이너가 비-상품 영역이 아니고 이미지 2장 이상일 때만 채택(아니면 전체 폴백) → **recall 보존(무회귀)**
- `_collect_dom_images`가 스코프 내 `img`/`source`만 수집
- 확장 `content_script` `_kgpNonProductRe`에도 리뷰/댓글 추가(JS 사이트 인페이지 추출), manifest `1.5.12→1.5.13`

**가격·메타:** 빈 USD 임의 KRW 환산 금지 + 원본 메타/플레이스홀더 숨김은 **v31에서 이미 완료**(이 PR은 이미지 스코프에 집중).

### 검증
- `test_v33_image_scope`(3) — 컨테이너 한정·추천/리뷰/푸터 0·폴백 동작·보수적(이미지 1장이면 미채택)
- 기존 이미지 추출 테스트 51 + 전체 **10335 passed**, 0 regressions

---
다음(마스터 순서): 3-3 토스트·버튼 비주얼 시스템 → 3-4 북마클릿 인페이지 토스트 + 전역 이모지 박멸 → 3-5 소싱 카드 확대·상태값 한글화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ngle_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_