### PR TITLE
v33 3-4: 전역 이모지·지구본 박멸 (단일 라인 아이콘셋 bi-*)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,11 @@
 
 ## 🟪 v33/마스터 브리프 (오너 2026-06-27 — v24~v33 통합 마스터, 1달 출시 로드맵)
 - (1~4주차 대부분은 이번 세션에서 v24~v32로 완료됨 — 404·삭제영속·이력·토큰·전체수집·메타숨김·Mock·네이버·디자인·랜딩·버튼·아마존·활성화.)
+- ✅ **3주차 3-4 전역 이모지·지구본 박멸 (Phase 315):** 셀러 콘솔/에러/파셜 전 사용자 템플릿의 이모지(🛒🛠📚💚👤🚪🔐📧🆘⭐ℹ️❌🧤✓)를
+  **단일 라인 아이콘셋 bi-***(shop/tools/book/heart-pulse/person/box-arrow-right/shield-lock/envelope/life-preserver/star-fill/info-circle…)로 교체.
+  topnav×2·404/500·markets_connect/guide·catalog·notifications·me·mobile_home·market_status·collect_preview·bookmarklet 전수.
+  북마클릿 드래그 버튼 🧤→**'수집' 텍스트**(이모지 없는 북마크 이름). **bi-globe(지구본) 아이콘 7개 → bi-translate**(지구본 0).
+  가드 test_v33_emoji_sweep(전 사용자 템플릿 이모지 0 파라미터화 + 핵심 chrome 라인아이콘). 전체 10392 passed.
 - ✅ **3주차 3-3 토스트 비주얼 시스템 (Phase 314):** pcToast 전면 재설계 — bootstrap 컬러배경+이모지(✅❌⚠️ℹ️)를
   **네오-클래식**(먹 vault 배경·한지 텍스트·금 보더·유형 좌악센트 teal/orange/danger·**라인 아이콘 bi-***)으로. 우상단
   슬라이드-인(pcToastIn)+자동/수동 닫기, reduced-motion 정지. app.css `.pc-toast`(토큰 단일소스), 이모지 0. 버튼 위계는

--- a/src/seller_console/templates/about.html
+++ b/src/seller_console/templates/about.html
@@ -17,7 +17,7 @@
       <p class="text-muted small">타오바오·아마존·알리 등 어떤 상품이든 버튼 한 번으로 가져와요. 크롬 확장·모바일 공유·붙여넣기까지.</p>
     </div>
     <div class="col-md-4">
-      <div class="fs-1 mb-2"><i class="bi bi-globe"></i></div>
+      <div class="fs-1 mb-2"><i class="bi bi-translate"></i></div>
       <h5 class="fw-bold">다듬기</h5>
       <p class="text-muted small">제목·설명을 한국어로 번역하고, 금지어를 정리하고, 가격·마진을 한 번에 맞춰요.</p>
     </div>

--- a/src/seller_console/templates/bookmarklet.html
+++ b/src/seller_console/templates/bookmarklet.html
@@ -42,7 +42,7 @@
         <div class="card-header"><strong><i class="bi bi-wrench"></i> 설치 방법 (2단계)</strong></div>
         <div class="card-body">
           <ol class="mb-2">
-            <li>아래 <strong>🧤 버튼</strong>을 마우스로 드래그해 브라우저 북마크바에 놓으세요.</li>
+            <li>아래 <strong>수집 버튼</strong>을 마우스로 드래그해 브라우저 북마크바에 놓으세요.</li>
             <li>상품 페이지에서 그 북마크를 클릭하면 <strong>이미지·상세설명·리뷰까지 자동 수집</strong>되고
                 <strong>‘수집 완료’</strong>만 표시됩니다. 결과는 <strong>내 계정의 ‘수집 이력’</strong>에서 확인·편집하세요.</li>
           </ol>
@@ -55,7 +55,7 @@
 
       <!-- 수집 시 번역 선택 -->
       <div class="card mb-4">
-        <div class="card-header"><strong><i class="bi bi-globe"></i> 번역 설정</strong></div>
+        <div class="card-header"><strong><i class="bi bi-translate"></i> 번역 설정</strong></div>
         <div class="card-body">
           <div class="form-check form-switch">
             <input class="form-check-input" type="checkbox" id="translateToggle" checked>
@@ -70,13 +70,13 @@
         <div class="card-header"><strong><i class="bi bi-bookmark-plus"></i> 북마클릿 (드래그해서 북마크바에 추가)</strong></div>
         <div class="card-body text-center py-4">
           <!-- 토큰 불필요: 새 탭(로그인 세션)으로 데이터를 보내 수집(CSP/CORS 우회).
-               북마크바에 이모지 1글자(🧤)만 이름으로 들어가 아이콘처럼 보이게 한다(긴 JS 코드 노출 방지). -->
+               북마크바에 짧은 이름(수집)만 들어가게 한다(긴 JS 코드 노출 방지). -->
           <a id="bookmarkletLink"
              class="d-inline-flex align-items-center justify-content-center text-decoration-none"
-             style="cursor:grab;border-radius:12px;border:1px solid #dee2e6;background:#fff;color:#1a1714;font-weight:700;font-size:1.6rem;line-height:1;width:52px;height:52px;"
-             title="이 버튼을 북마크바로 드래그하세요 — 🧤 한 글자로 추가됩니다"
-             aria-label="고가수집기 북마클릿">🧤</a>
-          <p class="mt-3 text-muted small mb-0">위 <strong>🧤</strong> 버튼을 북마크바로 드래그하세요. 북마크바에는 <strong>🧤</strong> 한 글자로 깔끔하게 표시됩니다.</p>
+             style="cursor:grab;border-radius:12px;border:1px solid #dee2e6;background:#fff;color:#1a1714;font-weight:700;font-size:0.95rem;line-height:1;width:52px;height:52px;"
+             title="이 버튼을 북마크바로 드래그하세요 — ‘수집’ 이름으로 추가됩니다"
+             aria-label="고가수집기 북마클릿">수집</a>
+          <p class="mt-3 text-muted small mb-0">위 <strong>수집</strong> 버튼을 북마크바로 드래그하세요. 북마크바에 <strong>수집</strong> 이름으로 깔끔하게 표시됩니다.</p>
           <p class="text-muted small mb-0">
             <span class="text-muted">※ Chrome 특성상 북마클릿(주소가 <code>javascript:</code>인 북마크)엔 기본 지구본 아이콘이 표시될 수 있어요. 완전한 브랜드 아이콘은 <a href="/seller/extension">크롬 확장 프로그램</a> 버전을 쓰세요.</span></p>
         </div>
@@ -89,7 +89,7 @@
         <div class="card-body">
           <details>
             <summary class="text-muted small" style="cursor:pointer">고급: 북마클릿 코드 보기 (개발용)</summary>
-            <p class="text-muted small mt-2 mb-2">대부분의 분은 이걸 볼 필요가 없어요. 위 <strong>🧤</strong> 버튼만 드래그하면 됩니다.</p>
+            <p class="text-muted small mt-2 mb-2">대부분의 분은 이걸 볼 필요가 없어요. 위 <strong>수집</strong> 버튼만 드래그하면 됩니다.</p>
             <pre class="bg-light p-3 rounded" style="font-size:0.72rem;overflow-x:auto;white-space:pre-wrap;" id="bookmarkletCode">코드 로딩 중…</pre>
             <button class="btn btn-sm btn-outline-secondary mt-2" onclick="copyCode()">코드 복사</button>
           </details>

--- a/src/seller_console/templates/catalog.html
+++ b/src/seller_console/templates/catalog.html
@@ -20,7 +20,7 @@
 
 {% if source == 'mock' %}
 <div class="alert alert-info mb-4">
-  <strong>ℹ️ Mock 데이터:</strong> Google Sheets catalog 워크시트가 비어있습니다.
+  <strong><i class="bi bi-info-circle"></i> Mock 데이터:</strong> Google Sheets catalog 워크시트가 비어있습니다.
   <a href="/seller/collect" class="alert-link">수동 수집기</a>에서 상품을 수집하고 "Sheets에 저장" 버튼으로 추가하세요.
 </div>
 {% endif %}

--- a/src/seller_console/templates/collect_history.html
+++ b/src/seller_console/templates/collect_history.html
@@ -158,7 +158,7 @@
           <i class="bi bi-folder"></i> 그룹 지정
         </button>
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkTranslateBtn" onclick="runBulkTranslate()" disabled>
-          <i class="bi bi-globe"></i> 한국어 번역
+          <i class="bi bi-translate"></i> 한국어 번역
         </button>
         <button type="button" class="btn btn-outline-primary btn-sm" id="bulkCleanBtn" onclick="runBulkClean()" disabled
                 title="설정한 금지어 제거 + 단어 치환을 제목에 적용">

--- a/src/seller_console/templates/collect_preview.html
+++ b/src/seller_console/templates/collect_preview.html
@@ -5,7 +5,7 @@
   <div class="mb-3 d-flex justify-content-between align-items-center">
     <a href="/seller/collect/history" class="text-decoration-none text-muted small">← 수집 이력으로 돌아가기</a>
     <span class="text-muted small">
-      <i class="bi bi-globe"></i> <a href="{{ item.url }}" target="_blank" rel="noopener noreferrer">{{ item.domain }}</a>
+      <i class="bi bi-translate"></i> <a href="{{ item.url }}" target="_blank" rel="noopener noreferrer">{{ item.domain }}</a>
       · {{ item.collected_at[:16] if item.collected_at else "" }}
     </span>
   </div>
@@ -320,7 +320,7 @@ function addImageRow(url) {
   const row = document.createElement('div');
   row.className = 'd-flex align-items-center gap-1 img-row';
   row.innerHTML = `
-    <button class="btn btn-outline-warning btn-sm btn-make-primary flex-shrink-0" type="button" title="대표 이미지로 지정">⭐</button>
+    <button class="btn btn-outline-warning btn-sm btn-make-primary flex-shrink-0" type="button" title="대표 이미지로 지정" aria-label="대표 이미지로 지정"><i class="bi bi-star"></i></button>
     <img class="img-thumb flex-shrink-0 rounded border" alt="" style="width:46px;height:46px;object-fit:cover;background:#f1f3f5;cursor:zoom-in"
          title="클릭하면 원본 보기" onerror="this.style.visibility='hidden'">
     <input type="url" class="form-control form-control-sm img-url" placeholder="https://..." value="${escapeHtml(url || '')}">

--- a/src/seller_console/templates/cs_stats.html
+++ b/src/seller_console/templates/cs_stats.html
@@ -89,7 +89,7 @@
   <!-- 언어별 -->
   <div class="col-md-4">
     <div class="card border-0 shadow-sm">
-      <div class="card-header fw-semibold"><i class="bi bi-globe"></i> 언어별</div>
+      <div class="card-header fw-semibold"><i class="bi bi-translate"></i> 언어별</div>
       <div class="card-body p-0">
         <table class="table table-sm mb-0">
           <thead><tr><th>언어</th><th>건수</th></tr></thead>

--- a/src/seller_console/templates/manual_collect.html
+++ b/src/seller_console/templates/manual_collect.html
@@ -186,7 +186,7 @@
             onclick="localizeProduct()"
             {% if not localization_configured %}disabled{% endif %}
           >
-            <i class="bi bi-globe"></i> 현지화 실행
+            <i class="bi bi-translate"></i> 현지화 실행
           </button>
           {% if not localization_configured %}
           <div class="small text-muted mt-2">번역 API 미설정: /admin/diagnostics에서 설정하세요.</div>

--- a/src/seller_console/templates/market_status.html
+++ b/src/seller_console/templates/market_status.html
@@ -130,7 +130,7 @@
 </div>
 
 <div class="text-muted small mt-2">
-  ℹ️ 30초마다 자동 새로고침됩니다. Phase 71/109 실연동 후 실시간 데이터 표시.
+  <i class="bi bi-info-circle"></i> 30초마다 자동 새로고침됩니다. Phase 71/109 실연동 후 실시간 데이터 표시.
 </div>
 {% endblock %}
 

--- a/src/seller_console/templates/markets_connect.html
+++ b/src/seller_console/templates/markets_connect.html
@@ -87,7 +87,7 @@
         <button type="button" class="btn btn-ghost btn-sm" id="mcToggleAll">전체 보기</button>
       </div>
       <div id="mcStepper" class="d-flex flex-wrap gap-2"></div>
-      <div class="small text-muted mt-2">연결을 마치면 ✓ 로 자동 체크돼요. 천천히 하나씩 하면 됩니다.</div>
+      <div class="small text-muted mt-2">연결을 마치면 <i class="bi bi-check-lg"></i> 로 자동 체크돼요. 천천히 하나씩 하면 됩니다.</div>
     </div>
   </div>
   {% endif %}
@@ -188,7 +188,7 @@ function copyServerIp(btn) {
   if (!ip) return;
   navigator.clipboard.writeText(ip.trim()).then(function () {
     if (window.pcToast) pcToast('서버 IP를 복사했어요. 마켓 허용 IP에 붙여넣으세요.', 'success');
-    if (btn) { var o = btn.textContent; btn.textContent = '복사됨 ✓'; setTimeout(function(){ btn.textContent = o; }, 1500); }
+    if (btn) { var o = btn.textContent; btn.textContent = '복사됨'; setTimeout(function(){ btn.textContent = o; }, 1500); }
   });
 }
 function collectValues(form) {
@@ -295,7 +295,7 @@ document.querySelectorAll('.market-connect-form').forEach(form => {
   }
 });
 
-// v14: 한 마켓씩 순차 진행(연결되면 ✓ 자동 체크). '전체 보기'로 그리드 전환.
+// v14: 한 마켓씩 순차 진행(연결되면 자동 체크). '전체 보기'로 그리드 전환.
 (function () {
   const cols = Array.from(document.querySelectorAll('.mc-market-col'));
   const stepper = document.getElementById('mcStepper');
@@ -310,7 +310,7 @@ document.querySelectorAll('.market-connect-form').forEach(form => {
       const on = c.dataset.connected === '1';
       const active = i === cur && !showAll;
       const cls = active ? 'btn-primary' : (on ? 'btn-outline-success' : 'btn-outline-secondary');
-      const mark = on ? '✓ ' : (i + 1) + '. ';
+      const mark = on ? '● ' : (i + 1) + '. ';
       return `<button type="button" class="btn btn-sm ${cls} mc-step" data-i="${i}">${mark}${c.dataset.label}</button>`;
     }).join('');
     stepper.querySelectorAll('.mc-step').forEach(b => b.addEventListener('click', () => { showAll = false; cur = parseInt(b.dataset.i, 10); apply(); }));

--- a/src/seller_console/templates/markets_guide.html
+++ b/src/seller_console/templates/markets_guide.html
@@ -33,7 +33,7 @@
         <text x="98" y="70" text-anchor="middle" font-size="13" fill="#334">마켓 판매자센터</text>
         <rect x="58" y="86" width="80" height="22" rx="6" fill="#0d6efd"/>
         <text x="98" y="101" text-anchor="middle" font-size="11" fill="#fff">API 키 발급</text>
-        <text x="232" y="66" text-anchor="middle" font-size="30">🔑</text>
+        <text x="232" y="66" text-anchor="middle" font-size="14">KEY</text>
         <path d="M196 75 H268" stroke="#9aa" stroke-width="2" marker-end="url(#arrow)"/>
         <path d="M300 75 H372" stroke="#9aa" stroke-width="2" marker-end="url(#arrow)"/>
         <defs><marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
@@ -44,7 +44,7 @@
         <rect x="394" y="60" width="142" height="20" rx="5" fill="#fff" stroke="#cfe6d4"/>
         <text x="465" y="74" text-anchor="middle" font-size="10" fill="#789">여기에 붙여넣기</text>
         <rect x="394" y="92" width="142" height="22" rx="6" fill="#198754"/>
-        <text x="465" y="107" text-anchor="middle" font-size="11" fill="#fff">연결 테스트 → ✅</text>
+        <text x="465" y="107" text-anchor="middle" font-size="11" fill="#fff">연결 테스트 OK</text>
       </svg>
       <div class="small text-muted mt-2">핵심: <strong>마켓에서 키 받기 → 우리 사이트 입력칸에 붙여넣기 → [연결 테스트]</strong> 3단계면 끝.</div>
     </div>
@@ -87,7 +87,7 @@
       </div>
       {% if g.status == 'planned' %}
       <div class="alert alert-warning small py-2">
-        <i class="bi bi-globe"></i> 글로벌 확장 마켓입니다. 키 발급 방법을 미리 안내하며, 어댑터 실연동은 순차 적용 예정입니다.
+        <i class="bi bi-translate"></i> 글로벌 확장 마켓입니다. 키 발급 방법을 미리 안내하며, 어댑터 실연동은 순차 적용 예정입니다.
         지금 키를 준비해두면 연동 시 바로 사용할 수 있어요.
       </div>
       {% endif %}
@@ -154,7 +154,7 @@
               <text x="30" y="92" font-size="9" fill="#7a6033">반품지  센터코드 1000274592</text>
               <rect x="22" y="104" width="182" height="20" rx="4" fill="#fff" stroke="#ffe0a3"/>
               <text x="30" y="118" font-size="9" fill="#7a6033">반품지 주소·우편번호·연락처</text>
-              <text x="250" y="86" text-anchor="middle" font-size="24">📋</text>
+              <text x="250" y="86" text-anchor="middle" font-size="12">FORM</text>
               <text x="250" y="104" text-anchor="middle" font-size="8" fill="#789">복사</text>
               <path d="M224 80 H300" stroke="#9aa" stroke-width="2" marker-end="url(#arrow)"/>
               <path d="M300 80 H372" stroke="#9aa" stroke-width="2" marker-end="url(#arrow)"/>
@@ -166,7 +166,7 @@
               <rect x="394" y="76" width="142" height="18" rx="4" fill="#fff" stroke="#cfe6d4"/>
               <text x="402" y="89" font-size="8" fill="#789">반품지센터코드 ▢</text>
               <rect x="394" y="104" width="142" height="20" rx="6" fill="#198754"/>
-              <text x="465" y="118" text-anchor="middle" font-size="10" fill="#fff">저장 → ✅</text>
+              <text x="465" y="118" text-anchor="middle" font-size="10" fill="#fff">저장 OK</text>
             </svg>
           </div>
 
@@ -191,7 +191,7 @@
             </table>
           </div>
           {% if g.shipping.optional_note %}
-          <div class="small text-muted mb-2">ℹ️ {{ g.shipping.optional_note }}</div>
+          <div class="small text-muted mb-2"><i class="bi bi-info-circle"></i> {{ g.shipping.optional_note }}</div>
           {% endif %}
           {% if g.shipping.tips %}
           <div class="alert alert-light border small mb-0">

--- a/src/seller_console/templates/me.html
+++ b/src/seller_console/templates/me.html
@@ -5,7 +5,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h4 class="mb-0 fw-bold"><i class="bi bi-person"></i> 마이페이지</h4>
   {% if user and user.role == 'admin' %}
-    <span class="badge bg-danger px-3 py-2 fs-6">⭐ Admin</span>
+    <span class="badge bg-danger px-3 py-2 fs-6"><i class="bi bi-star-fill"></i> Admin</span>
   {% endif %}
 </div>
 

--- a/src/seller_console/templates/mobile_home.html
+++ b/src/seller_console/templates/mobile_home.html
@@ -100,7 +100,7 @@
     <a href="/seller/start" class="m-card p-3 text-decoration-none text-dark"><i class="bi bi-stars"></i> For Beginners · 시작 가이드</a>
     <a href="/seller/markets/connect" class="m-card p-3 text-decoration-none text-dark"><i class="bi bi-shop"></i> 마켓 연동</a>
     <a href="/seller/dashboard" class="m-card p-3 text-decoration-none text-dark"><i class="bi bi-display"></i> 데스크톱 전체 콘솔</a>
-    <a href="/seller/about" class="m-card p-3 text-decoration-none text-dark">ℹ️ 고가브릿지란?</a>
+    <a href="/seller/about" class="m-card p-3 text-decoration-none text-dark"><i class="bi bi-info-circle"></i> 고가브릿지란?</a>
   </div>
   <div class="m-card p-3 mt-3 small text-muted">
     <i class="bi bi-phone"></i> <strong>홈 화면에 추가</strong>하면 앱처럼 쓸 수 있어요. iOS: 공유 → ‘홈 화면에 추가’, 안드로이드: 메뉴 → ‘앱 설치’.

--- a/src/seller_console/templates/notifications.html
+++ b/src/seller_console/templates/notifications.html
@@ -61,7 +61,7 @@
   <strong><i class="bi bi-pin-angle"></i> 알림 훅 포인트</strong>
   <ul class="mb-0 mt-1">
     <li>새 주문 sync 시: "신규 주문 N건 (마켓별 집계)"</li>
-    <li><code>/health/deep</code> fail 시: "❌ [서비스명] 체크 실패"</li>
+    <li><code>/health/deep</code> fail 시: "[실패] [서비스명] 체크 실패"</li>
     <li>재고 0 도달: "[상품명] — 재고 없음"</li>
     <li>마진 이상: "[상품명] 마진 손실 예상"</li>
   </ul>

--- a/src/seller_console/templates/partials/topnav.html
+++ b/src/seller_console/templates/partials/topnav.html
@@ -15,19 +15,19 @@
       <ul class="navbar-nav gap-1">
         <li class="nav-item">
           <a class="nav-link {% if request.path.startswith('/seller') %}active fw-semibold{% endif %}"
-             href="/seller/">🛒 셀러 콘솔</a>
+             href="/seller/"><i class="bi bi-shop"></i> 셀러 콘솔</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {% if request.path.startswith('/admin') %}active fw-semibold{% endif %}"
-             href="/admin/">🛠 관리자</a>
+             href="/admin/"><i class="bi bi-tools"></i> 관리자</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {% if request.path.startswith('/api/docs') %}active fw-semibold{% endif %}"
-             href="/api/docs">📚 API 문서</a>
+             href="/api/docs"><i class="bi bi-book"></i> API 문서</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {% if request.path == '/health/deep' %}active fw-semibold{% endif %}"
-             href="/health/deep">💚 시스템 상태</a>
+             href="/health/deep"><i class="bi bi-heart-pulse"></i> 시스템 상태</a>
         </li>
       </ul>
       {% set _user_id = session.get('user_id') if session is defined else None %}
@@ -44,21 +44,21 @@
             {% endif %}
           </button>
           <ul class="dropdown-menu dropdown-menu-end">
-            <li><a class="dropdown-item" href="/seller/me">👤 마이페이지</a></li>
+            <li><a class="dropdown-item" href="/seller/me"><i class="bi bi-person"></i> 마이페이지</a></li>
             <li><hr class="dropdown-divider"></li>
             <li>
               <form method="post" action="/auth/logout" class="px-2">
-                <button type="submit" class="btn btn-outline-secondary btn-sm w-100">🚪 로그아웃</button>
+                <button type="submit" class="btn btn-outline-secondary btn-sm w-100"><i class="bi bi-box-arrow-right"></i> 로그아웃</button>
               </form>
             </li>
           </ul>
         </div>
       {% else %}
         <div class="d-flex gap-2">
-          <a href="/auth/login" class="btn btn-outline-light btn-sm">🔐 OAuth 로그인</a>
-          <a href="/auth/magic-link" class="btn btn-outline-secondary btn-sm">📧 이메일 로그인</a>
+          <a href="/auth/login" class="btn btn-outline-light btn-sm"><i class="bi bi-shield-lock"></i> OAuth 로그인</a>
+          <a href="/auth/magic-link" class="btn btn-outline-secondary btn-sm"><i class="bi bi-envelope"></i> 이메일 로그인</a>
           {% if diagnostic_reveal_enabled %}
-            <a href="/auth/diagnostic-token/issue?reveal_safe=1&format=html" class="btn btn-warning btn-sm">🆘 비상 진입 (운영자)</a>
+            <a href="/auth/diagnostic-token/issue?reveal_safe=1&format=html" class="btn btn-warning btn-sm"><i class="bi bi-life-preserver"></i> 비상 진입 (운영자)</a>
           {% endif %}
           <a href="/auth/signup" class="btn btn-primary btn-sm">가입</a>
         </div>

--- a/src/templates/errors/404.html
+++ b/src/templates/errors/404.html
@@ -12,10 +12,10 @@
       URL을 다시 확인하거나 아래 링크를 이용해 주세요.
     </p>
     <div class="d-flex flex-wrap gap-2 justify-content-center">
-      <a href="/seller/" class="btn btn-outline-primary">🛒 셀러 콘솔</a>
-      <a href="/admin/" class="btn btn-outline-secondary">🛠 관리자 패널</a>
-      <a href="/api/docs" class="btn btn-outline-info">📚 API 문서</a>
-      <a href="/health/deep" class="btn btn-outline-success">💚 시스템 상태</a>
+      <a href="/seller/" class="btn btn-outline-primary"><i class="bi bi-shop"></i> 셀러 콘솔</a>
+      <a href="/admin/" class="btn btn-outline-secondary"><i class="bi bi-tools"></i> 관리자 패널</a>
+      <a href="/api/docs" class="btn btn-outline-info"><i class="bi bi-book"></i> API 문서</a>
+      <a href="/health/deep" class="btn btn-outline-success"><i class="bi bi-heart-pulse"></i> 시스템 상태</a>
     </div>
     <div class="mt-4">
       <a href="/" class="text-muted small"><i class="bi bi-house"></i> 홈으로 돌아가기</a>

--- a/src/templates/errors/500.html
+++ b/src/templates/errors/500.html
@@ -18,7 +18,7 @@
     </p>
     <div class="d-flex flex-wrap gap-2 justify-content-center">
       <a href="/" class="btn btn-outline-primary"><i class="bi bi-house"></i> 홈으로</a>
-      <a href="/health/deep" class="btn btn-outline-success">💚 시스템 상태 확인</a>
+      <a href="/health/deep" class="btn btn-outline-success"><i class="bi bi-heart-pulse"></i> 시스템 상태 확인</a>
     </div>
   </div>
 </div>

--- a/src/templates/partials/topnav.html
+++ b/src/templates/partials/topnav.html
@@ -15,19 +15,19 @@
       <ul class="navbar-nav gap-1">
         <li class="nav-item">
           <a class="nav-link {% if request.path.startswith('/seller') %}active fw-semibold{% endif %}"
-             href="/seller/">🛒 셀러 콘솔</a>
+             href="/seller/"><i class="bi bi-shop"></i> 셀러 콘솔</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {% if request.path.startswith('/admin') %}active fw-semibold{% endif %}"
-             href="/admin/">🛠 관리자</a>
+             href="/admin/"><i class="bi bi-tools"></i> 관리자</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {% if request.path.startswith('/api/docs') %}active fw-semibold{% endif %}"
-             href="/api/docs">📚 API 문서</a>
+             href="/api/docs"><i class="bi bi-book"></i> API 문서</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {% if request.path == '/health/deep' %}active fw-semibold{% endif %}"
-             href="/health/deep">💚 시스템 상태</a>
+             href="/health/deep"><i class="bi bi-heart-pulse"></i> 시스템 상태</a>
         </li>
       </ul>
       {% set _user_id = session.get('user_id') if session is defined else None %}
@@ -44,21 +44,21 @@
             {% endif %}
           </button>
           <ul class="dropdown-menu dropdown-menu-end">
-            <li><a class="dropdown-item" href="/seller/me">👤 마이페이지</a></li>
+            <li><a class="dropdown-item" href="/seller/me"><i class="bi bi-person"></i> 마이페이지</a></li>
             <li><hr class="dropdown-divider"></li>
             <li>
               <form method="post" action="/auth/logout" class="px-2">
-                <button type="submit" class="btn btn-outline-secondary btn-sm w-100">🚪 로그아웃</button>
+                <button type="submit" class="btn btn-outline-secondary btn-sm w-100"><i class="bi bi-box-arrow-right"></i> 로그아웃</button>
               </form>
             </li>
           </ul>
         </div>
       {% else %}
         <div class="d-flex gap-2">
-          <a href="/auth/login" class="btn btn-outline-light btn-sm">🔐 OAuth 로그인</a>
-          <a href="/auth/magic-link" class="btn btn-outline-secondary btn-sm">📧 이메일 로그인</a>
+          <a href="/auth/login" class="btn btn-outline-light btn-sm"><i class="bi bi-shield-lock"></i> OAuth 로그인</a>
+          <a href="/auth/magic-link" class="btn btn-outline-secondary btn-sm"><i class="bi bi-envelope"></i> 이메일 로그인</a>
           {% if diagnostic_reveal_enabled %}
-            <a href="/auth/diagnostic-token/issue?reveal_safe=1&format=html" class="btn btn-warning btn-sm">🆘 비상 진입 (운영자)</a>
+            <a href="/auth/diagnostic-token/issue?reveal_safe=1&format=html" class="btn btn-warning btn-sm"><i class="bi bi-life-preserver"></i> 비상 진입 (운영자)</a>
           {% endif %}
           <a href="/auth/signup" class="btn btn-primary btn-sm">가입</a>
         </div>

--- a/tests/test_extension_button_switch_v11.py
+++ b/tests/test_extension_button_switch_v11.py
@@ -29,8 +29,9 @@ def test_mutual_exclusion_in_refresh():
     assert "!looksLikeProductPage() && !kgpIsDetailUrl()" in CS
 
 
-def test_single_glove_icon_no_globe_image_in_bookmarklet_button():
+def test_bookmarklet_button_no_emoji_no_globe():
     bm = Path("src/seller_console/templates/bookmarklet.html").read_text(encoding="utf-8")
-    # 북마클릿 드래그 버튼은 🧤 한 글자(파비콘 글로브 이미지 미사용)
-    assert "🧤" in bm
+    # v33: 북마클릿 드래그 버튼 이름은 짧은 텍스트('수집') — 이모지 0, 글러브/지구본 0
+    assert ">수집</a>" in bm
+    assert "🧤" not in bm and "globe" not in bm.lower()
     assert "filename='favicon.svg'" not in bm and 'filename="favicon.svg"' not in bm

--- a/tests/test_v33_emoji_sweep.py
+++ b/tests/test_v33_emoji_sweep.py
@@ -1,0 +1,33 @@
+"""tests/test_v33_emoji_sweep.py — v33 3-4: 전역 이모지 박멸(라인 아이콘셋)."""
+from __future__ import annotations
+
+import glob
+import re
+
+import pytest
+
+_EMOJI = re.compile(
+    "[\U0001F000-\U0001FAFF\U00002600-\U000027BF\U0001F1E6-\U0001F1FF"
+    "✅❌⚠ℹ⭐✨️]"
+)
+
+_USER_TEMPLATES = sorted(
+    set(glob.glob("src/seller_console/templates/**/*.html", recursive=True))
+    | set(glob.glob("src/templates/**/*.html", recursive=True))
+)
+
+
+@pytest.mark.parametrize("path", _USER_TEMPLATES)
+def test_user_template_has_no_emoji(path):
+    text = open(path, encoding="utf-8").read()
+    found = _EMOJI.findall(text)
+    assert not found, f"{path}: 이모지 잔존 {found}"
+
+
+def test_key_chrome_uses_line_icons():
+    for p in ("src/seller_console/templates/partials/topnav.html",
+              "src/templates/partials/topnav.html",
+              "src/templates/errors/404.html"):
+        t = open(p, encoding="utf-8").read()
+        assert "bi bi-shop" in t            # 셀러 콘솔 → 라인 아이콘
+        assert "bi bi-tools" in t           # 관리자


### PR DESCRIPTION
## v33 3-4 — 전역 이모지·지구본 박멸 (단일 라인 아이콘셋)

마스터 3주차 3-4. 사용자 노출 전 템플릿의 이모지를 `bi-*` 라인 아이콘으로 교체 → "고급·세련" 톤 통일.

### 이모지 → bi-* 라인 아이콘 (전수)
- **topnav ×2**: 🛒→`bi-shop` · 🛠→`bi-tools` · 📚→`bi-book` · 💚→`bi-heart-pulse` · 👤→`bi-person` · 🚪→`bi-box-arrow-right` · 🔐→`bi-shield-lock` · 📧→`bi-envelope` · 🆘→`bi-life-preserver`
- **404/500 · markets_connect/guide · catalog · notifications · me · mobile_home · market_status · collect_preview** 의 ⭐/ℹ️/❌/✓ 등 정리
- **북마클릿 드래그 버튼** 🧤 → **"수집" 텍스트**(이모지 없는 깔끔한 북마크 이름)

### 지구본 0
- **`bi-globe` 아이콘 7개 → `bi-translate`** (번역/언어 맥락) — 어디에도 globe 0

### 토스트
- 3-3에서 이미 라인 아이콘으로 전환 완료

### 검증
- `test_v33_emoji_sweep` — **전 사용자 템플릿 이모지 0**(파라미터화) + 핵심 chrome 라인 아이콘
- 기존 글러브-이모지 가드는 v33 텍스트 기준으로 갱신
- 전체 **10392 passed**, 0 regressions

---
다음(v33 마지막): 3-5 소싱 카드 이미지 확대(본문 ≥15px·제목 ≥17px) + 상태값 한글화(접수/처리중/해결됨/자동처리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_