### PR TITLE
v33 3-3: 토스트 비주얼 시스템 네오-클래식 (먹/한지/금·라인 아이콘·이모지 0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@
 
 ## 🟪 v33/마스터 브리프 (오너 2026-06-27 — v24~v33 통합 마스터, 1달 출시 로드맵)
 - (1~4주차 대부분은 이번 세션에서 v24~v32로 완료됨 — 404·삭제영속·이력·토큰·전체수집·메타숨김·Mock·네이버·디자인·랜딩·버튼·아마존·활성화.)
+- ✅ **3주차 3-3 토스트 비주얼 시스템 (Phase 314):** pcToast 전면 재설계 — bootstrap 컬러배경+이모지(✅❌⚠️ℹ️)를
+  **네오-클래식**(먹 vault 배경·한지 텍스트·금 보더·유형 좌악센트 teal/orange/danger·**라인 아이콘 bi-***)으로. 우상단
+  슬라이드-인(pcToastIn)+자동/수동 닫기, reduced-motion 정지. app.css `.pc-toast`(토큰 단일소스), 이모지 0. 버튼 위계는
+  기존 토큰 컴포넌트(.btn-primary/.btn-cta/.btn-gold/.btn-ghost·로딩 setButtonLoading) 유지. 가드 test_v33_toast(4). 전체 10339 passed.
 - ✅ **2주차 2-1 이미지 PDP 스코프 한정 (Phase 313):** 엉뚱한 이미지(추천·리뷰·푸터·타 상품) 혼입 차단 강화 —
   `_NON_PRODUCT_REGION_RE`에 review/comment/reply/qna/feedback/testimonial 추가, 신규 `_find_product_scope`
   (itemtype Product·product-detail/goods 컨테이너로 이미지 수집 스코프 한정, **보수적**: 이미지 2장+ & 비-상품영역 아닐 때만

--- a/src/seller_console/static/seller.js
+++ b/src/seller_console/static/seller.js
@@ -79,41 +79,46 @@ function pcToast(message, type = 'info') {
     container.setAttribute('aria-atomic', 'true');
     document.body.appendChild(container);
   }
-  const toneMap = {success: 'success', error: 'danger', danger: 'danger', warning: 'warning', info: 'secondary'};
-  const iconMap = {success: '✅', error: '❌', danger: '❌', warning: '⚠️', info: 'ℹ️'};
-  const tone = toneMap[type] || 'secondary';
+  // v33 3-3: 네오-클래식 토스트 — 먹 배경·한지 텍스트·금 보더·유형 좌악센트·라인 아이콘(이모지 0).
+  const toneMap = {success: 'success', error: 'danger', danger: 'danger', warning: 'warning', info: 'info'};
+  const iconMap = {success: 'bi-check-circle', error: 'bi-x-circle', danger: 'bi-x-circle',
+                   warning: 'bi-exclamation-triangle', info: 'bi-info-circle'};
+  const tone = toneMap[type] || 'info';
 
   const toastEl = document.createElement('div');
-  toastEl.className = `toast align-items-center text-bg-${tone} border-0`;
+  toastEl.className = `pc-toast pc-toast-${tone}`;
   toastEl.setAttribute('role', 'alert');
-  toastEl.setAttribute('aria-live', 'assertive');
+  toastEl.setAttribute('aria-live', tone === 'danger' ? 'assertive' : 'polite');
   toastEl.setAttribute('aria-atomic', 'true');
 
-  const flex = document.createElement('div');
-  flex.className = 'd-flex';
-  const body = document.createElement('div');
-  body.className = 'toast-body';
-  body.textContent = `${iconMap[type] || ''} ${message}`.trim();
+  const ic = document.createElement('i');
+  ic.className = `bi ${iconMap[type] || 'bi-info-circle'} pc-toast-ic`;
+  ic.setAttribute('aria-hidden', 'true');
+  const msg = document.createElement('div');
+  msg.className = 'pc-toast-msg';
+  msg.textContent = String(message == null ? '' : message);
   const closeBtn = document.createElement('button');
   closeBtn.type = 'button';
-  closeBtn.className = 'btn-close btn-close-white me-2 m-auto';
-  closeBtn.setAttribute('data-bs-dismiss', 'toast');
+  closeBtn.className = 'pc-toast-x';
   closeBtn.setAttribute('aria-label', '닫기');
-  flex.appendChild(body);
-  flex.appendChild(closeBtn);
-  toastEl.appendChild(flex);
+  closeBtn.innerHTML = '<i class="bi bi-x-lg" aria-hidden="true"></i>';
+
+  toastEl.appendChild(ic);
+  toastEl.appendChild(msg);
+  toastEl.appendChild(closeBtn);
   container.appendChild(toastEl);
 
+  let timer = null;
+  const dismiss = () => {
+    if (timer) { clearTimeout(timer); timer = null; }
+    toastEl.style.transition = 'opacity .2s, transform .2s';
+    toastEl.style.opacity = '0';
+    toastEl.style.transform = 'translateX(16px)';
+    setTimeout(() => toastEl.remove(), 220);
+  };
+  closeBtn.addEventListener('click', dismiss);     // 수동 닫기
   const delay = (type === 'error' || type === 'danger') ? 6000 : 3500;
-  if (typeof bootstrap !== 'undefined' && bootstrap.Toast) {
-    const toast = new bootstrap.Toast(toastEl, {delay});
-    toastEl.addEventListener('hidden.bs.toast', () => toastEl.remove());
-    toast.show();
-  } else {
-    // bootstrap 미로딩 폴백: 잠깐 보여주고 제거
-    toastEl.classList.add('show');
-    setTimeout(() => toastEl.remove(), delay);
-  }
+  timer = setTimeout(dismiss, delay);              // 자동 닫기
 }
 
 /**

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -514,3 +514,33 @@ body::before {
   .pc-lift:hover { transform: none; }
   body::before { display: none; }
 }
+
+/* ============================================================================
+   v33 3-3 토스트 — 네오-클래식(먹 배경·한지 텍스트·금 보더·유형 좌악센트·라인 아이콘).
+   이모지 0, 토큰 단일소스, reduced-motion 존중.
+   ============================================================================ */
+.pc-toast {
+  display: flex; align-items: flex-start; gap: .55rem;
+  min-width: 260px; max-width: 380px;
+  background: var(--vault-surface); color: var(--vault-text);
+  border: 1px solid color-mix(in srgb, var(--gold) 30%, transparent);
+  border-left: 3px solid var(--teal);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  padding: .7rem .85rem;
+  font-family: var(--font-ui);
+  animation: pcToastIn var(--dur) var(--ease) both;
+}
+.pc-toast .pc-toast-ic { color: var(--teal); font-size: 1.05rem; line-height: 1.35; flex-shrink: 0; }
+.pc-toast .pc-toast-msg { flex: 1; font-size: .9rem; line-height: 1.45; }
+.pc-toast .pc-toast-x {
+  background: none; border: 0; cursor: pointer; padding: 0 .15rem; line-height: 1;
+  color: color-mix(in srgb, var(--cream) 65%, transparent); font-size: 1rem;
+}
+.pc-toast .pc-toast-x:hover { color: var(--cream); }
+.pc-toast-success { border-left-color: var(--teal); }    .pc-toast-success .pc-toast-ic { color: var(--teal); }
+.pc-toast-warning { border-left-color: var(--orange); }  .pc-toast-warning .pc-toast-ic { color: var(--orange); }
+.pc-toast-danger  { border-left-color: var(--danger); }  .pc-toast-danger .pc-toast-ic  { color: var(--danger); }
+.pc-toast-info    { border-left-color: var(--gold); }    .pc-toast-info .pc-toast-ic    { color: var(--gold); }
+@keyframes pcToastIn { from { opacity: 0; transform: translateX(16px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) { .pc-toast { animation: none; } }

--- a/tests/test_v33_toast.py
+++ b/tests/test_v33_toast.py
@@ -1,0 +1,46 @@
+"""tests/test_v33_toast.py — v33 3-3: 네오-클래식 토스트(먹/한지/금·라인 아이콘·이모지 0)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+JS = Path("src/seller_console/static/seller.js").read_text(encoding="utf-8")
+CSS = Path("src/static/app.css").read_text(encoding="utf-8")
+
+
+def _pctoast_block() -> str:
+    i = JS.index("function pcToast")
+    return JS[i:i + 3200]
+
+
+def test_toast_uses_line_icons_not_emoji():
+    blk = _pctoast_block()
+    # 라인 아이콘(bi-*) 사용, 이모지 0
+    for ic in ("bi-check-circle", "bi-x-circle", "bi-exclamation-triangle", "bi-info-circle"):
+        assert ic in blk, f"{ic} 누락"
+    for em in ("✅", "❌", "⚠️", "ℹ️"):
+        assert em not in blk, f"토스트에 이모지 {em} 잔존"
+    assert "pc-toast" in blk and "pc-toast-" in blk
+
+
+def test_toast_has_manual_and_auto_close():
+    blk = _pctoast_block()
+    assert "수동 닫기" in blk and "자동 닫기" in blk
+    assert "setTimeout(dismiss" in blk
+
+
+def test_toast_css_neo_classic_tokens():
+    # 먹 배경·한지 텍스트·금 보더·유형 좌악센트(토큰 단일소스)
+    assert ".pc-toast {" in CSS
+    blk = CSS[CSS.index(".pc-toast {"):CSS.index(".pc-toast {") + 700]
+    assert "var(--vault-surface)" in blk      # 먹 배경
+    assert "var(--vault-text)" in blk          # 한지 텍스트
+    assert "var(--gold)" in blk                # 금 보더
+    for accent in (".pc-toast-success", ".pc-toast-warning", ".pc-toast-danger"):
+        assert accent in CSS
+    assert "var(--teal)" in CSS and "var(--orange)" in CSS and "var(--danger)" in CSS
+
+
+def test_toast_reduced_motion_guard():
+    seg = CSS[CSS.index(".pc-toast {"):]
+    assert "prefers-reduced-motion: reduce" in seg
+    assert "pcToastIn" in CSS                   # 슬라이드-인 키프레임


### PR DESCRIPTION
## v33 3-3 — 토스트 비주얼 시스템 (네오-클래식)

마스터 3주차 3-3. 전역 알림(`pcToast`)을 "잘 보이고 + 고급" 동시 충족하게 재설계.

### before → after
- **before:** bootstrap 컬러 배경(`text-bg-success` 등) + **이모지**(✅❌⚠️ℹ️)
- **after:** 먹 vault 배경(`var(--vault-surface)`) · 한지 텍스트(`var(--vault-text)`) · **금 보더** · **유형 좌악센트 바**(성공 청록 / 경고 주황 / 실패 적) · **라인 아이콘**(`bi-check-circle`/`bi-x-circle`/`bi-exclamation-triangle`/`bi-info-circle`)

### 동작
- 우상단 **슬라이드-인**(`pcToastIn`, 220ms) + **자동 닫기**(성공 3.5s/실패 6s) + **수동 닫기**(line X)
- 은은한 그림자(`var(--shadow-lg)`), 유형별 강조 1색, **이모지 0**
- `prefers-reduced-motion`에서 애니메이션 정지

### 토큰 단일소스
- `app.css .pc-toast` 전부 `var(--*)` (하드코딩 0)
- 버튼 위계는 기존 토큰 컴포넌트 유지(`.btn-primary` 채움·hover lift+glow / `.btn-cta` 주황 주요행동 / `.btn-gold` 보조 / `.btn-ghost`, `setButtonLoading` 로딩 스피너, btn-lg ≥40px)

### 검증
- `test_v33_toast`(4) — 라인 아이콘/이모지 0, 자동+수동 닫기, 먹/한지/금 토큰, reduced-motion
- 전체 **10339 passed**, 0 regressions

---
다음: 3-4 북마클릿 인페이지 토스트 + 전역 이모지 박멸 → 3-5 소싱 카드 확대·상태값 한글화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_