### PR TITLE
Dockerfile: DB 이관 스크립트를 이미지에 포함 (Render Shell 실행 가능)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,8 @@ ENV PORT=10000 \
 
 # Copy startup script
 COPY scripts/start_render.sh ./scripts/start_render.sh
+# DB 이관 스크립트 — 운영자가 Render Shell에서 `python scripts/migrate_to_supabase.py` 실행.
+# (스키마 .sql 은 src/db/ 아래라 COPY src/ 에 이미 포함됨.)
+COPY scripts/migrate_to_supabase.py ./scripts/migrate_to_supabase.py
 
 CMD ["sh", "scripts/start_render.sh"]


### PR DESCRIPTION
## 진단 (팩트)
운영자가 Render Shell에서 `/app/scripts/migrate_to_supabase.py` 가 없다고 보고. **원인은 "미머지"가 아니라 Dockerfile COPY 누락**입니다.

**이관 코드는 이미 main에 머지되어 있습니다** (git ls-tree origin/main 결과):
```
scripts/migrate_to_supabase.py
src/db/pg.py
src/db/collect_history_pg.py
src/db/user_tokens_pg.py
src/db/orders_pg.py
src/db/market_links_pg.py
src/db/backup.py
src/db/schema_stage1.sql   src/db/schema_stage2.sql   src/db/schema_stage3.sql
```
관련 머지 이력: #417(1단계) · #418 · #419 · #420(2단계) · #421(3단계 orders) · #422(백업).

그런데 **Dockerfile이 `scripts/` 중 `start_render.sh` 한 파일만 COPY**해, `migrate_to_supabase.py`가 이미지에 안 들어갔습니다 (Phase 227의 `extensions/` 누락과 동일 패턴).

## 변경 (이 PR의 파일 목록)
- **`Dockerfile`** — `COPY scripts/migrate_to_supabase.py ./scripts/migrate_to_supabase.py` 한 줄 추가.
  - 스키마 `.sql` 은 `src/db/` 아래라 기존 `COPY src/ ./src/` 에 **이미 포함**.
  - `.dockerignore` 는 `scripts/` 미배제 → 빌드 컨텍스트에 포함(확인함).

## 요청하신 확인 사항
1. **이관 코드 main 머지** — ✅ 이미 머지됨(위 파일 목록·머지 이력). 이 PR은 그 코드를 **컨테이너에서 실행 가능**하게 만드는 Dockerfile 수정.
2. **requirements psycopg** — ✅ `requirements.txt` 에 `psycopg[binary]>=3.1,<4` 존재. (서버 import 가능)
3. **머지 후 운영자 액션** — Render **Manual Deploy** 후 Shell에서 `python scripts/migrate_to_supabase.py` 실행.
4. **성공 기준 사전 검증(로컬 PostgreSQL 16)** — 스크립트 실행 결과:
   ```
   === 이관 1·2단계: Sheets/파일 → Supabase Postgres (직접 연결 5432) ===
   [collect_history] Sheets 원본 N건 · 삽입 N건 · PG 총 N건
   [user_tokens]     Sheets 원본 N건 · 삽입 N건 · PG 총 N건
   [market_links]    파일 셀러 N명 · 삽입 N건 · PG 총 N건
   [orders]          Sheets 원본 N건 · 삽입 N건 · PG 총 N건
   검증(건수 대조): collect PG≥Sheets=True, tokens PG≥Sheets=True → OK
   ```
   → **테이블 4개 생성 + 건수 대조 출력 + exit 0** 확인. 부팅 시엔 order_webhook 이 `pg_enabled()` → **"DB 연결: Supabase OK"** 로깅 + `init_schema()` 로 테이블 idempotent 생성.

## 증명
- `COPY` 대상 파일이 없으면 Docker 빌드가 실패하므로, **CI `Docker Build & Smoke` 그린 = 이미지에 스크립트 포함** 증명.
- (로컬 Docker 빌드는 이 환경의 에이전트 프록시가 베이스 이미지 pull을 403 차단해 불가 → CI에 위임.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxGVkp5f6YphwkqMwzi5ZE)_