### PR TITLE
이미지·상세 추출: Temu 상세 텍스트+스펙표 site-branch 보강

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,11 @@ Claude Code는 지금처럼 브랜치·PR·머지를 자율로 한다. 단 **머
   (아마존 핫링크 차단 대응). manifest 1.5.31→1.5.32. 가드 test_v44_img_detail_extract(6: 소스계약+hi-res정규식+node로
   mock 아마존 PDP 추출 갤러리 고해상·A+·불릿). 전체 10755 passed. 캡처: docs/screens/v44/img-detail-amazon-ohsnap.png
   (OHSNAP 접착패드: 갤러리 7장 고해상+A+ 2장+불릿 4).
+- ✅ **이미지·상세 추출 Temu 상세 텍스트+스펙표 보강 (#409):** #408이 Temu는 갤러리/상세 '이미지'만 site-branch서
+  추출(텍스트는 generic 폴백)했던 것 → Temu 상세영역 `det.innerText`(본문) + 스펙표(table tr·dl·[class*=spec/attribute/param] li)를
+  out.description에 설정(양 사이트 텍스트+스펙 site-branch 일치). manifest 1.5.32→1.5.33. 가드 test_v44_img_detail_extract에
+  Temu 케이스 추가(node로 갤러리·상세이미지·본문+스펙 실증). 전체 10756 passed. (오너 재요청분=#408로 이미 구현·머지,
+  이 커밋은 Temu 텍스트/스펙 코너 보강.)
 - ⏳ v44 남음: 2 가격탭(옵션가표·마켓별 미리보기) / 3 키워드탭 / 4 썸네일탭 / 5 상세탭(리치에디터) / 6 상품명·카테고리·옵션.
 - ⏳ 후속: 1-2 이미지·상세 스코프 추가 강화(판매자 로고 제외) / PHASE 2 속도 / PHASE 3~5.
 - ⏳ 후속: PHASE 2 속도, STEP 3 JSON제거·UX / 4-1 라벨 '다리 너머, 오늘의 발굴' / STEP 5 디자인.

--- a/extensions/chrome-collector/content_script.js
+++ b/extensions/chrome-collector/content_script.js
@@ -102,7 +102,18 @@ function _kgpSitePdp() {
       const gal = document.querySelector('[class*="gallery" i],[class*="Gallery" i],[class*="mainImage" i],[class*="swiper" i]');
       if (gal) gal.querySelectorAll("img").forEach(im => _add(out.gallery, im.currentSrc || im.src || im.getAttribute("data-src") || ""));
       const det = document.querySelector('[class*="detail" i],[class*="Description" i],[class*="goods-desc" i]');
-      if (det) det.querySelectorAll("img").forEach(im => _add(out.detail, im.currentSrc || im.src || im.getAttribute("data-src") || ""));
+      if (det) {
+        det.querySelectorAll("img").forEach(im => _add(out.detail, im.currentSrc || im.src || im.getAttribute("data-src") || ""));
+        // v44: Temu 상세 영역 텍스트 + 스펙표(속성표) — 본문 innerText가 스펙표 셀도 포함.
+        const specRows = [];
+        det.querySelectorAll("table tr, dl > dt, dl > dd, [class*='spec' i] li, [class*='attribute' i] li, [class*='param' i] li").forEach(el => {
+          const t = (el.innerText || el.textContent || "").replace(/\s+/g, " ").trim();
+          if (t && t.length >= 2 && specRows.indexOf(t) < 0) specRows.push(t);
+        });
+        const bodyText = (det.innerText || "").trim();
+        out.description = [bodyText, specRows.length ? ("· " + specRows.slice(0, 40).join("\n· ")) : ""]
+          .filter(Boolean).join("\n\n").slice(0, 4000);
+      }
     }
   } catch (e) { /* noop */ }
   return out;

--- a/extensions/chrome-collector/manifest.json
+++ b/extensions/chrome-collector/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "고가수집기",
-  "version": "1.5.32",
+  "version": "1.5.33",
   "description": "지정 소싱처(타오바오·아마존 등)에서 한 클릭에 고가브릿지로 수집 (인페이지 수집 + 리스팅 다중 선택 수집 + 자동 번역)",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/tests/test_v38_fab_always_on_sourcing.py
+++ b/tests/test_v38_fab_always_on_sourcing.py
@@ -30,4 +30,4 @@ def test_list_vs_detail_still_mutually_exclusive():
 
 
 def test_extension_version_bumped():
-    assert MANIFEST["version"] == "1.5.32"
+    assert MANIFEST["version"] == "1.5.33"

--- a/tests/test_v38_icons_bridge_only.py
+++ b/tests/test_v38_icons_bridge_only.py
@@ -24,7 +24,7 @@ def test_extension_inpage_has_no_pictographic_emoji():
 
 def test_extension_version_bumped_for_icon_refresh():
     # 캐시된 옛 트레이 아이콘(지구본 오인) 갱신 위해 버전 bump
-    assert MANIFEST["version"] == "1.5.32"
+    assert MANIFEST["version"] == "1.5.33"
     # 아이콘 매핑은 브릿지 PNG(16/32/48/128)
     assert MANIFEST["icons"]["128"] == "icons/128.png"
 

--- a/tests/test_v39_a_no_globe.py
+++ b/tests/test_v39_a_no_globe.py
@@ -41,4 +41,4 @@ def test_all_extension_js_emoji_free():
 def test_favicon_is_bridge_and_version_bumped():
     fav = Path("src/seller_console/static/favicon.svg").read_text(encoding="utf-8")
     assert "bridge gateway mark" in fav and "globe" not in fav.lower()
-    assert MANIFEST["version"] == "1.5.32"
+    assert MANIFEST["version"] == "1.5.33"

--- a/tests/test_v39_e_fab_label.py
+++ b/tests/test_v39_e_fab_label.py
@@ -21,4 +21,4 @@ def test_fab_still_always_shown_on_sourcing():
 
 
 def test_extension_version_bumped():
-    assert MANIFEST["version"] == "1.5.32"
+    assert MANIFEST["version"] == "1.5.33"

--- a/tests/test_v41_4_2_extension_toolbar_icon.py
+++ b/tests/test_v41_4_2_extension_toolbar_icon.py
@@ -29,7 +29,7 @@ def test_manifest_icons_and_action_all_bridge_png():
 
 def test_version_bumped_for_reload():
     """캐시된 옛 확장(지구본) 재로딩 유도 — 버전 상향."""
-    assert MANIFEST["version"] == "1.5.32"
+    assert MANIFEST["version"] == "1.5.33"
 
 
 def test_manifest_has_no_globe():

--- a/tests/test_v44_img_detail_extract.py
+++ b/tests/test_v44_img_detail_extract.py
@@ -79,3 +79,28 @@ def test_amazon_pdp_extraction_behavioral():
     assert any("aplus/A1" in u for u in o["detail"])
     # 상세설명: 불릿 + productDescription
     assert "접착" in o["description"] and "·" in o["description"]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node 미설치")
+def test_temu_pdp_extracts_text_and_spec():
+    """Temu: 상세 영역 텍스트 + 스펙표(속성) + 본문 이미지 추출."""
+    i = CS.index("function _kgpAmazonHiRes")
+    j = CS.index("function extractProductMeta")
+    block = CS[i:j]
+    harness = block + r"""
+    function el(p){return Object.assign({getAttribute:(k)=>p[k]||null,querySelectorAll:(s)=>p['_all_'+s]||[],currentSrc:p.currentSrc||'',src:p.src||'',innerText:p.innerText||'',textContent:p.innerText||''},p);}
+    const trs=[el({innerText:'소재 폴리에스터'}),el({innerText:'사이즈 200x90cm'})];
+    const dimg=[el({src:'https://temu.com/detail1.jpg'})];
+    const specSel = "table tr, dl > dt, dl > dd, [class*='spec' i] li, [class*='attribute' i] li, [class*='param' i] li";
+    const det=el({innerText:'린넨 3인 소파. 소재 폴리에스터 사이즈 200x90cm', _all_img:dimg}); det['_all_'+specSel]=trs;
+    const gal=el({_all_img:[el({src:'https://temu.com/g1.jpg'})]});
+    global.location={hostname:'www.temu.com'};
+    global.document={querySelector:(s)=> (s.indexOf('gallery')>=0||s.indexOf('mainImage')>=0||s.indexOf('swiper')>=0)?gal:((s.indexOf('detail')>=0||s.indexOf('Description')>=0||s.indexOf('goods-desc')>=0)?det:null), querySelectorAll:()=>[]};
+    const o=_kgpSitePdp();
+    console.log(JSON.stringify({gallery:o.gallery.length, detail:o.detail.length, spec: o.description.includes('소재 폴리에스터') && o.description.includes('사이즈')}));
+    """
+    res = subprocess.run(["node", "-e", harness], capture_output=True, text=True, timeout=20)
+    assert res.returncode == 0, res.stderr
+    o = json.loads(res.stdout.strip())
+    assert o["gallery"] >= 1 and o["detail"] >= 1
+    assert o["spec"] is True   # 상세 텍스트 + 스펙표 포함


### PR DESCRIPTION
## 무엇을 / 왜
오너 재요청("이미지·상세를 가격과 동일 방식으로 클릭시점 추출")은 **PR #408로 이미 구현·머지**되어 있습니다(아마존 갤러리 고해상·A+·불릿 + Temu 캐러셀/상세 + 2버킷 + URL만 전송·상품ID 귀속 + referrerpolicy, OHSNAP 검증 캡처 포함).

이 PR은 그 요청의 **한 코너를 보강**합니다: #408에서 Temu는 갤러리/상세 **이미지**만 site-branch에서 뽑고, 상세 **텍스트**는 generic 폴백(`_kgpRealDescription`)에 의존했습니다. 오너 스펙("Temu: 상세 영역 텍스트 + 스펙표 + 본문 이미지")을 site-branch에서 완전히 충족하도록 텍스트/스펙을 추가했습니다.

## 수리
- Temu 상세 컨테이너의 **본문 텍스트**(`det.innerText`) + **스펙표/속성표**(`table tr`, `dl > dt/dd`, `[class*='spec'|'attribute'|'param'] li`)를 `out.description`에 설정.
- 이제 아마존(불릿+productDescription)·Temu(본문+스펙) **양쪽 모두 텍스트+스펙을 site-branch에서 일치**되게 추출. 필러면 버림(기존 가드).

## 셀프 점검 (CLAUDE.md 게이트)
- [x] **pytest 전부 그린**: 전체 **10756 passed** (0 fail). `test_v44_img_detail_extract`에 Temu 케이스 추가 — **node로 mock Temu PDP: 갤러리·상세 이미지 + 상세 텍스트+스펙표(소재/사이즈) 추출** 실증.
- [x] **검증 캡처**: 아마존 OHSNAP는 #408의 `docs/screens/v44/img-detail-amazon-ohsnap.png`(갤러리 7 고해상+A+ 2+불릿 4). Temu 텍스트/스펙은 node로 실증(추출 로직, 렌더 UI 아님).
- [x] **정직 데이터 위반 0**: 필러 아닐 때만 사용, 못 읽으면 빈 값.
- **적용 스킬**: 확장 DOM 추출 로직 — UI/CSS 아님 → gogabridj-design 불요.

manifest 1.5.32→1.5.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_