### PR TITLE
Supabase 연결 규칙: DDL·마이그레이션은 직접 연결(5432), 런타임은 풀러(6543) 안전화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,10 @@ Claude Code는 지금처럼 브랜치·PR·머지를 자율로 한다. 단 **머
 ## 🟦 DB 이관 (오너 2026-07-04 — Google Sheets → Supabase Postgres, 단계적)
 - 접속정보는 Render 환경변수(SUPABASE_DB_URL/DATABASE_URL)로만, 하드코딩 금지. 미설정이면 기존 Sheets/인메모리
   폴백(무회귀). 단계: 1(collect_history·user_tokens) → 2(products·market_links 암호화) → 3(주문·정산, Sheets 읽기전용 강등).
+- ⚠️ **Supabase 연결 규칙(오너 2026-07-04):** 런타임=트랜잭션 풀러(6543, SUPABASE_DB_URL) — prepared statement 이슈
+  주의(psycopg2는 named prepared 안 씀·pg.get_conn이 반납 전 rollback으로 idle-in-transaction 정리). **DDL·마이그레이션은
+  직접 연결(5432, 별도 env DATABASE_URL_DIRECT)** 로: pg.run_ddl/init_schema·pg.direct_conn()·migrate 스크립트가 직접 연결
+  사용(미설정이면 SUPABASE_DB_URL 폴백). CREATE EXTENSION/FUNCTION/TRIGGER는 풀러서 실패하므로 직접 연결 필수.
 - ✅ **1단계 collect_history + user_tokens PG 이관 (#417):** 버그 최다 2테이블. 신규 `src/db/pg.py`(env 접속·풀·
   `tx()` 트랜잭션 커밋 후에만 성공·`init_schema()`), `src/db/schema_stage1.sql`(uuid PK·user_id 스코프·**product_key
   부분 유니크**(활성행만, 중복수집 방지)·deleted_at 소프트삭제·created/updated_at + updated_at 트리거), `src/db/

--- a/scripts/migrate_to_supabase.py
+++ b/scripts/migrate_to_supabase.py
@@ -40,11 +40,12 @@ def _pg():
     from src.db import pg
     if not pg.pg_enabled():
         raise SystemExit("SUPABASE_DB_URL/DATABASE_URL 미설정 또는 연결 실패 — 이관 대상 없음.")
-    pg.init_schema()
+    pg.init_schema()   # DDL은 직접 연결(5432)로
     return pg
 
 
-def migrate_collect(pg, dry=False) -> tuple:
+def migrate_collect(cur, dry=False) -> tuple:
+    """cur = 직접 연결(5432) 커서. 트랜잭션 풀러 이슈 회피."""
     rows = _sheet_collect_rows()
     from src.collectors.product_key import normalize_product_key
     inserted = 0
@@ -56,32 +57,28 @@ def migrate_collect(pg, dry=False) -> tuple:
         collected_at = r.get("collected_at") or datetime.now(timezone.utc).isoformat()
         extra = r.get("extra_json") or "{}"
         try:
-            with pg.tx() as cur:
-                # id 보존(레거시 hex는 uuid가 아니므로 새 uuid 부여, 원본 id는 extra에 보관).
-                extra_obj = json.loads(extra) if isinstance(extra, str) else (extra or {})
-                if r.get("id"):
-                    extra_obj.setdefault("_legacy_id", str(r.get("id")))
-                cur.execute(
-                    """INSERT INTO collect_history
-                       (user_id, product_key, source, domain, url, title, image_url, price, currency, status, preview_url, extra_json, created_at)
-                       VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s)
-                       ON CONFLICT (user_id, product_key)
-                         WHERE product_key IS NOT NULL AND product_key <> '' AND deleted_at IS NULL
-                       DO NOTHING""",
-                    (r.get("seller_id", ""), pkey, r.get("source", ""), r.get("domain", ""),
-                     url, r.get("title", ""), r.get("image_url", ""), str(r.get("price", "") or ""),
-                     r.get("currency", ""), r.get("status", "ok") or "ok", r.get("preview_url", ""),
-                     json.dumps(extra_obj, ensure_ascii=False), collected_at))
-                inserted += cur.rowcount
+            extra_obj = json.loads(extra) if isinstance(extra, str) else (extra or {})
+            if r.get("id"):
+                extra_obj.setdefault("_legacy_id", str(r.get("id")))
+            cur.execute(
+                """INSERT INTO collect_history
+                   (user_id, product_key, source, domain, url, title, image_url, price, currency, status, preview_url, extra_json, created_at)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s)
+                   ON CONFLICT (user_id, product_key)
+                     WHERE product_key IS NOT NULL AND product_key <> '' AND deleted_at IS NULL
+                   DO NOTHING""",
+                (r.get("seller_id", ""), pkey, r.get("source", ""), r.get("domain", ""),
+                 url, r.get("title", ""), r.get("image_url", ""), str(r.get("price", "") or ""),
+                 r.get("currency", ""), r.get("status", "ok") or "ok", r.get("preview_url", ""),
+                 json.dumps(extra_obj, ensure_ascii=False), collected_at))
+            inserted += cur.rowcount
         except Exception as exc:
             _log(f"  collect 행 이관 실패(건너뜀): {exc}")
-    with pg.query() as cur:
-        cur.execute("SELECT count(*) FROM collect_history WHERE deleted_at IS NULL")
-        pg_count = int(cur.fetchone()[0])
-    return len(rows), inserted, pg_count
+    cur.execute("SELECT count(*) FROM collect_history WHERE deleted_at IS NULL")
+    return len(rows), inserted, int(cur.fetchone()[0])
 
 
-def migrate_tokens(pg, dry=False) -> tuple:
+def migrate_tokens(cur, dry=False) -> tuple:
     rows = _sheet_token_rows()
     inserted = 0
     for r in rows:
@@ -96,31 +93,31 @@ def migrate_tokens(pg, dry=False) -> tuple:
         if not th:
             continue
         try:
-            with pg.tx() as cur:
-                cur.execute(
-                    """INSERT INTO user_tokens (user_id, token_hash, token_prefix, scopes, status, last_used_at, expires_at, created_at)
-                       VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
-                       ON CONFLICT (token_hash) WHERE deleted_at IS NULL DO NOTHING""",
-                    (r.get("user_id", ""), th, th[:8], json.dumps(scopes),
-                     "revoked" if revoked else "active",
-                     r.get("last_used_at") or None, r.get("expires_at") or None,
-                     r.get("created_at") or datetime.now(timezone.utc).isoformat()))
-                inserted += cur.rowcount
+            cur.execute(
+                """INSERT INTO user_tokens (user_id, token_hash, token_prefix, scopes, status, last_used_at, expires_at, created_at)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+                   ON CONFLICT (token_hash) WHERE deleted_at IS NULL DO NOTHING""",
+                (r.get("user_id", ""), th, th[:8], json.dumps(scopes),
+                 "revoked" if revoked else "active",
+                 r.get("last_used_at") or None, r.get("expires_at") or None,
+                 r.get("created_at") or datetime.now(timezone.utc).isoformat()))
+            inserted += cur.rowcount
         except Exception as exc:
             _log(f"  token 행 이관 실패(건너뜀): {exc}")
-    with pg.query() as cur:
-        cur.execute("SELECT count(*) FROM user_tokens WHERE deleted_at IS NULL")
-        pg_count = int(cur.fetchone()[0])
-    return len(rows), inserted, pg_count
+    cur.execute("SELECT count(*) FROM user_tokens WHERE deleted_at IS NULL")
+    return len(rows), inserted, int(cur.fetchone()[0])
 
 
 def main():
     dry = "--count" in sys.argv
     pg = _pg()
-    _log("=== 이관 1단계: Sheets → Supabase Postgres ===")
-    sc, si, sp = migrate_collect(pg, dry=dry)
+    _log("=== 이관 1단계: Sheets → Supabase Postgres (직접 연결 5432) ===")
+    # 마이그레이션은 직접 연결(5432)로 — 트랜잭션 풀러(6543)의 prepared/DDL 이슈 회피.
+    with pg.direct_conn() as conn:
+        with conn.cursor() as cur:
+            sc, si, sp = migrate_collect(cur, dry=dry)
+            tc, ti, tp = migrate_tokens(cur, dry=dry)
     _log(f"[collect_history] Sheets 원본 {sc}건 · 삽입 {si}건 · PG 총 {sp}건")
-    tc, ti, tp = migrate_tokens(pg, dry=dry)
     _log(f"[user_tokens]     Sheets 원본 {tc}건 · 삽입 {ti}건 · PG 총 {tp}건")
     # 건수 대조(멱등 재실행 시 삽입 0이어도 PG 총계가 Sheets 이상이면 OK)
     ok = (sp >= sc) and (tp >= tc)

--- a/src/db/pg.py
+++ b/src/db/pg.py
@@ -24,8 +24,18 @@ _available = False
 
 
 def db_url() -> str:
-    """환경변수에서 접속 URL(없으면 '')."""
+    """런타임 접속 URL — Supabase 트랜잭션 풀러(포트 6543) 권장. 없으면 ''."""
     return (os.getenv("SUPABASE_DB_URL") or os.getenv("DATABASE_URL") or "").strip()
+
+
+def direct_url() -> str:
+    """DDL·마이그레이션용 **직접 연결**(포트 5432) URL.
+
+    Supabase 트랜잭션 풀러(6543)는 prepared statement/DDL 이슈가 있어, 스키마 생성·마이그레이션은
+    Direct connection(대시보드의 5432 URL)을 별도 env(DATABASE_URL_DIRECT)로 받아 쓴다. 미설정이면
+    풀러 URL로 폴백(로컬/단일 PG는 구분 없음).
+    """
+    return (os.getenv("DATABASE_URL_DIRECT") or "").strip() or db_url()
 
 
 def pg_enabled() -> bool:
@@ -90,12 +100,20 @@ def _get_pool():
 
 @contextlib.contextmanager
 def get_conn():
-    """풀에서 커넥션을 빌려주고 반납."""
+    """풀에서 커넥션을 빌려주고 반납.
+
+    트랜잭션 풀러(6543) 호환: 반납 전 `rollback()`으로 열린 트랜잭션을 반드시 정리한다
+    (idle-in-transaction·prepared statement 잔류 방지). tx()는 이미 commit했으므로 no-op.
+    """
     pool = _get_pool()
     conn = pool.getconn()
     try:
         yield conn
     finally:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
         pool.putconn(conn)
 
 
@@ -124,13 +142,36 @@ _SCHEMA_FILE = Path(__file__).with_name("schema_stage1.sql")
 _schema_done = False
 
 
+@contextlib.contextmanager
+def direct_conn():
+    """마이그레이션용 **직접 연결(5432)** 1회용 컨텍스트 — 정상 종료 시 commit, 예외 시 rollback."""
+    conn = _connect(direct_url())
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def run_ddl(ddl: str):
+    """DDL을 **직접 연결(5432)** 로 실행 — 트랜잭션 풀러의 DDL/prepared 이슈 회피."""
+    conn = _connect(direct_url())
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(ddl)
+    finally:
+        conn.close()
+
+
 def init_schema():
-    """1단계 스키마를 idempotent 적용(collect_history, user_tokens)."""
+    """1단계 스키마를 idempotent 적용(collect_history, user_tokens). 직접 연결로 실행."""
     global _schema_done
     if _schema_done or not pg_enabled():
         return
-    ddl = _SCHEMA_FILE.read_text(encoding="utf-8")
-    with tx() as cur:
-        cur.execute(ddl)
+    run_ddl(_SCHEMA_FILE.read_text(encoding="utf-8"))
     _schema_done = True
-    logger.info("Postgres 1단계 스키마 적용 완료")
+    logger.info("Postgres 1단계 스키마 적용 완료(직접 연결)")

--- a/tests/test_v45_supabase_conn.py
+++ b/tests/test_v45_supabase_conn.py
@@ -1,0 +1,45 @@
+"""tests/test_v45_supabase_conn.py — Supabase 연결 규칙(오너 운영 지침).
+
+런타임=풀러(6543, SUPABASE_DB_URL) · DDL/마이그레이션=직접 연결(5432, DATABASE_URL_DIRECT).
+PG 불필요 — env 로직 + 소스 계약만 검증.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import src.db.pg as pg
+
+PGSRC = Path("src/db/pg.py").read_text(encoding="utf-8")
+MIG = Path("scripts/migrate_to_supabase.py").read_text(encoding="utf-8")
+
+
+def test_direct_url_prefers_direct_env(monkeypatch):
+    monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://pooler:6543/db")
+    monkeypatch.setenv("DATABASE_URL_DIRECT", "postgresql://direct:5432/db")
+    assert pg.db_url().endswith(":6543/db")
+    assert pg.direct_url().endswith(":5432/db")     # DDL은 직접 연결
+
+
+def test_direct_url_falls_back_to_runtime(monkeypatch):
+    monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://pooler:6543/db")
+    monkeypatch.delenv("DATABASE_URL_DIRECT", raising=False)
+    assert pg.direct_url() == pg.db_url()           # 미설정이면 폴백
+
+
+def test_ddl_runs_via_direct_connection():
+    # init_schema → run_ddl(직접 연결). run_ddl은 direct_url()로 연결.
+    assert "def run_ddl(" in PGSRC
+    assert "_connect(direct_url())" in PGSRC
+    i = PGSRC.index("def init_schema")
+    assert "run_ddl(" in PGSRC[i:i + 400]
+
+
+def test_get_conn_rollback_on_return_for_pooler_safety():
+    i = PGSRC.index("def get_conn")
+    blk = PGSRC[i:i + 500]
+    assert "conn.rollback()" in blk                 # idle-in-transaction 정리(풀러 호환)
+
+
+def test_migration_uses_direct_conn():
+    assert "pg.direct_conn()" in MIG                # 마이그레이션은 직접 연결
+    assert "def direct_conn(" in PGSRC


### PR DESCRIPTION
## 배경 (오너 운영 지침)
Supabase 트랜잭션 풀러(6543)는 **prepared statement / DDL 이슈**가 있음 → DDL·마이그레이션은 **직접 연결(5432, `DATABASE_URL_DIRECT`)** 로 실행해야 함. 이 규칙을 코드에 반영.

> ⚠️ **긴급**: 이전(#417) `init_schema`가 DDL(`CREATE EXTENSION pgcrypto` / `CREATE FUNCTION` / `CREATE TRIGGER`)을 **풀러 URL로** 실행 → 풀러에서 실패했을 수 있음. 그러면 라이브 Supabase 스키마가 안 만들어져 토큰/수집이 계속 Sheets로 폴백(버그 지속). 이 PR로 직접 연결 사용해 해소.

## 변경
- **`pg.direct_url()`** — `DATABASE_URL_DIRECT`(5432) 우선, 미설정이면 `SUPABASE_DB_URL` 폴백(로컬/단일 PG 호환).
- **`pg.run_ddl()` / `init_schema()`** — DDL을 **직접 연결(5432)** 로 실행.
- **`pg.direct_conn()`** — 마이그레이션용 직접 연결 컨텍스트. `scripts/migrate_to_supabase.py`가 이걸로 대량 삽입.
- **`pg.get_conn()`** — 반납 전 `rollback()`으로 열린 트랜잭션 정리(**idle-in-transaction 방지** → 트랜잭션 풀러 호환). psycopg2는 named prepared statement를 안 써서 풀러 안전.

## 셀프 점검
- [x] **pytest 전부 그린** — `10815 passed, 6 skipped`. 신규 `test_v45_supabase_conn`(5: direct_url 우선/폴백·DDL 직접연결·get_conn rollback·마이그레이션 direct_conn). 로컬 PG stage1 6/6 재검증. CI 확인 후 머지.
- [x] **자기 회귀 점검** — 무-PG 폴백 완전 유지. 접속정보 하드코딩 0(env only).
- [x] **정직 데이터 위반 0** — 연결 규칙만 변경, 데이터 로직 무변경.

**적용 스킬:** 백엔드 DB 연결(UI 없음).

### 오너 액션
- Render에 **`DATABASE_URL_DIRECT`**(Supabase 대시보드 → Database → **Direct connection** URL, 포트 5432) 추가 권장. 미설정이어도 `SUPABASE_DB_URL`로 폴백하지만, DDL은 직접 연결이 안전합니다.
- 다음: DB 이관 2단계(products · market_links 암호화) 착수 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_